### PR TITLE
Update to RocksDB 10.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "node": ">=18"
   },
   "rocksdb": {
-    "version": "9.10.0"
+    "version": "10.0.1"
   },
   "pnpm": {
     "onlyBuiltDependencies": [


### PR DESCRIPTION
Update to the latest RocksDB 10.0.1 release: https://github.com/HarperDB/rocksdb-prebuilds/releases/tag/v10.0.1.