### PR TITLE
Replace node-gyp-build with simplified, rollup compatible loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,9 +30,6 @@
     "src/binding",
     "vendor"
   ],
-  "dependencies": {
-    "node-gyp-build": "4.8.4"
-  },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^28.0.3",
     "@rollup/plugin-node-resolve": "16.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,10 +7,6 @@ settings:
 importers:
 
   .:
-    dependencies:
-      node-gyp-build:
-        specifier: 4.8.4
-        version: 4.8.4
     devDependencies:
       '@rollup/plugin-commonjs':
         specifier: ^28.0.3
@@ -1163,10 +1159,6 @@ packages:
 
   node-gyp-build-optional-packages@5.2.2:
     resolution: {integrity: sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==}
-    hasBin: true
-
-  node-gyp-build@4.8.4:
-    resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
     hasBin: true
 
   node-gyp@11.2.0:
@@ -2467,8 +2459,6 @@ snapshots:
     dependencies:
       detect-libc: 2.0.3
     optional: true
-
-  node-gyp-build@4.8.4: {}
 
   node-gyp@11.2.0:
     dependencies:


### PR DESCRIPTION
Turns out `node-gyp-build` is not compatible with the rollup bundle. It obfuscates `require()` causing rollup to blow up at runtime. Furthermore, `node-gyp-build` does a bunch of extra stuff we don't need like Electron support.

I found a simpler solution. Since rocksdb-js is an ESM module, I needed to call `createRequire()` (added in Node 12), then `require()` the binding. It appears Node.js still doesn't support dynamically importing native bindings.

Removing `node-gyp-build` reduced the install size by around 13KB.

JIRA: https://harperdb.atlassian.net/browse/CORE-2691