### PR TITLE
Enable erasableSyntaxOnly TS flag

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "composite": false,
     "declaration": false,
     "declarationMap": false,
+    "erasableSyntaxOnly": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "inlineSources": false,


### PR DESCRIPTION
This TypeScript setting forbids using TS features that Node.js cannot strip such as enums.