### PR TITLE
Use crypto.randomBytes to create more random db path

### DIFF
--- a/test/lib/util.ts
+++ b/test/lib/util.ts
@@ -1,9 +1,10 @@
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
+import { randomBytes } from 'node:crypto';
 
 export function generateDBPath() {
 	return join(
 		tmpdir(),
-		`testdb-${Math.random().toString(36).substring(2, 15)}`
+		`testdb-${randomBytes(8).toString('hex')}`
 	);
 }


### PR DESCRIPTION
When running tests in parallel via worker threads, I was seeing collisions with path names generated using `Math.random()`. Switching to `crypto.randomBytes()` seems to fix this.