### PR TITLE
Move msgpackr and ordered-binary external to the bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,10 @@
     "src/binding",
     "vendor"
   ],
+  "dependencies": {
+    "msgpackr": "1.11.2",
+    "ordered-binary": "1.5.3"
+  },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^28.0.3",
     "@rollup/plugin-node-resolve": "16.0.1",
@@ -40,9 +44,7 @@
     "dotenv": "16.5.0",
     "esbuild": "0.25.3",
     "lefthook": "1.11.12",
-    "msgpackr": "1.11.2",
     "node-gyp": "11.2.0",
-    "ordered-binary": "1.5.3",
     "oxlint": "0.16.9",
     "prebuildify": "6.0.1",
     "rimraf": "6.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,13 @@ settings:
 importers:
 
   .:
+    dependencies:
+      msgpackr:
+        specifier: 1.11.2
+        version: 1.11.2
+      ordered-binary:
+        specifier: 1.5.3
+        version: 1.5.3
     devDependencies:
       '@rollup/plugin-commonjs':
         specifier: ^28.0.3
@@ -35,15 +42,9 @@ importers:
       lefthook:
         specifier: 1.11.12
         version: 1.11.12
-      msgpackr:
-        specifier: 1.11.2
-        version: 1.11.2
       node-gyp:
         specifier: 11.2.0
         version: 11.2.0
-      ordered-binary:
-        specifier: 1.5.3
-        version: 1.5.3
       oxlint:
         specifier: 0.16.9
         version: 0.16.9

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -10,6 +10,10 @@ const { version } = JSON.parse(readFileSync('./package.json', 'utf8'));
 
 export default defineConfig([
 	{
+		external: [
+			'msgpackr',
+			'ordered-binary'
+		],
 		input: './src/index.ts',
 		output: {
 			dir: './dist',
@@ -34,9 +38,7 @@ export default defineConfig([
 				}
 			}),
 			nodeResolve(),
-			commonjs({
-				ignoreDynamicRequires: true
-			})
+			commonjs()
 		]
 	}
 ]);


### PR DESCRIPTION
We want to move `msgpackr` and `ordered-binary` out of the bundle so that we can share the same versions used by Harper.