### PR TITLE
Enable code coverage for debug builds

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -66,6 +66,14 @@
 					}
 				},
 				'Debug': {
+					'cflags_cc+': ['-g', '--coverage'],
+					'defines': ['DEBUG'],
+					'ldflags': ['--coverage'],
+					'xcode_settings': {
+						'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
+						'OTHER_CFLAGS': ['-g', '--coverage'],
+						'OTHER_LDFLAGS': ['--coverage']
+					},
 					'msvs_settings': {
 						'VCCLCompilerTool': {
 							'RuntimeLibrary': 3,


### PR DESCRIPTION
Enable code coverage generation of debug builds. This does generate the lcov/gcov files, but more work needs to be done to analyze the files and generate the report.