### PR TITLE
Add flag to disable transaction snapshots

### DIFF
--- a/src/binding/transaction_handle.cpp
+++ b/src/binding/transaction_handle.cpp
@@ -10,7 +10,7 @@ namespace rocksdb_js {
  * Creates a new RocksDB transaction, enables snapshots, and sets the
  * transaction id.
  */
-TransactionHandle::TransactionHandle(std::shared_ptr<DBHandle> dbHandle) :
+TransactionHandle::TransactionHandle(std::shared_ptr<DBHandle> dbHandle, bool disableSnapshot) :
 	dbHandle(dbHandle),
 	txn(nullptr)
 {
@@ -25,7 +25,9 @@ TransactionHandle::TransactionHandle(std::shared_ptr<DBHandle> dbHandle) :
 	} else {
 		throw std::runtime_error("Invalid database");
 	}
-	this->txn->SetSnapshot();
+	if (!disableSnapshot) {
+		this->txn->SetSnapshot();
+	}
 	this->id = this->txn->GetId() & 0xffffffff;
 }
 

--- a/src/binding/transaction_handle.h
+++ b/src/binding/transaction_handle.h
@@ -25,7 +25,7 @@ struct DBHandle;
  * shared between the `Database` and `Transaction` classes.
  */
 struct TransactionHandle final {
-	TransactionHandle(std::shared_ptr<DBHandle> dbHandle);
+	TransactionHandle(std::shared_ptr<DBHandle> dbHandle, bool disableSnapshot = false);
 	~TransactionHandle();
 
 	napi_value get(


### PR DESCRIPTION
This adds a new `disableSnapshot` flag. Note that there's no public API to set this flag yet, but ticket https://harperdb.atlassian.net/browse/CORE-2769 will address that.