### PR TITLE
Remove version support

### DIFF
--- a/src/dbi.ts
+++ b/src/dbi.ts
@@ -44,10 +44,6 @@ export class DBI<T extends DBITransactional | unknown = unknown> {
 		this.#context = transaction || store.db;
 	}
 
-	doesExist(_key: Key, _versionOrValue: number | Buffer) {
-		//
-	}
-
 	/**
 	 * Retrieves the value for the given key, then returns the decoded value.
 	 */
@@ -205,24 +201,6 @@ export class DBI<T extends DBITransactional | unknown = unknown> {
 	}
 
 	/**
-	 * Retrieves a value for the given key as an "entry" object.
-	 *
-	 * An entry object contains a `value` property and when versions are enabled,
-	 * it also contains a `version` property.
-	 */
-	getEntry(key: Key, options?: GetOptions & T): MaybePromise<{ value: any } | undefined> {
-		const result = this.get(key, options);
-		return when(result, value => {
-			if (value !== undefined) {
-				// TODO: if versions are enabled, add a `version` property
-				return {
-					value,
-				};
-			}
-		});
-	}
-
-	/**
 	 * Retrieves all keys within a range.
 	 */
 	getKeys(_options?: GetRangeOptions & T) {
@@ -283,15 +261,15 @@ export class DBI<T extends DBITransactional | unknown = unknown> {
 	 * Removes a value for the given key. If the key does not exist, it will
 	 * not error.
 	 */
-	async remove(key: Key, ifVersionOrValue?: symbol | number | null, options?: T): Promise<void> {
-		this.removeSync(key, ifVersionOrValue, options);
+	async remove(key: Key, options?: T): Promise<void> {
+		this.removeSync(key, options);
 	}
 
 	/**
 	 * Removes a value for the given key. If the key does not exist, it will
 	 * not error.
 	 */
-	removeSync(key: Key, _ifVersionOrValue?: symbol | number | null, options?: T): void {
+	removeSync(key: Key, options?: T): void {
 		if (!this.store.isOpen()) {
 			throw new Error('Database not open');
 		}
@@ -335,14 +313,11 @@ interface GetRangeOptions {
 	start?: Key | Uint8Array;
 	values?: boolean;
 	valuesForKey?: boolean;
-	versions?: boolean;
 };
 
 interface PutOptions {
 	append?: boolean;
-	ifVersion?: number;
 	instructedWrite?: boolean;
 	noDupData?: boolean;
 	noOverwrite?: boolean;
-	version?: number;
 };

--- a/src/store.ts
+++ b/src/store.ts
@@ -48,7 +48,6 @@ export interface StoreOptions extends Omit<NativeDatabaseOptions, 'mode'> {
 	// readOnly?: boolean;
 	sharedStructuresKey?: symbol;
 	// trackMetrics?: boolean;
-	// useVersions?: boolean;
 }
 
 /**

--- a/test/read.test.ts
+++ b/test/read.test.ts
@@ -256,50 +256,6 @@ describe('Read Operations', () => {
 		});
 	});
 
-	describe('getEntry()', () => {
-		it('should error if database is not open', async () => {
-			const dbPath = generateDBPath();
-			let db: RocksDatabase | null = null;
-
-			try {
-				db = new RocksDatabase(dbPath);
-				await expect(db.getEntry('foo')).rejects.toThrow('Database not open');
-			} finally {
-				db?.close();
-				await rimraf(dbPath);
-			}
-		});
-
-		it('should return undefined if key does not exist', async () => {
-			const dbPath = generateDBPath();
-			let db: RocksDatabase | null = null;
-
-			try {
-				db = await RocksDatabase.open(dbPath);
-				const entry = await db.getEntry('baz');
-				expect(entry).toBeUndefined();
-			} finally {
-				db?.close();
-				await rimraf(dbPath);
-			}
-		});
-
-		it('should return the entry if key exists', async () => {
-			const dbPath = generateDBPath();
-			let db: RocksDatabase | null = null;
-
-			try {
-				db = await RocksDatabase.open(dbPath);
-				await db.put('foo', 'bar');
-				const entry = await db.getEntry('foo');
-				expect(entry).toEqual({ value: 'bar' });
-			} finally {
-				db?.close();
-				await rimraf(dbPath);
-			}
-		});
-	});
-
 	describe('getKeys()', () => {
 		it('should error if database is not open', async () => {
 			const dbPath = generateDBPath();


### PR DESCRIPTION
Per our discussion on https://harperdb.atlassian.net/browse/CORE-2766, we are moving the version logic to the Harper level in which case the `getEntry()` function is no longer needed.

We also determined `doesExist()` is no longer needed.