### PR TITLE
Remove on pull from CI

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -3,9 +3,6 @@ name: Test
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-  push:
-    branches:
-      - northstar
 
 concurrency:
   cancel-in-progress: true
@@ -54,7 +51,7 @@ jobs:
 
       - name: Run tests on Node.js ${{ matrix.node }}
         run: pnpm coverage
-      
+
       - name: Run tests on Bun
         if: ${{ matrix.node == '22' }}
         run: bun coverage


### PR DESCRIPTION
After talking with Nathan, I was unnecessarily running CI twice! Once on pull request synchronize and also on push. We can remove the `push`.