### PR TITLE
Fix filtering when running coverage tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "build:types:check": "tsc --project tsconfig.check.json",
     "check": "pnpm type-check && pnpm lint",
     "clean": "node-gyp clean",
-    "coverage": "node --expose-gc ./node_modules/vitest/vitest.mjs --coverage && tsx scripts/post-coverage/main.ts",
+    "coverage": "tsx scripts/coverage/main.ts",
     "lint": "oxlint",
     "prepublishOnly": "pnpm build:bundle && pnpm prebuild",
     "prebuild": "echo 'TODO'",

--- a/scripts/coverage/main.ts
+++ b/scripts/coverage/main.ts
@@ -6,6 +6,19 @@
 import { existsSync, readdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+
+const child = spawnSync(process.execPath, [
+	'--expose-gc',
+	'./node_modules/vitest/vitest.mjs',
+	'--coverage',
+	...process.argv.slice(2),
+], {
+	stdio: 'inherit',
+});
+if (child.status !== 0) {
+	process.exit(child.status);
+}
 
 const css = `<style type="text/css">
 	body {


### PR DESCRIPTION
When you run `pnpm coverage <suite>`, it runs all tests. The filtering is broken because the post-coverage script is receiving the arguments instead of the vitest command.

This PR renames the "post-coverage" script to "coverage" and moves the vitest call to the coverage script.