### PR TITLE
Download RocksDB prebuilds from S3

### DIFF
--- a/scripts/init-rocksdb/download-rocksdb.ts
+++ b/scripts/init-rocksdb/download-rocksdb.ts
@@ -5,7 +5,8 @@ import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { pipeline } from 'node:stream';
 import { promisify } from 'node:util';
-import type { Prebuild } from './get-prebuild';
+import { getPrebuildFromGitHub } from './get-prebuild';
+import semver from 'semver';
 
 const platformMap = {
 	darwin: 'osx',
@@ -14,28 +15,60 @@ const platformMap = {
 
 const streamPipeline = promisify(pipeline);
 
-export async function downloadRocksDB(prebuild: Prebuild, dest: string) {
-	const filename = `rocksdb-${prebuild.version}-${process.arch}-${platformMap[process.platform] || process.platform}`;
-	const [asset] = prebuild.assets.filter((asset) => asset.name.startsWith(filename));
+export async function downloadFromGitHub(
+	dest: string,
+	currentVersion: string | undefined,
+	desiredVersion: string | undefined
+) {
+	const prebuild = await getPrebuildFromGitHub(desiredVersion);
+
+	if (currentVersion && semver.lte(prebuild.version, currentVersion)) {
+		console.log(`No update needed, latest version ${prebuild.version} is active.`);
+		process.exit(0);
+	}
+
+	const filename = getFilename(prebuild.version);
+	const [asset] = prebuild.assets.filter((asset) => asset.name === filename);
 	if (!asset) {
 		throw new Error('No asset found');
 	}
 
-	const { name, url } = asset;
-	const tmpFile = join(tmpdir(), name);
+	const headers: Record<string, string> = {};
+	if (process.env.GH_TOKEN) {
+		headers.Authorization = `Bearer ${process.env.GH_TOKEN}`;
+	}
+
+	await downloadAndExtract({ dest, filename, headers, url: asset.url });
+}
+
+export async function downloadFromS3(dest: string, desiredVersion: string) {
+	const filename = getFilename(desiredVersion);
+	const url = `https://harper-artifacts.s3.us-east-2.amazonaws.com/rocksdb-prebuilds/v${desiredVersion}/${filename}`;
+
+	await downloadAndExtract({ dest, filename, url });
+}
+
+function getFilename(version: string) {
+	return `rocksdb-${version}-${process.arch}-${platformMap[process.platform] || process.platform}.tar.xz`;
+}
+
+async function downloadAndExtract({
+	dest, filename, headers, url
+}: {
+	dest: string;
+	filename: string;
+	headers?: Record<string, string>;
+	url: string;
+}) {
+	const tmpFile = join(tmpdir(), filename);
+	console.log(`Downloading ${url}`);
 
 	try {
-		console.log(`Downloading ${url}`);
-		const headers: Record<string, string> = {};
-		if (process.env.GH_TOKEN) {
-			headers.Authorization = `Bearer ${process.env.GH_TOKEN}`;
-		}
 		const response = await fetch(url, { headers });
 		if (!response.ok || !response.body) {
 			throw new Error(`Failed to download ${url} (${response.status} ${response.statusText})`);
 		}
 
-		// stream the response to the destination file
 		const fileStream = createWriteStream(tmpFile);
 		await streamPipeline(response.body, fileStream);
 

--- a/scripts/init-rocksdb/get-prebuild.ts
+++ b/scripts/init-rocksdb/get-prebuild.ts
@@ -18,7 +18,7 @@ export type Prebuild = {
 	}[];
 };
 
-export async function getPrebuild(desiredVersion?: string) {
+export async function getPrebuildFromGitHub(desiredVersion?: string) {
 	// download the latest RocksDB prebuild
 	const headers: Record<string, string> = {
 		Accept: 'application/vnd.github.v3.raw',

--- a/scripts/init-rocksdb/main.ts
+++ b/scripts/init-rocksdb/main.ts
@@ -15,8 +15,7 @@ import { config } from 'dotenv';
 import semver from 'semver';
 import { buildRocksDBFromSource } from './build-rocksdb-from-source';
 import { getCurrentVersion } from './get-current-version';
-import { getPrebuild } from './get-prebuild';
-import { downloadRocksDB } from './download-rocksdb';
+import { downloadFromGitHub, downloadFromS3 } from './download-rocksdb';
 import { readFileSync } from 'node:fs';
 
 const __dirname = fileURLToPath(dirname(import.meta.url));
@@ -44,14 +43,11 @@ try {
 		process.exit(0);
 	}
 
-	const prebuild = await getPrebuild(desiredVersion);
-
-	if (currentVersion && semver.lte(prebuild.version, currentVersion)) {
-		console.log(`No update needed, latest version ${prebuild.version} is active.`);
-		process.exit(0);
+	if (desiredVersion) {
+		await downloadFromS3(dest, desiredVersion);
+	} else {
+		await downloadFromGitHub(dest, currentVersion, desiredVersion);
 	}
-
-	await downloadRocksDB(prebuild, dest);
 } catch (error) {
 	console.error(error);
 	process.exit(1);


### PR DESCRIPTION
Running into a bunch of rate limiting issues downloading RocksDB prebuilds from GitHub. Now that we have the RocksDB prebuilt binaries on S3, we can download from there without any rate limiting.