### PR TITLE
Cache pnpm cache and RocksDB prebuilds

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -38,6 +38,27 @@ jobs:
         with:
           version: latest
 
+      - name: Get pnpm store directory
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+
+      - name: Setup pnpm cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Setup RocksDB cache
+        uses: actions/cache@v4
+        with:
+          path: deps/rocksdb
+          key: ${{ runner.os }}-rocksdb-${{ hashFiles('package.json') }}
+          restore-keys: |
+            ${{ runner.os }}-rocksdb-
+
       - name: Install dependencies
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
The test matrix runs the same tests on 4 different Node.js versions. While cache will be empty on the first push for all tasks, subsequent pushes to a branch should be significantly faster.

JIRA: https://harperdb.atlassian.net/browse/CORE-2800