### PR TITLE
Make `db.open()` sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ RocksDatabase.config({
 })
 ```
 
-### `db.open(): Promise<RocksDatabase>`
+### `db.open(): RocksDatabase`
 
 Opens the database at the given path. This must be called before performing
 any data operations.
@@ -45,13 +45,13 @@ any data operations.
 import { RocksDatabase } from '@harperdb/rocksdb-js';
 
 const db = new RocksDatabase('path/to/db');
-await db.open();
+db.open();
 ```
 
 There's also a static `open()` method for convenience that performs the same thing:
 
 ```typescript
-const db = await RocksDatabase.open('path/to/db');
+const db = RocksDatabase.open('path/to/db');
 ```
 
 ### `db.close()`
@@ -398,7 +398,7 @@ class MyStore extends Store {
 }
 
 const myStore = new MyStore('path/to/db');
-const db = await RocksDatabase.open(myStore);
+const db = RocksDatabase.open(myStore);
 await db.put('foo', 'bar');
 console.log(await db.get('foo'));
 ```

--- a/src/binding/database.cpp
+++ b/src/binding/database.cpp
@@ -190,7 +190,7 @@ napi_value Database::Get(napi_env env, napi_callback_info info) {
  *
  * @example
  * ```ts
- * const db = await NativeDatabase.open('path/to/db');
+ * const db = NativeDatabase.open('path/to/db');
  * const total = db.getCount();
  * const range = db.getCount({ start: 'a', end: 'z' });
  * ```

--- a/src/binding/database.h
+++ b/src/binding/database.h
@@ -11,10 +11,10 @@ namespace rocksdb_js {
 
 /**
  * The `NativeDatabase` JavaScript class implementation.
- * 
+ *
  * @example
  * ```js
- * const db = new binding.NativeDatabase();
+ * const db = new RocksDatabase();
  * db.open('/tmp/testdb');
  * db.put('foo', 'bar');
  * ```

--- a/test/block-cache.test.ts
+++ b/test/block-cache.test.ts
@@ -9,7 +9,7 @@ describe('Block Cache', () => {
 		const dbPath = generateDBPath();
 
 		try {
-			db = await RocksDatabase.open(dbPath, { noBlockCache: true });
+			db = RocksDatabase.open(dbPath, { noBlockCache: true });
 			await db.put('foo', 'bar');
 			// note get() will find 'foo' in the memtable and return it synchronously
 			expect(db.get('foo')).toBe('bar');
@@ -25,7 +25,7 @@ describe('Block Cache', () => {
 
 		try {
 			RocksDatabase.config({ blockCacheSize: 1024 * 1024 });
-			db = await RocksDatabase.open(dbPath);
+			db = RocksDatabase.open(dbPath);
 			await db.put('foo', 'bar');
 			expect(db.get('foo')).toBe('bar');
 		} finally {
@@ -41,7 +41,7 @@ describe('Block Cache', () => {
 		try {
 			RocksDatabase.config({ blockCacheSize: 1024 * 1024 });
 
-			db = await RocksDatabase.open(dbPath);
+			db = RocksDatabase.open(dbPath);
 			await db.put('foo', 'bar');
 			expect(db.get('foo')).toBe('bar');
 

--- a/test/column-families.test.ts
+++ b/test/column-families.test.ts
@@ -10,10 +10,10 @@ describe('Column Families', () => {
 		const dbPath = generateDBPath();
 
 		try {
-			db = await RocksDatabase.open(dbPath);
+			db = RocksDatabase.open(dbPath);
 			await db.put('foo', 'bar');
 
-			db2 = await RocksDatabase.open(dbPath, { name: 'foo' });
+			db2 = RocksDatabase.open(dbPath, { name: 'foo' });
 			await db2.put('foo', 'bar2');
 
 			expect(db.get('foo')).toBe('bar');
@@ -31,11 +31,11 @@ describe('Column Families', () => {
 		const dbPath = generateDBPath();
 
 		try {
-			db = await RocksDatabase.open(dbPath, { name: 'foo' });
+			db = RocksDatabase.open(dbPath, { name: 'foo' });
 			await db.put('foo', 'bar');
 			expect(db.get('foo')).toBe('bar');
 
-			db2 = await RocksDatabase.open(dbPath, { name: 'foo' });
+			db2 = RocksDatabase.open(dbPath, { name: 'foo' });
 			expect(db2.get('foo')).toBe('bar');
 		} finally {
 			db?.close();

--- a/test/encoder.test.ts
+++ b/test/encoder.test.ts
@@ -20,7 +20,7 @@ describe('Encoder', () => {
 		}
 
 		try {
-			db = await RocksDatabase.open(dbPath, {
+			db = RocksDatabase.open(dbPath, {
 				encoder: {
 					Encoder: CustomEncoder
 				}
@@ -40,7 +40,7 @@ describe('Encoder', () => {
 		const dbPath = generateDBPath();
 
 		try {
-			db = await RocksDatabase.open(dbPath, {
+			db = RocksDatabase.open(dbPath, {
 				encoder: {
 					encode: (value: any) => Buffer.from(value)
 				}
@@ -60,7 +60,7 @@ describe('Encoder', () => {
 		const dbPath = generateDBPath();
 
 		try {
-			db = await RocksDatabase.open(dbPath, {
+			db = RocksDatabase.open(dbPath, {
 				encoding: 'binary'
 			});
 
@@ -78,7 +78,7 @@ describe('Encoder', () => {
 		const dbPath = generateDBPath();
 
 		try {
-			db = await RocksDatabase.open(dbPath, {
+			db = RocksDatabase.open(dbPath, {
 				encoding: 'ordered-binary'
 			});
 
@@ -96,7 +96,7 @@ describe('Encoder', () => {
 		const dbPath = generateDBPath();
 
 		try {
-			db = await RocksDatabase.open(dbPath, {
+			db = RocksDatabase.open(dbPath, {
 				encoding: 'msgpack'
 			});
 
@@ -114,7 +114,7 @@ describe('Encoder', () => {
 		const dbPath = generateDBPath();
 
 		try {
-			db = await RocksDatabase.open(dbPath, {
+			db = RocksDatabase.open(dbPath, {
 				encoding: 'binary',
 				encoder: {
 					encode: (value: any) => value
@@ -136,7 +136,7 @@ describe('Encoder', () => {
 		const dbPath = generateDBPath();
 
 		try {
-			db = await RocksDatabase.open(dbPath, {
+			db = RocksDatabase.open(dbPath, {
 				encoding: false
 			});
 
@@ -154,7 +154,7 @@ describe('Encoder', () => {
 		const dbPath = generateDBPath();
 
 		try {
-			db = await RocksDatabase.open(dbPath, {
+			db = RocksDatabase.open(dbPath, {
 				encoding: false
 			});
 
@@ -170,7 +170,7 @@ describe('Encoder', () => {
 		const dbPath = generateDBPath();
 
 		try {
-			db = await RocksDatabase.open(dbPath, {
+			db = RocksDatabase.open(dbPath, {
 				encoding: false,
 				encoder: {
 					decode: null as any,

--- a/test/key-encoding.test.ts
+++ b/test/key-encoding.test.ts
@@ -11,7 +11,7 @@ describe('Key Encoding', () => {
 			let db: RocksDatabase | null = null;
 
 			try {
-				db = await RocksDatabase.open(dbPath, {
+				db = RocksDatabase.open(dbPath, {
 					keyEncoding: 'uint32'
 				});
 
@@ -34,7 +34,7 @@ describe('Key Encoding', () => {
 			let db: RocksDatabase | null = null;
 
 			try {
-				db = await RocksDatabase.open(dbPath, {
+				db = RocksDatabase.open(dbPath, {
 					keyEncoding: 'uint32'
 				});
 
@@ -67,7 +67,7 @@ describe('Key Encoding', () => {
 			let db: RocksDatabase | null = null;
 
 			try {
-				db = await RocksDatabase.open(dbPath, {
+				db = RocksDatabase.open(dbPath, {
 					keyEncoding: 'uint32'
 				});
 				await expect(db.put('foo', 'bar')).rejects.toThrow('Key is not a number');
@@ -84,7 +84,7 @@ describe('Key Encoding', () => {
 			let db: RocksDatabase | null = null;
 
 			try {
-				db = await RocksDatabase.open(dbPath, {
+				db = RocksDatabase.open(dbPath, {
 					keyEncoding: 'binary'
 				});
 				await db.put('foo', 'bar');
@@ -104,7 +104,7 @@ describe('Key Encoding', () => {
 			let db: RocksDatabase | null = null;
 
 			try {
-				db = await RocksDatabase.open(dbPath, {
+				db = RocksDatabase.open(dbPath, {
 					keyEncoding: 'ordered-binary'
 				});
 				await db.put('foo', 'bar');
@@ -124,7 +124,7 @@ describe('Key Encoding', () => {
 			let db: RocksDatabase | null = null;
 
 			try {
-				db = await RocksDatabase.open(dbPath, {
+				db = RocksDatabase.open(dbPath, {
 					keyEncoder: {
 						readKey(key: Buffer) {
 							return JSON.parse(key.toString('utf-8'));
@@ -150,7 +150,7 @@ describe('Key Encoding', () => {
 			let db: RocksDatabase | null = null;
 
 			try {
-				db = await RocksDatabase.open(dbPath, {
+				db = RocksDatabase.open(dbPath, {
 					keyEncoder: {
 						readKey: (_key: Buffer) => Buffer.from('foo'),
 						writeKey: (_key: Key, _target: Buffer, _start: number) => 0
@@ -167,9 +167,9 @@ describe('Key Encoding', () => {
 			const dbPath = generateDBPath();
 
 			try {
-				await expect(RocksDatabase.open(dbPath, {
+				expect(() => RocksDatabase.open(dbPath, {
 					keyEncoder: {}
-				})).rejects.toThrow('Custom key encoder must provide both readKey and writeKey');
+				})).toThrow('Custom key encoder must provide both readKey and writeKey');
 			} finally {
 				await rimraf(dbPath);
 			}
@@ -180,9 +180,9 @@ describe('Key Encoding', () => {
 
 	describe('Error handling', () => {
 		it('should error if key encoding is not supported', async () => {
-			await expect(RocksDatabase.open(generateDBPath(), {
+			expect(() => RocksDatabase.open(generateDBPath(), {
 				keyEncoding: 'foo'
-			} as any)).rejects.toThrow('Invalid key encoding: foo');
+			} as any)).toThrow('Invalid key encoding: foo');
 		});
 	});
 });

--- a/test/lifecycle.test.ts
+++ b/test/lifecycle.test.ts
@@ -15,8 +15,8 @@ describe('Lifecycle', () => {
 
 			db.close(); // noop
 
-			await db.open();
-			await db.open(); // noop
+			db.open();
+			db.open(); // noop
 
 			expect(db.isOpen()).toBe(true);
 			expect(db.get('foo')).toBeUndefined();

--- a/test/ranges.test.ts
+++ b/test/ranges.test.ts
@@ -9,7 +9,7 @@ async function initTestDB(test: (db: RocksDatabase) => Promise<void>, name?: str
 	const dbPath = generateDBPath();
 
 	try {
-		db = await RocksDatabase.open(dbPath, { name });
+		db = RocksDatabase.open(dbPath, { name });
 		await test(db);
 	} finally {
 		db?.close();

--- a/test/read.test.ts
+++ b/test/read.test.ts
@@ -24,7 +24,7 @@ describe('Read Operations', () => {
 			let db: RocksDatabase | null = null;
 
 			try {
-				db = await RocksDatabase.open(dbPath);
+				db = RocksDatabase.open(dbPath);
 				const value = await db.get('baz');
 				expect(value).toBeUndefined();
 			} finally {
@@ -38,7 +38,7 @@ describe('Read Operations', () => {
 			let db: RocksDatabase | null = null;
 
 			try {
-				db = await RocksDatabase.open(dbPath);
+				db = RocksDatabase.open(dbPath);
 				await expect((db.get as any)()).rejects.toThrow('Key is required');
 			} finally {
 				db?.close();
@@ -51,7 +51,7 @@ describe('Read Operations', () => {
 			let db: RocksDatabase | null = null;
 
 			try {
-				db = await RocksDatabase.open(dbPath);
+				db = RocksDatabase.open(dbPath);
 				await db.put('foo', 'bar');
 				const value = await db.get('foo', { skipDecode: true });
 				expect(value).not.toBe('bar');
@@ -85,7 +85,7 @@ describe('Read Operations', () => {
 			let db: RocksDatabase | null = null;
 
 			try {
-				db = await RocksDatabase.open(dbPath);
+				db = RocksDatabase.open(dbPath);
 				const value = db.getSync('baz');
 				expect(value).toBeUndefined();
 			} finally {
@@ -99,7 +99,7 @@ describe('Read Operations', () => {
 			let db: RocksDatabase | null = null;
 
 			try {
-				db = await RocksDatabase.open(dbPath);
+				db = RocksDatabase.open(dbPath);
 				expect(() => (db!.getSync as any)()).toThrow('Key is required');
 			} finally {
 				db?.close();
@@ -127,7 +127,7 @@ describe('Read Operations', () => {
 			let db: RocksDatabase | null = null;
 
 			try {
-				db = await RocksDatabase.open(dbPath);
+				db = RocksDatabase.open(dbPath);
 				const value = await db.getBinary('baz');
 				expect(value).toBeUndefined();
 			} finally {
@@ -141,7 +141,7 @@ describe('Read Operations', () => {
 			let db: RocksDatabase | null = null;
 
 			try {
-				db = await RocksDatabase.open(dbPath);
+				db = RocksDatabase.open(dbPath);
 				expect(() => (db!.getBinary as any)()).toThrow('Key is required');
 			} finally {
 				db?.close();
@@ -169,7 +169,7 @@ describe('Read Operations', () => {
 			let db: RocksDatabase | null = null;
 
 			try {
-				db = await RocksDatabase.open(dbPath);
+				db = RocksDatabase.open(dbPath);
 				const value = db.getBinarySync('baz');
 				expect(value).toBeUndefined();
 			} finally {
@@ -183,7 +183,7 @@ describe('Read Operations', () => {
 			let db: RocksDatabase | null = null;
 
 			try {
-				db = await RocksDatabase.open(dbPath);
+				db = RocksDatabase.open(dbPath);
 				expect(() => (db!.getBinarySync as any)()).toThrow('Key is required');
 			} finally {
 				db?.close();
@@ -211,7 +211,7 @@ describe('Read Operations', () => {
 			let db: RocksDatabase | null = null;
 
 			try {
-				db = await RocksDatabase.open(dbPath);
+				db = RocksDatabase.open(dbPath);
 				const value = await db.getBinaryFast('baz');
 				expect(value).toBeUndefined();
 			} finally {
@@ -225,7 +225,7 @@ describe('Read Operations', () => {
 			let db: RocksDatabase | null = null;
 
 			try {
-				db = await RocksDatabase.open(dbPath);
+				db = RocksDatabase.open(dbPath);
 				expect(() => (db!.getBinaryFast as any)()).toThrow('Key is required');
 			} finally {
 				db?.close();
@@ -253,7 +253,7 @@ describe('Read Operations', () => {
 			let db: RocksDatabase | null = null;
 
 			try {
-				db = await RocksDatabase.open(dbPath);
+				db = RocksDatabase.open(dbPath);
 				const value = db.getBinaryFastSync('baz');
 				expect(value).toBeUndefined();
 			} finally {
@@ -267,7 +267,7 @@ describe('Read Operations', () => {
 			let db: RocksDatabase | null = null;
 
 			try {
-				db = await RocksDatabase.open(dbPath);
+				db = RocksDatabase.open(dbPath);
 				expect(() => (db!.getBinaryFastSync as any)()).toThrow('Key is required');
 			} finally {
 				db?.close();

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -23,7 +23,7 @@ describe('Custom Store', () => {
 
 		try {
 			const store = new CustomStore(dbPath);
-			db = await RocksDatabase.open(dbPath, { store });
+			db = RocksDatabase.open(dbPath, { store });
 			await db.put('foo', 'bar');
 			expect(await db.get('foo')).toBe('bar');
 		} finally {

--- a/test/transactions.test.ts
+++ b/test/transactions.test.ts
@@ -30,7 +30,7 @@ for (const { name, options, txnOptions } of testOptions) {
 			const dbPath = generateDBPath();
 
 			try {
-				db = await RocksDatabase.open(dbPath, options);
+				db = RocksDatabase.open(dbPath, options);
 				await expect(db.transaction('foo' as any, txnOptions)).rejects.toThrow(
 					new TypeError('Callback must be a function')
 				);
@@ -45,7 +45,7 @@ for (const { name, options, txnOptions } of testOptions) {
 			const dbPath = generateDBPath();
 
 			try {
-				db = await RocksDatabase.open(dbPath, options);
+				db = RocksDatabase.open(dbPath, options);
 				await db.put('foo', 'bar');
 				await db.transaction(async (txn: Transaction) => {
 					const value = await txn.get('foo');
@@ -62,7 +62,7 @@ for (const { name, options, txnOptions } of testOptions) {
 			const dbPath = generateDBPath();
 
 			try {
-				db = await RocksDatabase.open(dbPath, options);
+				db = RocksDatabase.open(dbPath, options);
 				await db.transaction(async (txn: Transaction) => {
 					await txn.put('foo', 'bar2');
 				}, txnOptions);
@@ -79,7 +79,7 @@ for (const { name, options, txnOptions } of testOptions) {
 			const dbPath = generateDBPath();
 
 			try {
-				db = await RocksDatabase.open(dbPath, options);
+				db = RocksDatabase.open(dbPath, options);
 				await db.put('foo', 'bar');
 
 				await db.transaction(async (txn: Transaction) => {
@@ -99,7 +99,7 @@ for (const { name, options, txnOptions } of testOptions) {
 			const dbPath = generateDBPath();
 
 			try {
-				db = await RocksDatabase.open(dbPath, options);
+				db = RocksDatabase.open(dbPath, options);
 				await db.put('foo', 'bar');
 
 				await expect(db.transaction(async (txn: Transaction) => {
@@ -121,7 +121,7 @@ for (const { name, options, txnOptions } of testOptions) {
 				const dbPath = generateDBPath();
 
 				try {
-					db = await RocksDatabase.open(dbPath, options);
+					db = RocksDatabase.open(dbPath, options);
 					await db.put('foo', 'bar1');
 
 					setTimeout(() => db?.put('foo', 'bar2'));
@@ -165,7 +165,7 @@ for (const { name, options, txnOptions } of testOptions) {
 				const dbPath = generateDBPath();
 
 				try {
-					db = await RocksDatabase.open(dbPath, options);
+					db = RocksDatabase.open(dbPath, options);
 					await db.put('foo', 'bar1');
 
 					setTimeout(() => db?.put('foo', 'bar2'));
@@ -208,8 +208,8 @@ for (const { name, options, txnOptions } of testOptions) {
 			const dbPath = generateDBPath();
 
 			try {
-				db = await RocksDatabase.open(dbPath, options);
-				db2 = await RocksDatabase.open(dbPath, { ...options, name: 'foo' });
+				db = RocksDatabase.open(dbPath, options);
+				db2 = RocksDatabase.open(dbPath, { ...options, name: 'foo' });
 
 				await db.put('foo', 'bar');
 				await db2.put('foo2', 'baz');
@@ -237,8 +237,8 @@ for (const { name, options, txnOptions } of testOptions) {
 			const dbPath2 = generateDBPath();
 
 			try {
-				db = await RocksDatabase.open(dbPath, options);
-				db2 = await RocksDatabase.open(dbPath2, options);
+				db = RocksDatabase.open(dbPath, options);
+				db2 = RocksDatabase.open(dbPath2, options);
 
 				await Promise.all([
 					db.transaction(async (txn: Transaction) => {
@@ -266,7 +266,7 @@ for (const { name, options, txnOptions } of testOptions) {
 			const dbPath = generateDBPath();
 
 			try {
-				db = await RocksDatabase.open(dbPath, options);
+				db = RocksDatabase.open(dbPath, options);
 				for (const key of ['a', 'b', 'c', 'd', 'e']) {
 					await db.put(key, `value ${key}`);
 				}
@@ -298,7 +298,7 @@ for (const { name, options, txnOptions } of testOptions) {
 			const dbPath = generateDBPath();
 
 			try {
-				db = await RocksDatabase.open(dbPath, options);
+				db = RocksDatabase.open(dbPath, options);
 				expect(() => db!.transactionSync('foo' as any, txnOptions))
 					.toThrow(new TypeError('Callback must be a function'));
 			} finally {
@@ -312,7 +312,7 @@ for (const { name, options, txnOptions } of testOptions) {
 			const dbPath = generateDBPath();
 
 			try {
-				db = await RocksDatabase.open(dbPath, options);
+				db = RocksDatabase.open(dbPath, options);
 				await db.put('foo', 'bar');
 				db.transactionSync((txn: Transaction) => {
 					const value = txn.getSync('foo');
@@ -329,7 +329,7 @@ for (const { name, options, txnOptions } of testOptions) {
 			const dbPath = generateDBPath();
 
 			try {
-				db = await RocksDatabase.open(dbPath, options);
+				db = RocksDatabase.open(dbPath, options);
 
 				db.transactionSync((txn: Transaction) => {
 					txn.putSync('foo', 'bar2');
@@ -348,7 +348,7 @@ for (const { name, options, txnOptions } of testOptions) {
 			const dbPath = generateDBPath();
 
 			try {
-				db = await RocksDatabase.open(dbPath, options);
+				db = RocksDatabase.open(dbPath, options);
 				await db.put('foo', 'bar');
 
 				db.transactionSync((txn: Transaction) => {
@@ -368,7 +368,7 @@ for (const { name, options, txnOptions } of testOptions) {
 			const dbPath = generateDBPath();
 
 			try {
-				db = await RocksDatabase.open(dbPath, options);
+				db = RocksDatabase.open(dbPath, options);
 				await db.put('foo', 'bar');
 
 				expect(() => db!.transactionSync((txn: Transaction) => {
@@ -390,8 +390,8 @@ for (const { name, options, txnOptions } of testOptions) {
 			const dbPath = generateDBPath();
 
 			try {
-				db = await RocksDatabase.open(dbPath, options);
-				db2 = await RocksDatabase.open(dbPath, { ...options, name: 'foo' });
+				db = RocksDatabase.open(dbPath, options);
+				db2 = RocksDatabase.open(dbPath, { ...options, name: 'foo' });
 
 				await db.put('foo', 'bar');
 				await db2.put('foo2', 'baz');
@@ -417,7 +417,7 @@ for (const { name, options, txnOptions } of testOptions) {
 			const dbPath = generateDBPath();
 
 			try {
-				db = await RocksDatabase.open(dbPath, options);
+				db = RocksDatabase.open(dbPath, options);
 				for (const key of ['a', 'b', 'c', 'd', 'e']) {
 					db.putSync(key, `value ${key}`);
 				}
@@ -449,7 +449,7 @@ for (const { name, options, txnOptions } of testOptions) {
 			const dbPath = generateDBPath();
 
 			try {
-				db = await RocksDatabase.open(dbPath, options);
+				db = RocksDatabase.open(dbPath, options);
 				await expect(db.get('foo', { transaction: 'bar' as any })).rejects.toThrow('Invalid transaction');
 			} finally {
 				db?.close();
@@ -462,7 +462,7 @@ for (const { name, options, txnOptions } of testOptions) {
 			const dbPath = generateDBPath();
 
 			try {
-				db = await RocksDatabase.open(dbPath, options);
+				db = RocksDatabase.open(dbPath, options);
 				await expect(db.get('foo', { transaction: { id: 9926 } as any })).rejects.toThrow('Transaction not found');
 			} finally {
 				db?.close();

--- a/test/write.test.ts
+++ b/test/write.test.ts
@@ -10,7 +10,7 @@ describe('Write operations', () => {
 			let db: RocksDatabase | null = null;
 
 			try {
-				db = await RocksDatabase.open(dbPath);
+				db = RocksDatabase.open(dbPath);
 				await db.put('foo', 'bar1');
 				const value = await db.get('foo');
 				expect(value).toBe('bar1');
@@ -25,7 +25,7 @@ describe('Write operations', () => {
 			let db: RocksDatabase | null = null;
 
 			try {
-				db = await RocksDatabase.open(dbPath, {
+				db = RocksDatabase.open(dbPath, {
 					name: 'foo'
 				});
 				await db.put('foo', 'bar2');
@@ -42,7 +42,7 @@ describe('Write operations', () => {
 			let db: RocksDatabase | null = null;
 
 			try {
-				db = await RocksDatabase.open(dbPath);
+				db = RocksDatabase.open(dbPath);
 				await expect((db.put as any)()).rejects.toThrow('Key is required');
 			} finally {
 				db?.close();
@@ -55,7 +55,7 @@ describe('Write operations', () => {
 			let db: RocksDatabase | null = null;
 
 			try {
-				db = await RocksDatabase.open(dbPath);
+				db = RocksDatabase.open(dbPath);
 				await db.close();
 				await expect((db.put as any)()).rejects.toThrow('Database not open');
 			} finally {
@@ -71,7 +71,7 @@ describe('Write operations', () => {
 			let db: RocksDatabase | null = null;
 
 			try {
-				db = await RocksDatabase.open(dbPath);
+				db = RocksDatabase.open(dbPath);
 				db.putSync('foo', 'bar1');
 				const value = await db.get('foo');
 				expect(value).toBe('bar1');
@@ -86,7 +86,7 @@ describe('Write operations', () => {
 			let db: RocksDatabase | null = null;
 
 			try {
-				db = await RocksDatabase.open(dbPath, {
+				db = RocksDatabase.open(dbPath, {
 					name: 'foo'
 				});
 				db.putSync('foo', 'bar2');
@@ -103,7 +103,7 @@ describe('Write operations', () => {
 			let db: RocksDatabase | null = null;
 
 			try {
-				db = await RocksDatabase.open(dbPath);
+				db = RocksDatabase.open(dbPath);
 				expect(() => (db!.putSync as any)()).toThrow('Key is required');
 			} finally {
 				db?.close();
@@ -116,7 +116,7 @@ describe('Write operations', () => {
 			let db: RocksDatabase | null = null;
 
 			try {
-				db = await RocksDatabase.open(dbPath);
+				db = RocksDatabase.open(dbPath);
 				await db.close();
 				expect(() => (db!.putSync as any)()).toThrow('Database not open');
 			} finally {
@@ -132,7 +132,7 @@ describe('Write operations', () => {
 			let db: RocksDatabase | null = null;
 
 			try {
-				db = await RocksDatabase.open(dbPath);
+				db = RocksDatabase.open(dbPath);
 				await db.remove('baz');
 			} finally {
 				db?.close();
@@ -145,7 +145,7 @@ describe('Write operations', () => {
 			let db: RocksDatabase | null = null;
 
 			try {
-				db = await RocksDatabase.open(dbPath);
+				db = RocksDatabase.open(dbPath);
 				let value = await db.get('foo');
 				expect(value).toBeUndefined();
 				await db.put('foo', 'bar3');
@@ -165,7 +165,7 @@ describe('Write operations', () => {
 			let db: RocksDatabase | null = null;
 
 			try {
-				db = await RocksDatabase.open(dbPath);
+				db = RocksDatabase.open(dbPath);
 				await expect((db.remove as any)()).rejects.toThrow('Key is required');
 			} finally {
 				db?.close();
@@ -178,7 +178,7 @@ describe('Write operations', () => {
 			let db: RocksDatabase | null = null;
 
 			try {
-				db = await RocksDatabase.open(dbPath);
+				db = RocksDatabase.open(dbPath);
 				await db.close();
 				await expect((db.remove as any)()).rejects.toThrow('Database not open');
 			} finally {


### PR DESCRIPTION
`db.open()` was originally async in an effort to lazy load `msgpackr`, but Harper needs `db.open()` to be sync. Part of the work was done in https://github.com/HarperDB/rocksdb-js/pull/40 and this addresses the remainder.