### PR TITLE
Let create-pull-request do commit

### DIFF
--- a/.github/workflows/update-rocksdb.yaml
+++ b/.github/workflows/update-rocksdb.yaml
@@ -69,11 +69,10 @@ jobs:
           jq ".rocksdb.version = \"${{ steps.latest-release.outputs.latest }}\"" package.json > package.json.tmp
           mv package.json.tmp package.json
 
-      - name: Commit changes
+      - name: Stage changes
         if: steps.latest-release.outputs.should_update == 'true'
         run: |
           git add package.json
-          git commit -m "chore: update rocksdb to ${{ steps.latest-release.outputs.latest }}"
 
       - name: Pull request
         if: steps.latest-release.outputs.should_update == 'true'


### PR DESCRIPTION
The update RocksDB workflow manually commits the change and errors because the user email and name are not set:

```
Author identity unknown

*** Please tell me who you are.

Run

  git config --global user.email "you@example.com"
  git config --global user.name "Your Name"

to set your account's default identity.
Omit --global to set the identity only in this repository.

fatal: empty ident name (for <runner@pkrvmpptgkbjq6m.1joi1osonwlubklurnmqjjibde.cx.internal.cloudapp.net>) not allowed
```

Turns out, we don't even need to do the commit because the `peter-evans/create-pull-request` action does it for us using the token.