### PR TITLE
[CORE-2862] Set commit timestamp

### DIFF
--- a/src/load-binding.ts
+++ b/src/load-binding.ts
@@ -19,8 +19,8 @@ export type NativeTransaction = {
 	id: number;
 	new(context: NativeDatabase, options?: TransactionOptions): NativeTransaction;
 	abort(): void;
-	commit(resolve: () => void, reject: (err: Error) => void): void;
-	commitSync(): void;
+	commit(resolve: (timestamp: number) => void, reject: (err: Error) => void): void;
+	commitSync(): number;
 	get(key: Key, resolve: (value: Buffer) => void, reject: (err: Error) => void): number;
 	getCount(options?: RangeOptions): number;
 	getSync(key: Key): Buffer;

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -30,9 +30,9 @@ export class Transaction extends DBI {
 	/**
 	 * Commit the transaction.
 	 */
-	async commit(): Promise<void> {
+	async commit(): Promise<number> {
 		try {
-			await new Promise<void>((resolve, reject) => {
+			return await new Promise<number>((resolve, reject) => {
 				this.notify('beforecommit');
 				this.#txn.commit(resolve, reject);
 			});
@@ -45,10 +45,10 @@ export class Transaction extends DBI {
 		}
 	}
 
-	commitSync(): void {
+	commitSync(): number {
 		try {
 			this.notify('beforecommit');
-			this.#txn.commitSync();
+			return this.#txn.commitSync();
 		} finally {
 			this.notify('aftercommit', {
 				next: null,


### PR DESCRIPTION
This sets the timestamp in RocksDB when the commit happens. The `NativeTransaction`'s `commit()` and `commitSync()` will return this timestamp. This timestamp is currently internal only (e.g. `db.transaction()` does not surface this timestamp). Only consumers of the `Transaction` class can get this timestamp.