### PR TITLE
Update tests to use dbRunner() for test setup/teardown

### DIFF
--- a/test/clear.test.ts
+++ b/test/clear.test.ts
@@ -44,13 +44,13 @@ describe('Clear', () => {
 			// note: this test can be flaky because sometimes it can clear
 			// faster than the close, so set the batch size to 1 to slow it
 			// down a little
-			for (let i = 0; i < 100000; ++i) {
+			for (let i = 0; i < 100_000; ++i) {
 				db.putSync(`foo-${i}`, `bar-${i}`);
 			}
 			const promise = db.clear({ batchSize: 1 });
 			db.close();
 			await expect(promise).rejects.toThrow('Database closed during clear operation');
-		}));
+		}), 10_000);
 	});
 
 	describe('clearSync()', () => {

--- a/test/error-handling.test.ts
+++ b/test/error-handling.test.ts
@@ -1,11 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { rimraf } from 'rimraf';
 import { RocksDatabase, Store } from '../src/index.js';
-import { generateDBPath } from './lib/util.js';
+import { generateDBPath, dbRunner } from './lib/util.js';
 import { DBI } from '../src/dbi.js';
 
 describe('Error Handling', () => {
-	it('should error if database path is invalid', async () => {
+	it('should error if database path is invalid', () => {
 		expect(() => new RocksDatabase(undefined as any)).toThrow('Invalid database path or store');
 		expect(() => new RocksDatabase(null as any)).toThrow('Invalid database path or store');
 		expect(() => new RocksDatabase(1 as any)).toThrow('Invalid database path or store');
@@ -14,29 +13,22 @@ describe('Error Handling', () => {
 		expect(() => new RocksDatabase('')).toThrow('Invalid database path');
 	});
 
-	it('should error if database options is not an object', async () => {
+	it('should error if database options is not an object', () => {
 		expect(() => new RocksDatabase(generateDBPath(), 'foo' as any)).toThrow('Database options must be an object');
 		expect(() => new RocksDatabase(generateDBPath(), 1 as any)).toThrow('Database options must be an object');
 	});
 
-	it('should error if database not open', async () => {
-		let db: RocksDatabase | null = null;
-		const dbPath = generateDBPath();
+	it('should error if database not open', () => dbRunner({
+		skipOpen: true
+	}, async ({ db }) => {
+		await expect(db.get('test')).rejects.toThrow('Database not open');
+	}));
 
-		try {
-			db = new RocksDatabase(dbPath);
-			await expect(db.get('test')).rejects.toThrow('Database not open');
-		} finally {
-			db?.close();
-			await rimraf(dbPath);
-		}
-	});
-
-	it('should error creating an abstract DBI instance', async () => {
+	it('should error creating an abstract DBI instance', () => {
 		expect(() => new DBI(null as any)).toThrow('DBI is an abstract class and cannot be instantiated directly');
 	});
 
-	it('should error if store is invalid', async () => {
+	it('should error if store is invalid', () => {
 		expect(() => new Store(null as any)).toThrow('Invalid database path');
 	});
 });

--- a/test/fixtures/try-lock-worker.mts
+++ b/test/fixtures/try-lock-worker.mts
@@ -15,9 +15,11 @@ parentPort?.on('message', event => {
 	if (event.unlock) {
 		db.unlock('foo');
 		parentPort?.postMessage({ unlocked: true });
-	}
-	if (event.lock) {
+	} else if (event.lock) {
 		getLock();
+	} else if (event.close) {
+		db.close();
+		process.exit(0);
 	}
 });
 

--- a/test/key-encoding.test.ts
+++ b/test/key-encoding.test.ts
@@ -1,185 +1,129 @@
 import { describe, expect, it } from 'vitest';
-import { rimraf } from 'rimraf';
 import { RocksDatabase } from '../src/index.js';
-import { generateDBPath } from './lib/util.js';
+import { dbRunner, generateDBPath } from './lib/util.js';
 import type { Key } from '../src/encoding.js';
 
 describe('Key Encoding', () => {
 	describe('uint32', () => {
-		it('should encode key using uint32', async () => {
-			const dbPath = generateDBPath();
-			let db: RocksDatabase | null = null;
-
-			try {
-				db = RocksDatabase.open(dbPath, {
-					keyEncoding: 'uint32'
-				});
-
-				for (let i = 0; i < 10; i++) {
-					await db.put(i, `value-${i}`);
-				}
-
-				for (let i = 0; i < 10; i++) {
-					const value = await db.get(i);
-					expect(value).toBe(`value-${i}`);
-				}
-			} finally {
-				db?.close();
-				await rimraf(dbPath);
+		it('should encode key using uint32', () => dbRunner({
+			dbOptions: [ {
+				keyEncoding: 'uint32'
+			} ]
+		}, async ({ db }) => {
+			for (let i = 0; i < 10; i++) {
+				await db.put(i, `value-${i}`);
 			}
-		});
 
-		it.skip('should read and write a range', async () => {
-			const dbPath = generateDBPath();
-			let db: RocksDatabase | null = null;
-
-			try {
-				db = RocksDatabase.open(dbPath, {
-					keyEncoding: 'uint32'
-				});
-
-				let i;
-				for (i = 0; i < 10; i++) {
-					await db.put(i, `value-${i}`);
-				}
-
-				// i = 0;
-				// for (let { key, value } of db.getRange()) {
-				// 	expect(key).toBe(i);
-				// 	expect(value).toBe(`value-${i}`);
-				// 	i++;
-				// }
-
-				// i = 0;
-				// for (let { key, value } of db.getRange({ start: 0 })) {
-				// 	expect(key).toBe(i);
-				// 	expect(value).toBe(`value-${i}`);
-				// 	i++;
-				// }
-			} finally {
-				db?.close();
-				await rimraf(dbPath);
+			for (let i = 0; i < 10; i++) {
+				const value = await db.get(i);
+				expect(value).toBe(`value-${i}`);
 			}
-		});
+		}));
 
-		it('should error if key is not a number', async () => {
-			const dbPath = generateDBPath();
-			let db: RocksDatabase | null = null;
-
-			try {
-				db = RocksDatabase.open(dbPath, {
-					keyEncoding: 'uint32'
-				});
-				await expect(db.put('foo', 'bar')).rejects.toThrow('Key is not a number');
-			} finally {
-				db?.close();
-				await rimraf(dbPath);
+		it.skip('should read and write a range', () => dbRunner({
+			dbOptions: [ {
+				keyEncoding: 'uint32'
+			} ]
+		}, async ({ db }) => {
+			let i;
+			for (i = 0; i < 10; i++) {
+				await db.put(i, `value-${i}`);
 			}
-		});
+
+			// i = 0;
+			// for (let { key, value } of db.getRange()) {
+			// 	expect(key).toBe(i);
+			// 	expect(value).toBe(`value-${i}`);
+			// 	i++;
+			// }
+
+			// i = 0;
+			// for (let { key, value } of db.getRange({ start: 0 })) {
+			// 	expect(key).toBe(i);
+			// 	expect(value).toBe(`value-${i}`);
+			// 	i++;
+			// }
+		}));
+
+		it('should error if key is not a number', () => dbRunner({
+			dbOptions: [ {
+				keyEncoding: 'uint32'
+			} ]
+		}, async ({ db }) => {
+			await expect(db.put('foo', 'bar')).rejects.toThrow('Key is not a number');
+		}));
 	});
 
 	describe('binary', () => {
-		it('should encode key using binary', async () => {
-			const dbPath = generateDBPath();
-			let db: RocksDatabase | null = null;
+		it('should encode key using binary', () => dbRunner({
+			dbOptions: [ {
+				keyEncoding: 'binary'
+			} ]
+		}, async ({ db }) => {
+			await db.put('foo', 'bar');
 
-			try {
-				db = RocksDatabase.open(dbPath, {
-					keyEncoding: 'binary'
-				});
-				await db.put('foo', 'bar');
-
-				const value = await db.get('foo');
-				expect(value).toBe('bar');
-			} finally {
-				db?.close();
-				await rimraf(dbPath);
-			}
-		});
+			const value = await db.get('foo');
+			expect(value).toBe('bar');
+		}));
 	});
 
 	describe('ordered-binary', () => {
-		it('should encode key using ordered-binary', async () => {
-			const dbPath = generateDBPath();
-			let db: RocksDatabase | null = null;
+		it('should encode key using ordered-binary', () => dbRunner({
+			dbOptions: [ {
+				keyEncoding: 'ordered-binary'
+			} ]
+		}, async ({ db }) => {
+			await db.put('foo', 'bar');
 
-			try {
-				db = RocksDatabase.open(dbPath, {
-					keyEncoding: 'ordered-binary'
-				});
-				await db.put('foo', 'bar');
-
-				const value = await db.get('foo');
-				expect(value).toBe('bar');
-			} finally {
-				db?.close();
-				await rimraf(dbPath);
-			}
-		});
+			const value = await db.get('foo');
+			expect(value).toBe('bar');
+		}));
 	});
 
 	describe('Custom key encoder', () => {
-		it('should encode key with string using custom key encoder', async () => {
-			const dbPath = generateDBPath();
-			let db: RocksDatabase | null = null;
-
-			try {
-				db = RocksDatabase.open(dbPath, {
-					keyEncoder: {
-						readKey(key: Buffer) {
-							return JSON.parse(key.toString('utf-8'));
-						},
-						writeKey(key: Key, target: Buffer, start: number) {
-							return target.write(JSON.stringify(
-								key instanceof Buffer ? key : String(key)
-							), start);
-						}
+		it('should encode key with string using custom key encoder', () => dbRunner({
+			dbOptions: [ {
+				keyEncoder: {
+					readKey(key: Buffer) {
+						return JSON.parse(key.toString('utf-8'));
+					},
+					writeKey(key: Key, target: Buffer, start: number) {
+						return target.write(JSON.stringify(
+							key instanceof Buffer ? key : String(key)
+						), start);
 					}
-				});
-				await db.put({ foo: 'bar' } as any, 'baz');
-				const value = await db.get({ foo: 'bar' } as any);
-				expect(value).toBe('baz');
-			} finally {
-				db?.close();
-				await rimraf(dbPath);
-			}
-		});
+				}
+			} ]
+		}, async ({ db }) => {
+			await db.put({ foo: 'bar' } as any, 'baz');
+			const value = await db.get({ foo: 'bar' } as any);
+			expect(value).toBe('baz');
+		}));
 
-		it('should throw an error if key has zero length', async () => {
-			const dbPath = generateDBPath();
-			let db: RocksDatabase | null = null;
-
-			try {
-				db = RocksDatabase.open(dbPath, {
-					keyEncoder: {
-						readKey: (_key: Buffer) => Buffer.from('foo'),
-						writeKey: (_key: Key, _target: Buffer, _start: number) => 0
-					}
-				});
-				await expect(db.get('foo')).rejects.toThrow('Zero length key is not allowed');
-			} finally {
-				db?.close();
-				await rimraf(dbPath);
-			}
-		});
+		it('should throw an error if key has zero length', () => dbRunner({
+			dbOptions: [ {
+				keyEncoder: {
+					readKey: (_key: Buffer) => Buffer.from('foo'),
+					writeKey: (_key: Key, _target: Buffer, _start: number) => 0
+				}
+			} ]
+		}, async ({ db }) => {
+			await expect(db.get('foo')).rejects.toThrow('Zero length key is not allowed');
+		}));
 
 		it('should error if key encoder is missing readKey or writeKey', async () => {
 			const dbPath = generateDBPath();
 
-			try {
-				expect(() => RocksDatabase.open(dbPath, {
-					keyEncoder: {}
-				})).toThrow('Custom key encoder must provide both readKey and writeKey');
-			} finally {
-				await rimraf(dbPath);
-			}
+			expect(() => new RocksDatabase(dbPath, {
+				keyEncoder: {}
+			})).toThrow('Custom key encoder must provide both readKey and writeKey');
 		});
 	});
 
-	// mixed keys
+	// TODO: mixed keys
 
 	describe('Error handling', () => {
-		it('should error if key encoding is not supported', async () => {
+		it('should error if key encoding is not supported', () => {
 			expect(() => RocksDatabase.open(generateDBPath(), {
 				keyEncoding: 'foo'
 			} as any)).toThrow('Invalid key encoding: foo');

--- a/test/lifecycle.test.ts
+++ b/test/lifecycle.test.ts
@@ -1,89 +1,67 @@
 import { describe, expect, it } from 'vitest';
-import { rimraf } from 'rimraf';
-import { RocksDatabase } from '../src/index.js';
-import { generateDBPath } from './lib/util.js';
+import { dbRunner } from './lib/util.js';
 
 describe('Lifecycle', () => {
-	it('should open and close database', async () => {
-		let db: RocksDatabase | null = null;
-		const dbPath = generateDBPath();
+	it('should open and close database', () => dbRunner({
+		skipOpen: true
+	}, async ({ db }) => {
+		expect(db.isOpen()).toBe(false);
 
-		try {
-			db = new RocksDatabase(dbPath);
+		db.close(); // noop
 
-			expect(db.isOpen()).toBe(false);
+		db.open();
+		db.open(); // noop
 
-			db.close(); // noop
+		expect(db.isOpen()).toBe(true);
+		expect(db.get('foo')).toBeUndefined();
 
-			db.open();
-			db.open(); // noop
+		db.close();
 
-			expect(db.isOpen()).toBe(true);
-			expect(db.get('foo')).toBeUndefined();
+		expect(db.isOpen()).toBe(false);
 
-			db.close();
+		await expect(db.get('foo')).rejects.toThrow('Database not open');
+	}));
 
-			expect(db.isOpen()).toBe(false);
+	it('should open and close multiple databases', () => dbRunner({
+		dbOptions: [ {}, { name: 'foo' }, { name: 'foo' } ],
+		skipOpen: true
+	}, async ({ db }, { db: db2 }, { db: db3 }) => {
+		expect(db.isOpen()).toBe(false);
+		expect(db2.isOpen()).toBe(false);
+		expect(db3.isOpen()).toBe(false);
 
-			await expect(db.get('foo')).rejects.toThrow('Database not open');
-		} finally {
-			db?.close();
-			await rimraf(dbPath);
-		}
-	});
+		db.close(); // noop
+		db2.close(); // noop
+		db3.close(); // noop
 
-	it('should open and close multiple databases', async () => {
-		let db: RocksDatabase | null = null;
-		let db2: RocksDatabase | null = null;
-		let db3: RocksDatabase | null = null;
-		const dbPath = generateDBPath();
+		db.open();
+		db.open(); // noop
 
-		try {
-			db = new RocksDatabase(dbPath);
-			db2 = new RocksDatabase(dbPath, { name: 'foo' });
-			db3 = new RocksDatabase(dbPath, { name: 'foo' });
+		db2.open();
+		db2.open(); // noop
 
-			expect(db.isOpen()).toBe(false);
-			expect(db2.isOpen()).toBe(false);
-			expect(db3.isOpen()).toBe(false);
+		db3.open();
+		db3.open(); // noop
 
-			db.close(); // noop
-			db2.close(); // noop
-			db3.close(); // noop
+		expect(db.isOpen()).toBe(true);
+		expect(db.get('foo')).toBeUndefined();
 
-			db.open();
-			db.open(); // noop
+		expect(db2.isOpen()).toBe(true);
+		expect(db2.get('foo')).toBeUndefined();
 
-			db2.open();
-			db2.open(); // noop
+		expect(db3.isOpen()).toBe(true);
+		expect(db3.get('foo')).toBeUndefined();
 
-			db3.open();
-			db3.open(); // noop
+		db.close();
+		db2.close();
+		db3.close();
 
-			expect(db.isOpen()).toBe(true);
-			expect(db.get('foo')).toBeUndefined();
+		expect(db.isOpen()).toBe(false);
+		expect(db2.isOpen()).toBe(false);
+		expect(db3.isOpen()).toBe(false);
 
-			expect(db2.isOpen()).toBe(true);
-			expect(db2.get('foo')).toBeUndefined();
-
-			expect(db3.isOpen()).toBe(true);
-			expect(db3.get('foo')).toBeUndefined();
-
-			db.close();
-			db2.close();
-			db3.close();
-
-			expect(db.isOpen()).toBe(false);
-			expect(db2.isOpen()).toBe(false);
-			expect(db3.isOpen()).toBe(false);
-
-			await expect(db.get('foo')).rejects.toThrow('Database not open');
-			await expect(db2.get('foo')).rejects.toThrow('Database not open');
-			await expect(db3.get('foo')).rejects.toThrow('Database not open');
-		} finally {
-			db?.close();
-			db2?.close();
-			await rimraf(dbPath);
-		}
-	});
+		await expect(db.get('foo')).rejects.toThrow('Database not open');
+		await expect(db2.get('foo')).rejects.toThrow('Database not open');
+		await expect(db3.get('foo')).rejects.toThrow('Database not open');
+	}));
 });

--- a/test/lock.test.ts
+++ b/test/lock.test.ts
@@ -6,37 +6,37 @@ import { dbRunner } from './lib/util.js';
 describe('Lock', () => {
 	describe('tryLock()', () => {
 		it('should error attempting to lock if key is not specified', () => dbRunner(async ({ db }) => {
-			expect(() => (db!.tryLock as any)()).toThrow('Key is required');
+			expect(() => (db.tryLock as any)()).toThrow('Key is required');
 		}));
 
 		it('should error if callback is not a function', () => dbRunner(async ({ db }) => {
-			expect(() => db!.tryLock('foo', 'bar' as any)).toThrow('Callback must be a function');
+			expect(() => db.tryLock('foo', 'bar' as any)).toThrow('Callback must be a function');
 		}));
 
 		it('should error attempting to lock if database is not open', () => dbRunner({
 			skipOpen: true
 		}, async ({ db }) => {
-			expect(() => db!.tryLock('foo')).toThrow('Database not open');
+			expect(() => db.tryLock('foo')).toThrow('Database not open');
 		}));
 
 		it('should lock and unlock', () => dbRunner(async ({ db }) => {
-			expect(db!.hasLock('foo')).toBe(false);
-			expect(db!.unlock('foo')).toBe(false);
+			expect(db.hasLock('foo')).toBe(false);
+			expect(db.unlock('foo')).toBe(false);
 
 			let unlockCounter = 0;
-			expect(db!.tryLock('foo', () => {
+			expect(db.tryLock('foo', () => {
 				unlockCounter++;
 			})).toBe(true);
 
 			const promises = [
 				new Promise<void>(resolve => {
-					expect(db!.tryLock('foo', () => {
+					expect(db.tryLock('foo', () => {
 						unlockCounter++;
 						resolve();
 					})).toBe(false);
 				}),
 				new Promise<void>(resolve => {
-					expect(db!.tryLock('foo', () => {
+					expect(db.tryLock('foo', () => {
 						unlockCounter++;
 						resolve();
 					})).toBe(false);
@@ -44,28 +44,28 @@ describe('Lock', () => {
 			];
 
 			expect(unlockCounter).toBe(0);
-			expect(db!.hasLock('foo')).toBe(true);
-			expect(db!.unlock('foo')).toBe(true);
-			expect(db!.hasLock('foo')).toBe(false);
+			expect(db.hasLock('foo')).toBe(true);
+			expect(db.unlock('foo')).toBe(true);
+			expect(db.hasLock('foo')).toBe(false);
 			await Promise.all(promises);
 			expect(unlockCounter).toBe(2);
 		}));
 
 		it('should lock in a lock', () => dbRunner(async ({ db }) => {
-			expect(db!.tryLock('foo', () => {})).toBe(true);
-			expect(db!.tryLock('foo', () => {
-				expect(db!.tryLock('foo', () => {})).toBe(true);
+			expect(db.tryLock('foo', () => {})).toBe(true);
+			expect(db.tryLock('foo', () => {
+				expect(db.tryLock('foo', () => {})).toBe(true);
 			})).toBe(false);
-			expect(db!.unlock('foo')).toBe(true);
+			expect(db.unlock('foo')).toBe(true);
 			await delay(100);
-			expect(db!.unlock('foo')).toBe(true);
-			expect(db!.unlock('foo')).toBe(false);
+			expect(db.unlock('foo')).toBe(true);
+			expect(db.unlock('foo')).toBe(false);
 		}));
 
 		it('should not unlock if another database is closed', () => dbRunner(async ({ db }, { db: db2 }) => {
 			expect(db.hasLock('foo')).toBe(false);
 			expect(db2.hasLock('foo')).toBe(false);
-			expect(db!.tryLock('foo', () => {})).toBe(true);
+			expect(db.tryLock('foo', () => {})).toBe(true);
 			expect(db2.hasLock('foo')).toBe(true);
 			db2.close();
 			expect(db.hasLock('foo')).toBe(true);
@@ -81,16 +81,21 @@ describe('Lock', () => {
 
 			// Node.js 18 and older doesn't properly eval ESM code
 			const majorVersion = parseInt(process.versions.node.split('.')[0]);
-			const script = majorVersion < 20
+			const script = process.versions.deno || process.versions.bun
 				?	`
-					const tsx = require('tsx/cjs/api');
-					tsx.require('./test/fixtures/try-lock-worker.mts', __dirname);
+					import { pathToFileURL } from 'node:url';
+					import(pathToFileURL('./test/fixtures/try-lock-worker.mts'));
 					`
-				:	`
-					import { register } from 'tsx/esm/api';
-					register();
-					import('./test/fixtures/try-lock-worker.mts');
-					`;
+				:	majorVersion < 20
+					?	`
+						const tsx = require('tsx/cjs/api');
+						tsx.require('./test/fixtures/try-lock-worker.mts', __dirname);
+						`
+					:	`
+						import { register } from 'tsx/esm/api';
+						register();
+						import('./test/fixtures/try-lock-worker.mts');
+						`;
 
 			const worker = new Worker(
 				script,
@@ -143,45 +148,45 @@ describe('Lock', () => {
 			expect(db.hasLock('foo')).toBe(true); // worker has lock
 
 			await new Promise<void>(resolve => {
-				expect(db!.tryLock('foo', () => resolve())).toBe(false);
-				worker.terminate();
+				expect(db.tryLock('foo', () => resolve())).toBe(false);
+				worker.postMessage({ close: true });
 			});
 		}));
 	});
 
 	describe('unlock()', () => {
 		it('should error attempting to unlock if key is not specified', () => dbRunner(async ({ db }) => {
-			expect(() => (db!.unlock as any)()).toThrow('Key is required');
+			expect(() => (db.unlock as any)()).toThrow('Key is required');
 		}));
 
 		it('should error attempting to unlock if database is not open', () => dbRunner({
 			skipOpen: true
 		}, async ({ db }) => {
-			expect(() => db!.unlock('foo')).toThrow('Database not open');
+			expect(() => db.unlock('foo')).toThrow('Database not open');
 		}));
 	});
 
 	describe('hasLock()', () => {
 		it('should error attempting to unlock if key is not specified', () => dbRunner(async ({ db }) => {
-			expect(() => (db!.hasLock as any)()).toThrow('Key is required');
+			expect(() => (db.hasLock as any)()).toThrow('Key is required');
 		}));
 
 		it('should error attempting to unlock if database is not open', () => dbRunner({
 			skipOpen: true
 		}, async ({ db }) => {
-			expect(() => db!.hasLock('foo')).toThrow('Database not open');
+			expect(() => db.hasLock('foo')).toThrow('Database not open');
 		}));
 	});
 
 	describe('withLock()', () => {
 		it('should error if callback is not a function', () => dbRunner(async ({ db }) => {
-			await expect(db!.withLock('foo', 'bar' as any)).rejects.toThrow('Callback must be a function');
+			await expect(db.withLock('foo', 'bar' as any)).rejects.toThrow('Callback must be a function');
 		}));
 
 		it('should error if database is not open', () => dbRunner({
 			skipOpen: true
 		}, async ({ db }) => {
-			await expect(db!.withLock('foo', () => {})).rejects.toThrow('Database not open');
+			await expect(db.withLock('foo', () => {})).rejects.toThrow('Database not open');
 		}));
 
 		it('should lock and unlock', () => dbRunner(async ({ db }) => {
@@ -190,12 +195,12 @@ describe('Lock', () => {
 			await db.withLock('foo', async () => {
 				spy();
 
-				await db!.withLock('bar', async () => {
+				await db.withLock('bar', async () => {
 					// async
 					await delay(100);
 					spy();
 
-					await db!.withLock('baz', () => {
+					await db.withLock('baz', () => {
 						// sync
 						spy();
 					});
@@ -210,7 +215,7 @@ describe('Lock', () => {
 
 			const promise = db.withLock('foo', async () => {
 				spy();
-				expect(db!.hasLock('foo')).toBe(true);
+				expect(db.hasLock('foo')).toBe(true);
 				await delay(100);
 			});
 
@@ -221,7 +226,7 @@ describe('Lock', () => {
 
 			await db.withLock('foo', async () => {
 				spy();
-				expect(db!.hasLock('foo')).toBe(true);
+				expect(db.hasLock('foo')).toBe(true);
 			});
 
 			expect(db.hasLock('foo')).toBe(false);
@@ -233,16 +238,21 @@ describe('Lock', () => {
 
 			// Node.js 18 and older doesn't properly eval ESM code
 			const majorVersion = parseInt(process.versions.node.split('.')[0]);
-			const script = majorVersion < 20
+			const script = process.versions.deno || process.versions.bun
 				?	`
-					const tsx = require('tsx/cjs/api');
-					tsx.require('./test/fixtures/with-lock-worker.mts', __dirname);
+					import { pathToFileURL } from 'node:url';
+					import(pathToFileURL('./test/fixtures/with-lock-worker.mts'));
 					`
-				:	`
-					import { register } from 'tsx/esm/api';
-					register();
-					import('./test/fixtures/with-lock-worker.mts');
-					`;
+				:	majorVersion < 20
+					?	`
+						const tsx = require('tsx/cjs/api');
+						tsx.require('./test/fixtures/with-lock-worker.mts', __dirname);
+						`
+					:	`
+						import { register } from 'tsx/esm/api';
+						register();
+						import('./test/fixtures/with-lock-worker.mts');
+						`;
 
 			const worker = new Worker(
 				script,
@@ -285,21 +295,21 @@ describe('Lock', () => {
 			const promise = Promise.all([
 				db.withLock('foo', async () => {
 					spy();
-					expect(db!.hasLock('foo')).toBe(true);
+					expect(db.hasLock('foo')).toBe(true);
 					expect(workerLocked).toBe(false);
 				}),
 				db.withLock('foo', async () => {
 					spy();
-					expect(db!.hasLock('foo')).toBe(true);
+					expect(db.hasLock('foo')).toBe(true);
 					worker.postMessage({ lock: true });
 					await delay(250);
 					expect(workerLocked).toBe(false);
 				}),
 				(async () => {
 					await delay(100),
-					await db!.withLock('foo', async () => {
+					await db.withLock('foo', async () => {
 						spy();
-						expect(db!.hasLock('foo')).toBe(true);
+						expect(db.hasLock('foo')).toBe(true);
 						await delay(100);
 						expect(workerLocked).toBe(false);
 					})
@@ -311,6 +321,13 @@ describe('Lock', () => {
 			expect(spy).toHaveBeenCalledTimes(3);
 
 			worker.postMessage({ close: true });
+
+			if (process.versions.deno) {
+				// deno doesn't emit an `exit` event when the worker quits, but
+				// `terminate()` will trigger the `exit` event
+				await delay(100);
+				worker.terminate();
+			}
 		}));
 	});
 });

--- a/test/ranges.test.ts
+++ b/test/ranges.test.ts
@@ -1,21 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { rimraf } from 'rimraf';
-import { RocksDatabase, RocksDatabaseOptions } from '../src/index.js';
-import { generateDBPath } from './lib/util.js';
+import { dbRunner } from './lib/util.js';
 import type { Key } from '../src/encoding.js';
-
-async function initTestDB(test: (db: RocksDatabase) => Promise<void>, nameOrOptions?: string | RocksDatabaseOptions) {
-	let db: RocksDatabase | null = null;
-	const dbPath = generateDBPath();
-
-	try {
-		db = RocksDatabase.open(dbPath, typeof nameOrOptions === 'string' ? { name: nameOrOptions } : nameOrOptions);
-		await test(db);
-	} finally {
-		db?.close();
-		await rimraf(dbPath);
-	}
-}
 
 describe('Ranges', () => {
 	describe('getRange()', () => {
@@ -41,902 +26,807 @@ describe('Ranges', () => {
 			'z',
 		];
 
-		it('should query a range synchronously', async () => {
-			await initTestDB(async db => {
-				for (const key of testKeys) {
-					await db.put(key, 'value');
-				}
+		it('should query a range synchronously', () => dbRunner(async ({ db }) => {
+			for (const key of testKeys) {
+				await db.put(key, 'value');
+			}
 
-				const opts = {
-					start: Symbol.for('A')
-				};
+			const opts = {
+				start: Symbol.for('A')
+			};
 
+			const returnedKeys: Key[] = [];
+			for (const { key, value } of db.getRange(opts)) {
+				returnedKeys.push(key);
+				expect(value).toBe(db.getSync(key));
+			}
+			expect(testKeys).toEqual(returnedKeys);
+		}));
+
+		it('should query a range synchronously for a column family', () => dbRunner({
+			dbOptions: [ { name: 'foo' } ]
+		}, async ({ db }) => {
+			for (const key of testKeys) {
+				await db.put(key, 'value');
+			}
+
+			const opts = {
+				start: Symbol.for('A')
+			};
+
+			const returnedKeys: Key[] = [];
+			for (const { key, value } of db.getRange(opts)) {
+				returnedKeys.push(key);
+				expect(value).toBe(db.getSync(key));
+			}
+			expect(testKeys).toEqual(returnedKeys);
+		}));
+
+		it('should query a range asynchronously', () => dbRunner(async ({ db }) => {
+			for (const key of testKeys) {
+				await db.put(key, 'value');
+			}
+
+			const opts = {
+				start: Symbol.for('A')
+			};
+
+			const returnedKeys: Key[] = [];
+			for await (const { key, value } of db.getRange(opts)) {
+				returnedKeys.push(key);
+				expect(value).toBe(db.getSync(key));
+			}
+			expect(testKeys).toEqual(returnedKeys);
+		}));
+
+		it('should get a range within a transaction', () => dbRunner(async ({ db }) => {
+			for (const key of ['a', 'b', 'c', 'd', 'e']) {
+				await db.put(key, 'value');
+			}
+
+			const opts = {
+				start: 'b',
+				end: 'd'
+			};
+
+			await db.transaction(async txn => {
 				const returnedKeys: Key[] = [];
-				for (const { key, value } of db.getRange(opts)) {
+				for await (const { key, value } of txn.getRange(opts)) {
 					returnedKeys.push(key);
 					expect(value).toBe(db.getSync(key));
 				}
-				expect(testKeys).toEqual(returnedKeys);
+				expect(['b', 'c']).toEqual(returnedKeys);
 			});
-		});
+		}));
 
-		it('should query a range synchronously for a column family', async () => {
-			await initTestDB(async db => {
-				for (const key of testKeys) {
-					await db.put(key, 'value');
-				}
+		it('should get a range within a transaction for a column family', () => dbRunner({
+			dbOptions: [ { name: 'foo' } ]
+		}, async ({ db }) => {
+			for (const key of ['a', 'b', 'c', 'd', 'e']) {
+				await db.put(key, 'value');
+			}
 
-				const opts = {
-					start: Symbol.for('A')
-				};
+			const opts = {
+				start: 'b',
+				end: 'd'
+			};
 
+			await db.transaction(async txn => {
 				const returnedKeys: Key[] = [];
-				for (const { key, value } of db.getRange(opts)) {
+				for await (const { key, value } of txn.getRange(opts)) {
 					returnedKeys.push(key);
 					expect(value).toBe(db.getSync(key));
 				}
-				expect(testKeys).toEqual(returnedKeys);
-			}, 'foo');
-		});
-
-		it('should query a range asynchronously', async () => {
-			await initTestDB(async db => {
-				for (const key of testKeys) {
-					await db.put(key, 'value');
-				}
-
-				const opts = {
-					start: Symbol.for('A')
-				};
-
-				const returnedKeys: Key[] = [];
-				for await (const { key, value } of db.getRange(opts)) {
-					returnedKeys.push(key);
-					expect(value).toBe(db.getSync(key));
-				}
-				expect(testKeys).toEqual(returnedKeys);
+				expect(['b', 'c']).toEqual(returnedKeys);
 			});
-		});
+		}));
 
-		it('should get a range within a transaction', async () => {
-			await initTestDB(async db => {
-				for (const key of ['a', 'b', 'c', 'd', 'e']) {
-					await db.put(key, 'value');
-				}
+		it('should iterate over a range asynchronously', () => dbRunner(async ({ db }) => {
+			for (const key of ['a', 'b', 'c', 'd', 'e']) {
+				await db.put(key, 'value');
+			}
 
-				const opts = {
-					start: 'b',
-					end: 'd'
-				};
+			const returnedKeys: Key[] = [];
+			for await (const { key, value } of db.getRange()) {
+				returnedKeys.push(key);
+				expect(value).toBe(db.getSync(key));
+			}
+			expect(['a', 'b', 'c', 'd', 'e']).toEqual(returnedKeys);
+		}));
 
-				await db.transaction(async txn => {
-					const returnedKeys: Key[] = [];
-					for await (const { key, value } of txn.getRange(opts)) {
-						returnedKeys.push(key);
-						expect(value).toBe(db.getSync(key));
-					}
-					expect(['b', 'c']).toEqual(returnedKeys);
-				});
-			});
-		});
+		it('should close iterator if returning before iterator is done', () => dbRunner(async ({ db }) => {
+			for (const key of ['a', 'b', 'c', 'd', 'e']) {
+				await db.put(key, `value ${key}`);
+			}
 
-		it('should get a range within a transaction for a column family', async () => {
-			await initTestDB(async db => {
-				for (const key of ['a', 'b', 'c', 'd', 'e']) {
-					await db.put(key, 'value');
-				}
+			const iter = db.getRange()[Symbol.iterator]();
+			const first = iter.next();
+			expect(first).toEqual({ done: false, value: { key: 'a', value: 'value a' } });
 
-				const opts = {
-					start: 'b',
-					end: 'd'
-				};
+			if (iter.return) {
+				const rval = iter.return();
+				expect(rval).toEqual({ done: true, value: undefined });
+			} else {
+				throw new Error('Iterator does not support return');
+			}
+		}));
 
-				await db.transaction(async txn => {
-					const returnedKeys: Key[] = [];
-					for await (const { key, value } of txn.getRange(opts)) {
-						returnedKeys.push(key);
-						expect(value).toBe(db.getSync(key));
-					}
-					expect(['b', 'c']).toEqual(returnedKeys);
-				});
-			}, 'foo');
-		});
+		it('should close iterator if throwing before iterator is done', () => dbRunner(async ({ db }) => {
+			for (const key of ['a', 'b', 'c', 'd', 'e']) {
+				await db.put(key, `value ${key}`);
+			}
 
-		it('should iterate over a range asynchronously', async () => {
-			await initTestDB(async db => {
-				for (const key of ['a', 'b', 'c', 'd', 'e']) {
-					await db.put(key, 'value');
-				}
-
-				const returnedKeys: Key[] = [];
-				for await (const { key, value } of db.getRange()) {
-					returnedKeys.push(key);
-					expect(value).toBe(db.getSync(key));
-				}
-				expect(['a', 'b', 'c', 'd', 'e']).toEqual(returnedKeys);
-			});
-		});
-
-		it('should close iterator if returning before iterator is done', async () => {
-			await initTestDB(async db => {
-				for (const key of ['a', 'b', 'c', 'd', 'e']) {
-					await db.put(key, `value ${key}`);
-				}
-
+			try {
 				const iter = db.getRange()[Symbol.iterator]();
 				const first = iter.next();
 				expect(first).toEqual({ done: false, value: { key: 'a', value: 'value a' } });
 
-				if (iter.return) {
-					const rval = iter.return();
-					expect(rval).toEqual({ done: true, value: undefined });
+				if (iter.throw) {
+					iter.throw(new Error('test'));
 				} else {
-					throw new Error('Iterator does not support return');
+					throw new Error('Iterator does not support throw');
 				}
-			});
-		});
-
-		it('should close iterator if throwing before iterator is done', async () => {
-			await initTestDB(async db => {
-				for (const key of ['a', 'b', 'c', 'd', 'e']) {
-					await db.put(key, `value ${key}`);
-				}
-
-				try {
-					const iter = db.getRange()[Symbol.iterator]();
-					const first = iter.next();
-					expect(first).toEqual({ done: false, value: { key: 'a', value: 'value a' } });
-
-					if (iter.throw) {
-						iter.throw(new Error('test'));
-					} else {
-						throw new Error('Iterator does not support throw');
-					}
-				} catch (error) {
-					console.log(error);
-				}
-			});
-		});
-
-		it('should get iterate in reverse', async () => {
-			await initTestDB(async db => {
-				for (const key of ['a', 'b', 'c', 'd', 'e']) {
-					await db.put(key, `value ${key}`);
-				}
-
-				const returnedKeys: Key[] = [];
-				for (const { key, value } of db.getRange({ reverse: true })) {
-					returnedKeys.push(key);
-					expect(value).toBe(db.getSync(key));
-				}
-				expect(['e', 'd', 'c', 'b', 'a']).toEqual(returnedKeys);
-			});
-		});
-
-		it('should include end key', async () => {
-			await initTestDB(async db => {
-				for (const key of ['a', 'b', 'c', 'd', 'e']) {
-					await db.put(key, `value ${key}`);
-				}
-
-				const iter = db.getRange({ end: 'c', inclusiveEnd: true });
-				expect(Array.from(iter)).toEqual([
-					{ key: 'a', value: 'value a' },
-					{ key: 'b', value: 'value b' },
-					{ key: 'c', value: 'value c' }
-				]);
-			});
-		});
-
-		it('should exclude start key', async () => {
-			await initTestDB(async db => {
-				for (const key of ['a', 'b', 'c', 'd', 'e']) {
-					await db.put(key, `value ${key}`);
-				}
-
-				const iter = db.getRange({ start: 'a', exclusiveStart: true });
-				expect(Array.from(iter)).toEqual([
-					{ key: 'b', value: 'value b' },
-					{ key: 'c', value: 'value c' },
-					{ key: 'd', value: 'value d' },
-					{ key: 'e', value: 'value e' }
-				]);
-			});
-		});
-
-		it('should get keys only', async () => {
-			await initTestDB(async db => {
-				for (const key of ['a', 'b', 'c', 'd', 'e']) {
-					await db.put(key, `value ${key}`);
-				}
-
-				const iter = db.getRange({ values: false });
-				expect(Array.from(iter)).toEqual([
-					{ key: 'a' },
-					{ key: 'b' },
-					{ key: 'c' },
-					{ key: 'd' },
-					{ key: 'e' }
-				]);
-			});
-		});
-
-		it('should error if database is not open', async () => {
-			let db: RocksDatabase | null = null;
-			const dbPath = generateDBPath();
-
-			try {
-				expect(() => {
-					db = new RocksDatabase(dbPath);
-					db.getRange();
-				}).toThrow('Database not open');
-			} finally {
-				await rimraf(dbPath);
+			} catch (error) {
+				console.log(error);
 			}
-		});
+		}));
+
+		it('should get iterate in reverse', () => dbRunner(async ({ db }) => {
+			for (const key of ['a', 'b', 'c', 'd', 'e']) {
+				await db.put(key, `value ${key}`);
+			}
+
+			const returnedKeys: Key[] = [];
+			for (const { key, value } of db.getRange({ reverse: true })) {
+				returnedKeys.push(key);
+				expect(value).toBe(db.getSync(key));
+			}
+			expect(['e', 'd', 'c', 'b', 'a']).toEqual(returnedKeys);
+		}));
+
+		it('should include end key', () => dbRunner(async ({ db }) => {
+			for (const key of ['a', 'b', 'c', 'd', 'e']) {
+				await db.put(key, `value ${key}`);
+			}
+
+			const iter = db.getRange({ end: 'c', inclusiveEnd: true });
+			expect(Array.from(iter)).toEqual([
+				{ key: 'a', value: 'value a' },
+				{ key: 'b', value: 'value b' },
+				{ key: 'c', value: 'value c' }
+			]);
+		}));
+
+		it('should exclude start key', () => dbRunner(async ({ db }) => {
+			for (const key of ['a', 'b', 'c', 'd', 'e']) {
+				await db.put(key, `value ${key}`);
+			}
+
+			const iter = db.getRange({ start: 'a', exclusiveStart: true });
+			expect(Array.from(iter)).toEqual([
+				{ key: 'b', value: 'value b' },
+				{ key: 'c', value: 'value c' },
+				{ key: 'd', value: 'value d' },
+				{ key: 'e', value: 'value e' }
+			]);
+		}));
+
+		it('should get keys only', () => dbRunner(async ({ db }) => {
+			for (const key of ['a', 'b', 'c', 'd', 'e']) {
+				await db.put(key, `value ${key}`);
+			}
+
+			const iter = db.getRange({ values: false });
+			expect(Array.from(iter)).toEqual([
+				{ key: 'a' },
+				{ key: 'b' },
+				{ key: 'c' },
+				{ key: 'd' },
+				{ key: 'e' }
+			]);
+		}));
+
+		it('should error if database is not open', () => dbRunner({
+			skipOpen: true
+		}, async ({ db }) => {
+			expect(() => db.getRange()).toThrow('Database not open');
+		}));
 	});
 
 	describe('getKeys()', () => {
-		it('should get keys only', async () => {
-			await initTestDB(async db => {
-				for (const key of ['a', 'b', 'c', 'd', 'e']) {
-					await db.put(key, `value ${key}`);
-				}
-
-				const iter = db.getKeys();
-				expect(Array.from(iter)).toEqual([
-					{ key: 'a' },
-					{ key: 'b' },
-					{ key: 'c' },
-					{ key: 'd' },
-					{ key: 'e' }
-				]);
-			});
-		});
-
-		it('should get keys only in a column family', async () => {
-			await initTestDB(async db => {
-				for (const key of ['a', 'b', 'c', 'd', 'e']) {
-					await db.put(key, `value ${key}`);
-				}
-
-				const iter = db.getKeys();
-				expect(Array.from(iter)).toEqual([
-					{ key: 'a' },
-					{ key: 'b' },
-					{ key: 'c' },
-					{ key: 'd' },
-					{ key: 'e' }
-				]);
-			}, 'foo');
-		});
-
-		it('should get keys only for a transaction', async () => {
-			await initTestDB(async db => {
-				for (const key of ['a', 'b', 'c', 'd', 'e']) {
-					await db.put(key, `value ${key}`);
-				}
-
-				await db.transaction(async txn => {
-					const iter = txn.getKeys();
-					expect(Array.from(iter)).toEqual([
-						{ key: 'a' },
-						{ key: 'b' },
-						{ key: 'c' },
-						{ key: 'd' },
-						{ key: 'e' }
-					]);
-				});
-			});
-		});
-
-		it('should get keys only for a transaction and column family', async () => {
-			await initTestDB(async db => {
-				for (const key of ['a', 'b', 'c', 'd', 'e']) {
-					await db.put(key, `value ${key}`);
-				}
-
-				await db.transaction(async txn => {
-					const iter = txn.getKeys();
-					expect(Array.from(iter)).toEqual([
-						{ key: 'a' },
-						{ key: 'b' },
-						{ key: 'c' },
-						{ key: 'd' },
-						{ key: 'e' }
-					]);
-				});
-			}, 'foo');
-		});
-
-		it('should error if database is not open', async () => {
-			let db: RocksDatabase | null = null;
-			const dbPath = generateDBPath();
-
-			try {
-				expect(() => {
-					db = new RocksDatabase(dbPath);
-					db.getKeys();
-				}).toThrow('Database not open');
-			} finally {
-				await rimraf(dbPath);
+		it('should get keys only', () => dbRunner(async ({ db }) => {
+			for (const key of ['a', 'b', 'c', 'd', 'e']) {
+				await db.put(key, `value ${key}`);
 			}
-		});
+
+			const iter = db.getKeys();
+			expect(Array.from(iter)).toEqual([
+				{ key: 'a' },
+				{ key: 'b' },
+				{ key: 'c' },
+				{ key: 'd' },
+				{ key: 'e' }
+			]);
+		}));
+
+		it('should get keys only in a column family', () => dbRunner({
+			dbOptions: [ { name: 'foo' } ]
+		}, async ({ db }) => {
+			for (const key of ['a', 'b', 'c', 'd', 'e']) {
+				await db.put(key, `value ${key}`);
+			}
+
+			const iter = db.getKeys();
+			expect(Array.from(iter)).toEqual([
+				{ key: 'a' },
+				{ key: 'b' },
+				{ key: 'c' },
+				{ key: 'd' },
+				{ key: 'e' }
+			]);
+		}));
+
+		it('should get keys only for a transaction', () => dbRunner(async ({ db }) => {
+			for (const key of ['a', 'b', 'c', 'd', 'e']) {
+				await db.put(key, `value ${key}`);
+			}
+
+			await db.transaction(async txn => {
+				const iter = txn.getKeys();
+				expect(Array.from(iter)).toEqual([
+					{ key: 'a' },
+					{ key: 'b' },
+					{ key: 'c' },
+					{ key: 'd' },
+					{ key: 'e' }
+				]);
+			});
+		}));
+
+		it('should get keys only for a transaction and column family', () => dbRunner({
+			dbOptions: [ { name: 'foo' } ]
+		}, async ({ db }) => {
+			for (const key of ['a', 'b', 'c', 'd', 'e']) {
+				await db.put(key, `value ${key}`);
+			}
+
+			await db.transaction(async txn => {
+				const iter = txn.getKeys();
+				expect(Array.from(iter)).toEqual([
+					{ key: 'a' },
+					{ key: 'b' },
+					{ key: 'c' },
+					{ key: 'd' },
+					{ key: 'e' }
+				]);
+			});
+		}));
+
+		it('should error if database is not open', () => dbRunner({
+			skipOpen: true
+		}, async ({ db }) => {
+			expect(() => db.getKeys()).toThrow('Database not open');
+		}));
 	});
 
 	describe('getKeysCount()', () => {
-		it('should get the number of keys for a range', async () => {
-			await initTestDB(async db => {
-				let count = db.getKeysCount();
-				expect(count).toBe(0);
+		it('should get the number of keys for a range', () => dbRunner(async ({ db }) => {
+			let count = db.getKeysCount();
+			expect(count).toBe(0);
 
-				for (const key of ['a', 'b', 'c', 'd', 'e']) {
-					await db.put(key, `value ${key}`);
-				}
-
-				count = db.getKeysCount();
-				expect(count).toBe(5);
-
-				count = db.getKeysCount({ start: 'b' });
-				expect(count).toBe(4);
-
-				count = db.getKeysCount({ start: 'b', exclusiveStart: true });
-				expect(count).toBe(3);
-
-				count = db.getKeysCount({ end: 'c' });
-				expect(count).toBe(2);
-
-				count = db.getKeysCount({ end: 'c', inclusiveEnd: true });
-				expect(count).toBe(3);
-
-				count = db.getKeysCount({ start: 'b', end: 'd' });
-				expect(count).toBe(2);
-
-				count = db.getKeysCount({ start: 'b', end: 'd', inclusiveEnd: true });
-				expect(count).toBe(3);
-
-				count = db.getKeysCount({ start: 'b', end: 'd', exclusiveStart: true });
-				expect(count).toBe(1);
-
-				count = db.getKeysCount({ start: 'b', end: 'd', inclusiveEnd: true, exclusiveStart: true });
-				expect(count).toBe(2);
-			});
-		});
-
-		it('should get the number of keys for a range in a column family', async () => {
-			await initTestDB(async db => {
-				let count = db.getKeysCount();
-				expect(count).toBe(0);
-
-				for (const key of ['a', 'b', 'c', 'd', 'e']) {
-					await db.put(key, `value ${key}`);
-				}
-
-				count = db.getKeysCount();
-				expect(count).toBe(5);
-
-				count = db.getKeysCount({ start: 'b' });
-				expect(count).toBe(4);
-
-				count = db.getKeysCount({ start: 'b', exclusiveStart: true });
-				expect(count).toBe(3);
-
-				count = db.getKeysCount({ end: 'c' });
-				expect(count).toBe(2);
-
-				count = db.getKeysCount({ end: 'c', inclusiveEnd: true });
-				expect(count).toBe(3);
-
-				count = db.getKeysCount({ start: 'b', end: 'd' });
-				expect(count).toBe(2);
-
-				count = db.getKeysCount({ start: 'b', end: 'd', inclusiveEnd: true });
-				expect(count).toBe(3);
-
-				count = db.getKeysCount({ start: 'b', end: 'd', exclusiveStart: true });
-				expect(count).toBe(1);
-
-				count = db.getKeysCount({ start: 'b', end: 'd', inclusiveEnd: true, exclusiveStart: true });
-				expect(count).toBe(2);
-			}, 'foo');
-		});
-
-		it('should get the number of keys for a range in a transaction', async () => {
-			await initTestDB(async db => {
-				for (const key of ['a', 'b', 'c', 'd', 'e']) {
-					await db.put(key, `value ${key}`);
-				}
-
-				await db.transaction(async txn => {
-					let count = txn.getKeysCount();
-					expect(count).toBe(5);
-
-					count = db.getKeysCount({ start: 'b' });
-					expect(count).toBe(4);
-
-					count = db.getKeysCount({ start: 'b', exclusiveStart: true });
-					expect(count).toBe(3);
-
-					count = db.getKeysCount({ end: 'c' });
-					expect(count).toBe(2);
-
-					count = db.getKeysCount({ end: 'c', inclusiveEnd: true });
-					expect(count).toBe(3);
-
-					count = db.getKeysCount({ start: 'b', end: 'd' });
-					expect(count).toBe(2);
-
-					count = db.getKeysCount({ start: 'b', end: 'd', inclusiveEnd: true });
-					expect(count).toBe(3);
-
-					count = db.getKeysCount({ start: 'b', end: 'd', exclusiveStart: true });
-					expect(count).toBe(1);
-
-					count = db.getKeysCount({ start: 'b', end: 'd', inclusiveEnd: true, exclusiveStart: true });
-					expect(count).toBe(2);
-				});
-			});
-		});
-
-		it('should get the number of keys for a range in a transaction and column family', async () => {
-			await initTestDB(async db => {
-				for (const key of ['a', 'b', 'c', 'd', 'e']) {
-					await db.put(key, `value ${key}`);
-				}
-
-				await db.transaction(async txn => {
-					let count = txn.getKeysCount();
-					expect(count).toBe(5);
-
-					count = db.getKeysCount({ start: 'b' });
-					expect(count).toBe(4);
-
-					count = db.getKeysCount({ start: 'b', exclusiveStart: true });
-					expect(count).toBe(3);
-
-					count = db.getKeysCount({ end: 'c' });
-					expect(count).toBe(2);
-
-					count = db.getKeysCount({ end: 'c', inclusiveEnd: true });
-					expect(count).toBe(3);
-
-					count = db.getKeysCount({ start: 'b', end: 'd' });
-					expect(count).toBe(2);
-
-					count = db.getKeysCount({ start: 'b', end: 'd', inclusiveEnd: true });
-					expect(count).toBe(3);
-
-					count = db.getKeysCount({ start: 'b', end: 'd', exclusiveStart: true });
-					expect(count).toBe(1);
-
-					count = db.getKeysCount({ start: 'b', end: 'd', inclusiveEnd: true, exclusiveStart: true });
-					expect(count).toBe(2);
-				});
-			}, 'foo');
-		});
-
-		it('should error if database is not open', async () => {
-			let db: RocksDatabase | null = null;
-			const dbPath = generateDBPath();
-
-			try {
-				expect(() => {
-					db = new RocksDatabase(dbPath);
-					db.getKeysCount();
-				}).toThrow('Database not open');
-			} finally {
-				await rimraf(dbPath);
+			for (const key of ['a', 'b', 'c', 'd', 'e']) {
+				await db.put(key, `value ${key}`);
 			}
-		});
+
+			count = db.getKeysCount();
+			expect(count).toBe(5);
+
+			count = db.getKeysCount({ start: 'b' });
+			expect(count).toBe(4);
+
+			count = db.getKeysCount({ start: 'b', exclusiveStart: true });
+			expect(count).toBe(3);
+
+			count = db.getKeysCount({ end: 'c' });
+			expect(count).toBe(2);
+
+			count = db.getKeysCount({ end: 'c', inclusiveEnd: true });
+			expect(count).toBe(3);
+
+			count = db.getKeysCount({ start: 'b', end: 'd' });
+			expect(count).toBe(2);
+
+			count = db.getKeysCount({ start: 'b', end: 'd', inclusiveEnd: true });
+			expect(count).toBe(3);
+
+			count = db.getKeysCount({ start: 'b', end: 'd', exclusiveStart: true });
+			expect(count).toBe(1);
+
+			count = db.getKeysCount({ start: 'b', end: 'd', inclusiveEnd: true, exclusiveStart: true });
+			expect(count).toBe(2);
+		}));
+
+		it('should get the number of keys for a range in a column family', () => dbRunner({
+			dbOptions: [ { name: 'foo' } ]
+		}, async ({ db }) => {
+			let count = db.getKeysCount();
+			expect(count).toBe(0);
+
+			for (const key of ['a', 'b', 'c', 'd', 'e']) {
+				await db.put(key, `value ${key}`);
+			}
+
+			count = db.getKeysCount();
+			expect(count).toBe(5);
+
+			count = db.getKeysCount({ start: 'b' });
+			expect(count).toBe(4);
+
+			count = db.getKeysCount({ start: 'b', exclusiveStart: true });
+			expect(count).toBe(3);
+
+			count = db.getKeysCount({ end: 'c' });
+			expect(count).toBe(2);
+
+			count = db.getKeysCount({ end: 'c', inclusiveEnd: true });
+			expect(count).toBe(3);
+
+			count = db.getKeysCount({ start: 'b', end: 'd' });
+			expect(count).toBe(2);
+
+			count = db.getKeysCount({ start: 'b', end: 'd', inclusiveEnd: true });
+			expect(count).toBe(3);
+
+			count = db.getKeysCount({ start: 'b', end: 'd', exclusiveStart: true });
+			expect(count).toBe(1);
+
+			count = db.getKeysCount({ start: 'b', end: 'd', inclusiveEnd: true, exclusiveStart: true });
+			expect(count).toBe(2);
+		}));
+
+		it('should get the number of keys for a range in a transaction', () => dbRunner(async ({ db }) => {
+			for (const key of ['a', 'b', 'c', 'd', 'e']) {
+				await db.put(key, `value ${key}`);
+			}
+
+			await db.transaction(async txn => {
+				let count = txn.getKeysCount();
+				expect(count).toBe(5);
+
+				count = db.getKeysCount({ start: 'b' });
+				expect(count).toBe(4);
+
+				count = db.getKeysCount({ start: 'b', exclusiveStart: true });
+				expect(count).toBe(3);
+
+				count = db.getKeysCount({ end: 'c' });
+				expect(count).toBe(2);
+
+				count = db.getKeysCount({ end: 'c', inclusiveEnd: true });
+				expect(count).toBe(3);
+
+				count = db.getKeysCount({ start: 'b', end: 'd' });
+				expect(count).toBe(2);
+
+				count = db.getKeysCount({ start: 'b', end: 'd', inclusiveEnd: true });
+				expect(count).toBe(3);
+
+				count = db.getKeysCount({ start: 'b', end: 'd', exclusiveStart: true });
+				expect(count).toBe(1);
+
+				count = db.getKeysCount({ start: 'b', end: 'd', inclusiveEnd: true, exclusiveStart: true });
+				expect(count).toBe(2);
+			});
+		}));
+
+		it('should get the number of keys for a range in a transaction and column family', () => dbRunner({
+			dbOptions: [ { name: 'foo' } ]
+		}, async ({ db }) => {
+			for (const key of ['a', 'b', 'c', 'd', 'e']) {
+				await db.put(key, `value ${key}`);
+			}
+
+			await db.transaction(async txn => {
+				let count = txn.getKeysCount();
+				expect(count).toBe(5);
+
+				count = db.getKeysCount({ start: 'b' });
+				expect(count).toBe(4);
+
+				count = db.getKeysCount({ start: 'b', exclusiveStart: true });
+				expect(count).toBe(3);
+
+				count = db.getKeysCount({ end: 'c' });
+				expect(count).toBe(2);
+
+				count = db.getKeysCount({ end: 'c', inclusiveEnd: true });
+				expect(count).toBe(3);
+
+				count = db.getKeysCount({ start: 'b', end: 'd' });
+				expect(count).toBe(2);
+
+				count = db.getKeysCount({ start: 'b', end: 'd', inclusiveEnd: true });
+				expect(count).toBe(3);
+
+				count = db.getKeysCount({ start: 'b', end: 'd', exclusiveStart: true });
+				expect(count).toBe(1);
+
+				count = db.getKeysCount({ start: 'b', end: 'd', inclusiveEnd: true, exclusiveStart: true });
+				expect(count).toBe(2);
+			});
+		}));
+
+		it('should error if database is not open', () => dbRunner({
+			skipOpen: true
+		}, async ({ db }) => {
+			expect(() => db.getKeysCount()).toThrow('Database not open');
+		}));
 	});
 
 	describe('asArray', () => {
-		it('should return a iterable as an array', async () => {
-			await initTestDB(async db => {
-				for (const key of ['a', 'b', 'c', 'd', 'e']) {
-					await db.put(key, `value ${key}`);
-				}
+		it('should return a iterable as an array', () => dbRunner(async ({ db }) => {
+			for (const key of ['a', 'b', 'c', 'd', 'e']) {
+				await db.put(key, `value ${key}`);
+			}
 
-				const iter = db.getRange();
-				const array = iter.asArray;
-				expect(Array.isArray(array)).toBe(true);
+			const iter = db.getRange();
+			const array = iter.asArray;
+			expect(Array.isArray(array)).toBe(true);
 
-				expect(array).toMatchObject([
-					{ key: 'a', value: 'value a' },
-					{ key: 'b', value: 'value b' },
-					{ key: 'c', value: 'value c' },
-					{ key: 'd', value: 'value d' },
-					{ key: 'e', value: 'value e' },
-				]);
-			});
-		});
+			expect(array).toMatchObject([
+				{ key: 'a', value: 'value a' },
+				{ key: 'b', value: 'value b' },
+				{ key: 'c', value: 'value c' },
+				{ key: 'd', value: 'value d' },
+				{ key: 'e', value: 'value e' },
+			]);
+		}));
 	});
 
 	/*
 	describe('at()', () => {
-		it('should return an item at a specific index of an iterable', async () => {
-			await initTestDB(async db => {
-				for (const key of ['a', 'b', 'c', 'd', 'e']) {
-					await db.put(key, `value ${key}`);
-				}
+		it('should return an item at a specific index of an iterable', () => dbRunner(async ({ db }) => {
+			for (const key of ['a', 'b', 'c', 'd', 'e']) {
+				await db.put(key, `value ${key}`);
+			}
 
-				const iter = db.getRange();
-				expect(iter.at(2)).toEqual({ key: 'c', value: 'value c' });
-			});
-		});
+			const iter = db.getRange();
+			expect(iter.at(2)).toEqual({ key: 'c', value: 'value c' });
+		}));
 	});
 	*/
 
 	describe('concat()', () => {
-		it('should concat two ranges', async () => {
-			await initTestDB(async db => {
-				for (const key of ['a', 'b', 'c', 'd']) {
-					await db.put(key, `value ${key}`);
-				}
+		it('should concat two ranges', () => dbRunner(async ({ db }) => {
+			for (const key of ['a', 'b', 'c', 'd']) {
+				await db.put(key, `value ${key}`);
+			}
 
-				const iter = db.getRange({ start: 'a', end: 'c' });
-				const iter2 = db.getRange({ start: 'c', end: 'e' });
-				// @ts-expect-error ExtendedIterable v1 concat() type definition is missing
-				const concat = iter.concat(iter2);
-				expect(Array.from(concat)).toEqual([
-					{ key: 'a', value: 'value a' },
-					{ key: 'b', value: 'value b' },
-					{ key: 'c', value: 'value c' },
-					{ key: 'd', value: 'value d' },
-				]);
-			});
-		});
-
+			const iter = db.getRange({ start: 'a', end: 'c' });
+			const iter2 = db.getRange({ start: 'c', end: 'e' });
+			// @ts-expect-error ExtendedIterable v1 concat() type definition is missing
+			const concat = iter.concat(iter2);
+			expect(Array.from(concat)).toEqual([
+				{ key: 'a', value: 'value a' },
+				{ key: 'b', value: 'value b' },
+				{ key: 'c', value: 'value c' },
+				{ key: 'd', value: 'value d' },
+			]);
+		}));
 	});
 
 	/*
 	describe('drop()', () => {
-		it('should drop items from a range', async () => {
-			await initTestDB(async db => {
-				for (const key of ['a', 'b', 'c', 'd']) {
-					await db.put(key, `value ${key}`);
-				}
+		it('should drop items from a range', () => dbRunner(async ({ db }) => {
+			for (const key of ['a', 'b', 'c', 'd']) {
+				await db.put(key, `value ${key}`);
+			}
 
-				const iter = db.getRange();
-				const dropped = iter.drop(2);
-				expect(Array.from(dropped)).toEqual([{ key: 'c', value: 'value c' }, { key: 'd', value: 'value d' }]);
-			});
-		});
+			const iter = db.getRange();
+			const dropped = iter.drop(2);
+			expect(Array.from(dropped)).toEqual([{ key: 'c', value: 'value c' }, { key: 'd', value: 'value d' }]);
+		}));
 	});
 	*/
 
 	/*
 	describe('every()', () => {
-		it('should return true if every item of an iterable passes a test', async () => {
-			await initTestDB(async db => {
-				for (const key of ['a', 'b', 'c', 'd']) {
-					await db.put(key, `value ${key}`);
-				}
+		it('should return true if every item of an iterable passes a test', () => dbRunner(async ({ db }) => {
+			for (const key of ['a', 'b', 'c', 'd']) {
+				await db.put(key, `value ${key}`);
+			}
 
-				const iter = db.getRange();
-				const every = iter.every(item => (item.value as string).startsWith('value'));
-				expect(every).toBe(true);
-			});
-		});
+			const iter = db.getRange();
+			const every = iter.every(item => (item.value as string).startsWith('value'));
+			expect(every).toBe(true);
+		}));
 
-		it('should return false if any item of an iterable fails a test', async () => {
-			await initTestDB(async db => {
-				for (const key of ['a', 'b', 'c', 'd']) {
-					await db.put(key, `value ${key}`);
-				}
+		it('should return false if any item of an iterable fails a test', () => dbRunner(async ({ db }) => {
+			for (const key of ['a', 'b', 'c', 'd']) {
+				await db.put(key, `value ${key}`);
+			}
 
-				const iter = db.getRange();
-				const every = iter.every(item => (item.value as string).endsWith('a'));
-				expect(every).toBe(false);
-			});
-		});
+			const iter = db.getRange();
+			const every = iter.every(item => (item.value as string).endsWith('a'));
+			expect(every).toBe(false);
+		}));
 	});
 	*/
 
 	describe('filter()', () => {
-		it('should filter items of an iterable', async () => {
-			await initTestDB(async db => {
-				let i = 0;
-				for (const key of ['a', 'b', 'c', 'd']) {
-					await db.put(key, i++);
-				}
+		it('should filter items of an iterable', () => dbRunner(async ({ db }) => {
+			let i = 0;
+			for (const key of ['a', 'b', 'c', 'd']) {
+				await db.put(key, i++);
+			}
 
-				const iter = db.getRange();
-				const filtered = iter.filter(item => ((item.value as number) % 2 === 0));
-				expect(Array.from(filtered)).toEqual([
-					{ key: 'a', value: 0 },
-					{ key: 'c', value: 2 }
-				]);
-			});
-		});
+			const iter = db.getRange();
+			const filtered = iter.filter(item => ((item.value as number) % 2 === 0));
+			expect(Array.from(filtered)).toEqual([
+				{ key: 'a', value: 0 },
+				{ key: 'c', value: 2 }
+			]);
+		}));
 	});
 
 	/*
 	describe('find()', () => {
-		it('should find the first item of an iterable', async () => {
-			await initTestDB(async db => {
-				for (const key of ['a', 'b', 'c', 'd']) {
-					await db.put(key, `value ${key}`);
-				}
+		it('should find the first item of an iterable', () => dbRunner(async ({ db }) => {
+			for (const key of ['a', 'b', 'c', 'd']) {
+				await db.put(key, `value ${key}`);
+			}
 
-				const iter = db.getRange();
-				const found = iter.find(item => item.value === 'value c');
-				expect(found).toEqual({ key: 'c', value: 'value c' });
-			});
-		});
+			const iter = db.getRange();
+			const found = iter.find(item => item.value === 'value c');
+			expect(found).toEqual({ key: 'c', value: 'value c' });
+		}));
 	});
 	*/
 
 	describe('flatMap()', () => {
-		it('should flatten a range', async () => {
-			await initTestDB(async db => {
-				for (const key of ['a', 'b', 'c']) {
-					await db.put(key, `value ${key}`);
-				}
+		it('should flatten a range', () => dbRunner(async ({ db }) => {
+			for (const key of ['a', 'b', 'c']) {
+				await db.put(key, `value ${key}`);
+			}
 
-				const iter = db.getRange();
-				const flattened = iter.flatMap(item => [item.value, item.value]);
-				expect(Array.from(flattened)).toEqual([
-					'value a', 'value a', 'value b', 'value b', 'value c', 'value c'
-				]);
-			});
-		});
+			const iter = db.getRange();
+			const flattened = iter.flatMap(item => [item.value, item.value]);
+			expect(Array.from(flattened)).toEqual([
+				'value a', 'value a', 'value b', 'value b', 'value c', 'value c'
+			]);
+		}));
 	});
 
 	describe('forEach()', () => {
-		it('should call a function for each item of an iterable', async () => {
-			await initTestDB(async db => {
-				for (const key of ['a', 'b', 'c', 'd', 'e']) {
-					await db.put(key, `value ${key}`);
-				}
+		it('should call a function for each item of an iterable', () => dbRunner(async ({ db }) => {
+			for (const key of ['a', 'b', 'c', 'd', 'e']) {
+				await db.put(key, `value ${key}`);
+			}
 
-				const iter = db.getRange();
-				const values: string[] = [];
-				iter.forEach(item => values.push(item.value as string));
-				expect(values).toEqual(['value a', 'value b', 'value c', 'value d', 'value e']);
-			});
-		});
+			const iter = db.getRange();
+			const values: string[] = [];
+			iter.forEach(item => values.push(item.value as string));
+			expect(values).toEqual(['value a', 'value b', 'value c', 'value d', 'value e']);
+		}));
 	});
 
 	describe('map()', () => {
-		it('should map each item of an iterable', async () => {
-			await initTestDB(async db => {
-				for (const key of ['a', 'b', 'c', 'd', 'e']) {
-					await db.put(key, `value ${key}`);
-				}
+		it('should map each item of an iterable', () => dbRunner(async ({ db }) => {
+			for (const key of ['a', 'b', 'c', 'd', 'e']) {
+				await db.put(key, `value ${key}`);
+			}
 
-				const iter = db.getRange();
-				const mapped = iter.map(item => {
+			const iter = db.getRange();
+			const mapped = iter.map(item => {
+				return {
+					...item,
+					value: `${item.value}!`
+				};
+			});
+
+			expect(Array.from(mapped)).toEqual([
+				{ key: 'a', value: 'value a!' },
+				{ key: 'b', value: 'value b!' },
+				{ key: 'c', value: 'value c!' },
+				{ key: 'd', value: 'value d!' },
+				{ key: 'e', value: 'value e!' },
+			]);
+		}));
+	});
+
+	describe('mapError()', () => {
+		it('should catch errors thrown iterating over a range', () => dbRunner(async ({ db }) => {
+			for (const key of ['a', 'b', 'c', 'd', 'e']) {
+				await db.put(key, `value ${key}`);
+			}
+
+			const iter = db.getRange();
+			const mapped = iter
+				.map(item => {
+					if (item.value === 'value c') {
+						throw new Error('found c');
+					}
 					return {
 						...item,
 						value: `${item.value}!`
 					};
+				})
+				.mapError(error => {
+					return new Error(`Error: ${(error as Error).message}`);
 				});
 
-				expect(Array.from(mapped)).toEqual([
-					{ key: 'a', value: 'value a!' },
-					{ key: 'b', value: 'value b!' },
-					{ key: 'c', value: 'value c!' },
-					{ key: 'd', value: 'value d!' },
-					{ key: 'e', value: 'value e!' },
-				]);
-			});
-		});
-	});
-
-	describe('mapError()', () => {
-		it('should catch errors thrown iterating over a range', async () => {
-			await initTestDB(async db => {
-				for (const key of ['a', 'b', 'c', 'd', 'e']) {
-					await db.put(key, `value ${key}`);
-				}
-
-				const iter = db.getRange();
-				const mapped = iter
-					.map(item => {
-						if (item.value === 'value c') {
-							throw new Error('found c');
-						}
-						return {
-							...item,
-							value: `${item.value}!`
-						};
-					})
-					.mapError(error => {
-						return new Error(`Error: ${(error as Error).message}`);
-					});
-
-				expect(Array.from(mapped)).toEqual([
-					{ key: 'a', value: 'value a!' },
-					{ key: 'b', value: 'value b!' },
-					new Error('Error: found c'),
-					{ key: 'd', value: 'value d!' },
-					{ key: 'e', value: 'value e!' },
-				]);
-			});
-		});
+			expect(Array.from(mapped)).toEqual([
+				{ key: 'a', value: 'value a!' },
+				{ key: 'b', value: 'value b!' },
+				new Error('Error: found c'),
+				{ key: 'd', value: 'value d!' },
+				{ key: 'e', value: 'value e!' },
+			]);
+		}));
 	});
 
 	/*
 	describe('reduce()', () => {
-		it('should reduce a range', async () => {
-			await initTestDB(async db => {
-				for (const key of ['a', 'b', 'c', 'd', 'e']) {
-					await db.put(key, `value ${key}`);
-				}
+		it('should reduce a range', () => dbRunner(async ({ db }) => {
+			for (const key of ['a', 'b', 'c', 'd', 'e']) {
+				await db.put(key, `value ${key}`);
+			}
 
-				const iter = db.getRange();
-				const reduced = iter.reduce((acc, item) => acc + (item.value as string).length, 0);
-				expect(reduced).toEqual(7 * 5);
-			});
-		});
+			const iter = db.getRange();
+			const reduced = iter.reduce((acc, item) => acc + (item.value as string).length, 0);
+			expect(reduced).toEqual(7 * 5);
+		}));
 	});
 	*/
 
 	describe('slice()', () => {
-		it('should slice a range', async () => {
-			await initTestDB(async db => {
-				for (const key of ['a', 'b', 'c', 'd', 'e']) {
-					await db.put(key, `value ${key}`);
-				}
+		it('should slice a range', () => dbRunner(async ({ db }) => {
+			for (const key of ['a', 'b', 'c', 'd', 'e']) {
+				await db.put(key, `value ${key}`);
+			}
 
-				const iter = db.getRange();
-				const sliced = iter.slice(1, 3);
-				expect(Array.from(sliced)).toEqual([{ key: 'b', value: 'value b' }, { key: 'c', value: 'value c' }]);
-			});
-		});
+			const iter = db.getRange();
+			const sliced = iter.slice(1, 3);
+			expect(Array.from(sliced)).toEqual([{ key: 'b', value: 'value b' }, { key: 'c', value: 'value c' }]);
+		}));
 	});
 
 	/*
 	describe('some()', () => {
-		it('should check if some items in a range pass a test', async () => {
-			await initTestDB(async db => {
-				for (const key of ['a', 'b', 'c', 'd', 'e']) {
-					await db.put(key, `value ${key}`);
-				}
+		it('should check if some items in a range pass a test', () => dbRunner(async ({ db }) => {
+			for (const key of ['a', 'b', 'c', 'd', 'e']) {
+				await db.put(key, `value ${key}`);
+			}
 
-				const iter = db.getRange();
-				expect(iter.some(item => (item.value === 'value c'))).toBe(true);
+			const iter = db.getRange();
+			expect(iter.some(item => (item.value === 'value c'))).toBe(true);
 
-				const iter2 = db.getRange();
-				expect(iter2.some(item => (item.value === 'value f'))).toBe(false);
-			});
-		});
+			const iter2 = db.getRange();
+			expect(iter2.some(item => (item.value === 'value f'))).toBe(false);
+		}));
 	});
 	*/
 
 	/*
 	describe('take()', () => {
-		it('should take items from a range', async () => {
-			await initTestDB(async db => {
-				for (const key of ['a', 'b', 'c', 'd', 'e']) {
-					await db.put(key, `value ${key}`);
-				}
+		it('should take items from a range', () => dbRunner(async ({ db }) => {
+			for (const key of ['a', 'b', 'c', 'd', 'e']) {
+				await db.put(key, `value ${key}`);
+			}
 
-				const iter = db.getRange();
-				const taken = iter.take(2);
-				expect(Array.from(taken)).toEqual([{ key: 'a', value: 'value a' }, { key: 'b', value: 'value b' }]);
-			});
-		});
+			const iter = db.getRange();
+			const taken = iter.take(2);
+			expect(Array.from(taken)).toEqual([{ key: 'a', value: 'value a' }, { key: 'b', value: 'value b' }]);
+		}));
 	});
 	*/
 
 	describe('chaining', () => {
-		it('should chain multiple methods', async () => {
-			await initTestDB(async db => {
-				for (const key of ['a', 'b', 'c', 'd', 'e']) {
-					await db.put(key, `value ${key}`);
-				}
+		it('should chain multiple methods', () => dbRunner(async ({ db }) => {
+			for (const key of ['a', 'b', 'c', 'd', 'e']) {
+				await db.put(key, `value ${key}`);
+			}
 
-				const iter = db.getRange();
-				const results = iter
-					.map((item, index) => {
-						return {
-							...item,
-							value: `${item.value}${index % 2 === 0 ? '!' : ''}`
-						};
-					})
-					.filter(item => item.value.endsWith('!'));
+			const iter = db.getRange();
+			const results = iter
+				.map((item, index) => {
+					return {
+						...item,
+						value: `${item.value}${index % 2 === 0 ? '!' : ''}`
+					};
+				})
+				.filter(item => item.value.endsWith('!'));
 
-				expect(Array.from(results)).toEqual([
-					{ key: 'a', value: 'value a!' },
-					{ key: 'c', value: 'value c!' },
-					{ key: 'e', value: 'value e!' },
-				]);
-			});
-		});
+			expect(Array.from(results)).toEqual([
+				{ key: 'a', value: 'value a!' },
+				{ key: 'c', value: 'value c!' },
+				{ key: 'e', value: 'value e!' },
+			]);
+		}));
 
-		it('should map error', async () => {
-			await initTestDB(async db => {
-				for (const key of ['a', 'b', 'c', 'd', 'e']) {
-					await db.put(key, `value ${key}`);
-				}
+		it('should map error', () => dbRunner(async ({ db }) => {
+			for (const key of ['a', 'b', 'c', 'd', 'e']) {
+				await db.put(key, `value ${key}`);
+			}
 
-				const iter = db.getRange();
-				const results = iter
-					.map((item, index) => {
-						if (index === 1) {
-							throw new Error('test');
-						}
-						return {
-							...item,
-							value: `${item.value}${index % 2 === 0 ? '!' : ''}`
-						};
-					})
-					.mapError(error => error);
+			const iter = db.getRange();
+			const results = iter
+				.map((item, index) => {
+					if (index === 1) {
+						throw new Error('test');
+					}
+					return {
+						...item,
+						value: `${item.value}${index % 2 === 0 ? '!' : ''}`
+					};
+				})
+				.mapError(error => error);
 
-				const arr = Array.from(results);
-				expect(arr.length).toEqual(5);
-				expect(arr[0]).toEqual({ key: 'a', value: 'value a!' });
-				expect(arr[1]).toBeInstanceOf(Error);
-				expect((arr[1] as Error).message).toEqual('test');
-				expect(arr[2]).toEqual({ key: 'c', value: 'value c!' });
-				expect(arr[3]).toEqual({ key: 'd', value: 'value d' });
-				expect(arr[4]).toEqual({ key: 'e', value: 'value e!' });
-			});
-		});
+			const arr = Array.from(results);
+			expect(arr.length).toEqual(5);
+			expect(arr[0]).toEqual({ key: 'a', value: 'value a!' });
+			expect(arr[1]).toBeInstanceOf(Error);
+			expect((arr[1] as Error).message).toEqual('test');
+			expect(arr[2]).toEqual({ key: 'c', value: 'value c!' });
+			expect(arr[3]).toEqual({ key: 'd', value: 'value d' });
+			expect(arr[4]).toEqual({ key: 'e', value: 'value e!' });
+		}));
 
-		it('should close iterator if throwing before iterator is done', async () => {
-			await initTestDB(async db => {
-				for (const key of ['a', 'b', 'c', 'd', 'e']) {
-					await db.put(key, `value ${key}`);
-				}
+		it('should close iterator if throwing before iterator is done', () => dbRunner(async ({ db }) => {
+			for (const key of ['a', 'b', 'c', 'd', 'e']) {
+				await db.put(key, `value ${key}`);
+			}
 
-				const iter = db.getRange();
-				const results = iter
-					.map((item, index) => {
-						if (index === 1) {
-							throw new Error('test');
-						}
-						return item;
-					});
+			const iter = db.getRange();
+			const results = iter
+				.map((item, index) => {
+					if (index === 1) {
+						throw new Error('test');
+					}
+					return item;
+				});
 
-				const iterator = results[Symbol.iterator]();
-				expect(iterator.next()).toEqual({ value: { key: 'a', value: 'value a' } });
-				expect(() => iterator.next()).toThrow('test');
-			});
-		});
+			const iterator = results[Symbol.iterator]();
+			expect(iterator.next()).toEqual({ value: { key: 'a', value: 'value a' } });
+			expect(() => iterator.next()).toThrow('test');
+		}));
 
-		it('should close iterator if returning before iterator is done', async () => {
-			await initTestDB(async db => {
-				for (const key of ['a', 'b', 'c', 'd', 'e']) {
-					await db.put(key, `value ${key}`);
-				}
+		it('should close iterator if returning before iterator is done', () => dbRunner(async ({ db }) => {
+			for (const key of ['a', 'b', 'c', 'd', 'e']) {
+				await db.put(key, `value ${key}`);
+			}
 
-				const iter = db.getRange();
-				const results = iter
-					.map(item => {
-						return {
-							...item,
-							value: `${item.value}!`
-						};
-					})
-					.mapError(error => error);
+			const iter = db.getRange();
+			const results = iter
+				.map(item => {
+					return {
+						...item,
+						value: `${item.value}!`
+					};
+				})
+				.mapError(error => error);
 
-				const iterator = results[Symbol.iterator]();
-				expect(iterator.return?.()).toEqual({ done: true, value: undefined });
-				expect(() => iterator.next()).toThrow('Next failed: Iterator not initialized');
-			});
-		});
+			const iterator = results[Symbol.iterator]();
+			expect(iterator.return?.()).toEqual({ done: true, value: undefined });
+			expect(() => iterator.next()).toThrow('Next failed: Iterator not initialized');
+		}));
 
-		it('should get range with shared structures key', async () => {
-			await initTestDB(async db => {
-				db.putSync(Symbol.for('test'), 2);
+		it('should get range with shared structures key', () => dbRunner({
+			dbOptions: [ { sharedStructuresKey: Symbol.for('structures') } ],
+		}, async ({ db }) => {
+			db.putSync(Symbol.for('test'), 2);
 
-				const data = {
-					bar: 'baz'
-				};
+			const data = {
+				bar: 'baz'
+			};
 
-				db.putSync('foo', data);
+			db.putSync('foo', data);
 
-				const iterable = db.getRange({ start: true });
-				const results = iterable.asArray;
-				expect(results).toHaveLength(1);
-				expect(results[0].key).toEqual('foo');
-				expect(results[0].value).toEqual(data);
-			}, {
-				sharedStructuresKey: Symbol.for('structures'),
-			});
-		});
+			const iterable = db.getRange({ start: true });
+			const results = iterable.asArray;
+			expect(results).toHaveLength(1);
+			expect(results[0].key).toEqual('foo');
+			expect(results[0].value).toEqual(data);
+		}));
 	});
 });

--- a/test/read.test.ts
+++ b/test/read.test.ts
@@ -1,278 +1,126 @@
+// note: msgpackr/pack.d.ts is missing these const exports
+declare module 'msgpackr/pack' {
+  export const REUSE_BUFFER_MODE: number;
+  export const RESET_BUFFER_MODE: number;
+}
+
 import { describe, expect, it } from 'vitest';
-import { rimraf } from 'rimraf';
-import { RocksDatabase } from '../src/index.js';
-import { generateDBPath } from './lib/util.js';
-import { Encoder, RESET_BUFFER_MODE, REUSE_BUFFER_MODE } from 'msgpackr';
+import { dbRunner } from './lib/util.js';
+import { Encoder } from 'msgpackr';
+import { RESET_BUFFER_MODE, REUSE_BUFFER_MODE } from 'msgpackr/pack';
+import type { BufferWithDataView } from '../src/encoding.js';
 
 describe('Read Operations', () => {
 	describe('get()', () => {
-		it('should error if database is not open', async () => {
-			const dbPath = generateDBPath();
-			let db: RocksDatabase | null = null;
+		it('should error if database is not open', () => dbRunner({
+			skipOpen: true
+		}, async ({ db }) => {
+			await expect(db.get('foo')).rejects.toThrow('Database not open');
+		}));
 
-			try {
-				db = new RocksDatabase(dbPath);
-				await expect(db.get('foo')).rejects.toThrow('Database not open');
-			} finally {
-				db?.close();
-				await rimraf(dbPath);
-			}
-		});
+		it('should return undefined if key does not exist', () => dbRunner(async ({ db }) => {
+			const value = await db.get('baz');
+			expect(value).toBeUndefined();
+		}));
 
-		it('should return undefined if key does not exist', async () => {
-			const dbPath = generateDBPath();
-			let db: RocksDatabase | null = null;
+		it('should throw an error if key is not specified', () => dbRunner(async ({ db }) => {
+			await expect((db.get as any)()).rejects.toThrow('Key is required');
+		}));
 
-			try {
-				db = RocksDatabase.open(dbPath);
-				const value = await db.get('baz');
-				expect(value).toBeUndefined();
-			} finally {
-				db?.close();
-				await rimraf(dbPath);
-			}
-		});
+		it('should return the undecoded value if decode is false', () => dbRunner(async ({ db }) => {
+			await db.put('foo', 'bar');
+			const value = await db.get('foo', { skipDecode: true });
+			expect(value).not.toBe('bar');
 
-		it('should throw an error if key is not specified', async () => {
-			const dbPath = generateDBPath();
-			let db: RocksDatabase | null = null;
-
-			try {
-				db = RocksDatabase.open(dbPath);
-				await expect((db.get as any)()).rejects.toThrow('Key is required');
-			} finally {
-				db?.close();
-				await rimraf(dbPath);
-			}
-		});
-
-		it('should return the undecoded value if decode is false', async () => {
-			const dbPath = generateDBPath();
-			let db: RocksDatabase | null = null;
-
-			try {
-				db = RocksDatabase.open(dbPath);
-				await db.put('foo', 'bar');
-				const value = await db.get('foo', { skipDecode: true });
-				expect(value).not.toBe('bar');
-
-				const encoder = new Encoder({ copyBuffers: true });
-				const expected = encoder.encode('bar', REUSE_BUFFER_MODE | RESET_BUFFER_MODE);
-				expect(value.equals(expected)).toBe(true);
-			} finally {
-				db?.close();
-				await rimraf(dbPath);
-			}
-		});
+			const encoder = new Encoder({ copyBuffers: true });
+			const encoded = encoder.encode('bar', REUSE_BUFFER_MODE | RESET_BUFFER_MODE) as unknown as BufferWithDataView;
+			const expected = encoded.subarray(encoded.start, encoded.end);
+			expect(value.equals(expected)).toBe(true);
+		}));
 	});
 
 	describe('getSync()', () => {
-		it('should error if database is not open', async () => {
-			const dbPath = generateDBPath();
-			let db: RocksDatabase | null = null;
+		it('should error if database is not open', () => dbRunner({
+			skipOpen: true
+		}, async ({ db }) => {
+			expect(() => db.getSync('foo')).toThrow('Database not open');
+		}));
 
-			try {
-				db = new RocksDatabase(dbPath);
-				expect(() => db!.getSync('foo')).toThrow('Database not open');
-			} finally {
-				db?.close();
-				await rimraf(dbPath);
-			}
-		});
+		it('should return undefined if key does not exist', () => dbRunner(async ({ db }) => {
+			const value = db.getSync('baz');
+			expect(value).toBeUndefined();
+		}));
 
-		it('should return undefined if key does not exist', async () => {
-			const dbPath = generateDBPath();
-			let db: RocksDatabase | null = null;
-
-			try {
-				db = RocksDatabase.open(dbPath);
-				const value = db.getSync('baz');
-				expect(value).toBeUndefined();
-			} finally {
-				db?.close();
-				await rimraf(dbPath);
-			}
-		});
-
-		it('should throw an error if key is not specified', async () => {
-			const dbPath = generateDBPath();
-			let db: RocksDatabase | null = null;
-
-			try {
-				db = RocksDatabase.open(dbPath);
-				expect(() => (db!.getSync as any)()).toThrow('Key is required');
-			} finally {
-				db?.close();
-				await rimraf(dbPath);
-			}
-		});
+		it('should throw an error if key is not specified', () => dbRunner(async ({ db }) => {
+			expect(() => (db.getSync as any)()).toThrow('Key is required');
+		}));
 	});
 
 	describe('getBinary()', () => {
-		it('should error if database is not open', async () => {
-			const dbPath = generateDBPath();
-			let db: RocksDatabase | null = null;
+		it('should error if database is not open', () => dbRunner({
+			skipOpen: true
+		}, async ({ db }) => {
+			await expect(db.getBinary('foo')).rejects.toThrow('Database not open');
+		}));
 
-			try {
-				db = new RocksDatabase(dbPath);
-				await expect(db!.getBinary('foo')).rejects.toThrow('Database not open');
-			} finally {
-				db?.close();
-				await rimraf(dbPath);
-			}
-		});
+		it('should return undefined if key does not exist', () => dbRunner(async ({ db }) => {
+			const value = await db.getBinary('baz');
+			expect(value).toBeUndefined();
+		}));
 
-		it('should return undefined if key does not exist', async () => {
-			const dbPath = generateDBPath();
-			let db: RocksDatabase | null = null;
-
-			try {
-				db = RocksDatabase.open(dbPath);
-				const value = await db.getBinary('baz');
-				expect(value).toBeUndefined();
-			} finally {
-				db?.close();
-				await rimraf(dbPath);
-			}
-		});
-
-		it('should throw an error if key is not specified', async () => {
-			const dbPath = generateDBPath();
-			let db: RocksDatabase | null = null;
-
-			try {
-				db = RocksDatabase.open(dbPath);
-				expect(() => (db!.getBinary as any)()).toThrow('Key is required');
-			} finally {
-				db?.close();
-				await rimraf(dbPath);
-			}
-		});
+		it('should throw an error if key is not specified', () => dbRunner(async ({ db }) => {
+			expect(() => (db.getBinary as any)()).toThrow('Key is required');
+		}));
 	});
 
 	describe('getBinarySync()', () => {
-		it('should error if database is not open', async () => {
-			const dbPath = generateDBPath();
-			let db: RocksDatabase | null = null;
+		it('should error if database is not open', () => dbRunner({
+			skipOpen: true
+		}, async ({ db }) => {
+			expect(() => db.getBinarySync('foo')).toThrow('Database not open');
+		}));
 
-			try {
-				db = new RocksDatabase(dbPath);
-				expect(() => db!.getBinarySync('foo')).toThrow('Database not open');
-			} finally {
-				db?.close();
-				await rimraf(dbPath);
-			}
-		});
+		it('should return undefined if key does not exist', () => dbRunner(async ({ db }) => {
+			const value = db.getBinarySync('baz');
+			expect(value).toBeUndefined();
+		}));
 
-		it('should return undefined if key does not exist', async () => {
-			const dbPath = generateDBPath();
-			let db: RocksDatabase | null = null;
-
-			try {
-				db = RocksDatabase.open(dbPath);
-				const value = db.getBinarySync('baz');
-				expect(value).toBeUndefined();
-			} finally {
-				db?.close();
-				await rimraf(dbPath);
-			}
-		});
-
-		it('should throw an error if key is not specified', async () => {
-			const dbPath = generateDBPath();
-			let db: RocksDatabase | null = null;
-
-			try {
-				db = RocksDatabase.open(dbPath);
-				expect(() => (db!.getBinarySync as any)()).toThrow('Key is required');
-			} finally {
-				db?.close();
-				await rimraf(dbPath);
-			}
-		});
+		it('should throw an error if key is not specified', () => dbRunner(async ({ db }) => {
+			expect(() => (db.getBinarySync as any)()).toThrow('Key is required');
+		}));
 	});
 
 	describe('getBinaryFast()', () => {
-		it('should error if database is not open', async () => {
-			const dbPath = generateDBPath();
-			let db: RocksDatabase | null = null;
+		it('should error if database is not open', () => dbRunner({
+			skipOpen: true
+		}, async ({ db }) => {
+			await expect(db.getBinaryFast('foo')).rejects.toThrow('Database not open');
+		}));
 
-			try {
-				db = new RocksDatabase(dbPath);
-				await expect(db!.getBinaryFast('foo')).rejects.toThrow('Database not open');
-			} finally {
-				db?.close();
-				await rimraf(dbPath);
-			}
-		});
+		it('should return undefined if key does not exist', () => dbRunner(async ({ db }) => {
+			const value = await db.getBinaryFast('baz');
+			expect(value).toBeUndefined();
+		}));
 
-		it('should return undefined if key does not exist', async () => {
-			const dbPath = generateDBPath();
-			let db: RocksDatabase | null = null;
-
-			try {
-				db = RocksDatabase.open(dbPath);
-				const value = await db.getBinaryFast('baz');
-				expect(value).toBeUndefined();
-			} finally {
-				db?.close();
-				await rimraf(dbPath);
-			}
-		});
-
-		it('should throw an error if key is not specified', async () => {
-			const dbPath = generateDBPath();
-			let db: RocksDatabase | null = null;
-
-			try {
-				db = RocksDatabase.open(dbPath);
-				expect(() => (db!.getBinaryFast as any)()).toThrow('Key is required');
-			} finally {
-				db?.close();
-				await rimraf(dbPath);
-			}
-		});
+		it('should throw an error if key is not specified', () => dbRunner(async ({ db }) => {
+			expect(() => (db.getBinaryFast as any)()).toThrow('Key is required');
+		}));
 	});
 
 	describe('getBinaryFastSync()', () => {
-		it('should error if database is not open', async () => {
-			const dbPath = generateDBPath();
-			let db: RocksDatabase | null = null;
+		it('should error if database is not open', () => dbRunner({
+			skipOpen: true
+		}, async ({ db }) => {
+			expect(() => db.getBinaryFastSync('foo')).toThrow('Database not open');
+		}));
 
-			try {
-				db = new RocksDatabase(dbPath);
-				expect(() => db!.getBinaryFastSync('foo')).toThrow('Database not open');
-			} finally {
-				db?.close();
-				await rimraf(dbPath);
-			}
-		});
+		it('should return undefined if key does not exist', () => dbRunner(async ({ db }) => {
+			const value = db.getBinaryFastSync('baz');
+			expect(value).toBeUndefined();
+		}));
 
-		it('should return undefined if key does not exist', async () => {
-			const dbPath = generateDBPath();
-			let db: RocksDatabase | null = null;
-
-			try {
-				db = RocksDatabase.open(dbPath);
-				const value = db.getBinaryFastSync('baz');
-				expect(value).toBeUndefined();
-			} finally {
-				db?.close();
-				await rimraf(dbPath);
-			}
-		});
-
-		it('should throw an error if key is not specified', async () => {
-			const dbPath = generateDBPath();
-			let db: RocksDatabase | null = null;
-
-			try {
-				db = RocksDatabase.open(dbPath);
-				expect(() => (db!.getBinaryFastSync as any)()).toThrow('Key is required');
-			} finally {
-				db?.close();
-				await rimraf(dbPath);
-			}
-		});
+		it('should throw an error if key is not specified', () => dbRunner(async ({ db }) => {
+			expect(() => (db.getBinaryFastSync as any)()).toThrow('Key is required');
+		}));
 	});
 });

--- a/test/snapshot.test.ts
+++ b/test/snapshot.test.ts
@@ -1,75 +1,48 @@
 import { describe, expect, it } from 'vitest';
-import { rimraf } from 'rimraf';
-import { RocksDatabase } from '../src/index.js';
-import { generateDBPath } from './lib/util.js';
+import { dbRunner } from './lib/util.js';
 import { setTimeout as delay } from 'node:timers/promises';
 
 describe('getOldestSnapshotTimestamp()', () => {
-	it('should get oldest snapshot timestamp in optimistic mode', async () => {
-		let db: RocksDatabase | null = null;
-		const dbPath = generateDBPath();
+	it('should get oldest snapshot timestamp in optimistic mode', () => dbRunner(async ({ db }) => {
+		expect(db.getOldestSnapshotTimestamp()).toBe(0);
 
-		try {
-			db = new RocksDatabase(dbPath).open();
-			expect(db.getOldestSnapshotTimestamp()).toBe(0);
-
-			await db.transaction(async (txn) => {
-				expect(db?.getOldestSnapshotTimestamp()).toBe(0);
-				await txn.put('foo', 'bar');
-				expect(db?.getOldestSnapshotTimestamp()).toBe(0);
-				await txn.get('foo');
-				expect(db?.getOldestSnapshotTimestamp()).toBeGreaterThan(0);
-			});
-
-			expect(db.getOldestSnapshotTimestamp()).toBe(0);
-		} finally {
-			db?.close();
-			await rimraf(dbPath);
-		}
-	});
-
-	it('should get oldest snapshot timestamp in optimistic mode', async () => {
-		let db: RocksDatabase | null = null;
-		const dbPath = generateDBPath();
-
-		try {
-			db = new RocksDatabase(dbPath).open();
-			expect(db.getOldestSnapshotTimestamp()).toBe(0);
-
-			const promise = db.transaction(async (txn) => {
-				await txn.get('foo');
-				await delay(100);
-			});
-
+		await db.transaction(async (txn) => {
+			expect(db?.getOldestSnapshotTimestamp()).toBe(0);
+			await txn.put('foo', 'bar');
+			expect(db?.getOldestSnapshotTimestamp()).toBe(0);
+			await txn.get('foo');
 			expect(db?.getOldestSnapshotTimestamp()).toBeGreaterThan(0);
-			await promise;
-			expect(db.getOldestSnapshotTimestamp()).toBe(0);
-		} finally {
-			db?.close();
-			await rimraf(dbPath);
-		}
-	});
+		});
 
-	it('should get oldest snapshot timestamp in pessimistic mode', async () => {
-		let db: RocksDatabase | null = null;
-		const dbPath = generateDBPath();
+		expect(db.getOldestSnapshotTimestamp()).toBe(0);
+	}));
 
-		try {
-			db = new RocksDatabase(dbPath, { pessimistic: true }).open();
-			expect(db.getOldestSnapshotTimestamp()).toBe(0);
+	it('should get oldest snapshot timestamp in optimistic mode', () => dbRunner(async ({ db }) => {
+		expect(db.getOldestSnapshotTimestamp()).toBe(0);
 
-			await db.transaction(async (txn) => {
-				expect(db?.getOldestSnapshotTimestamp()).toBe(0);
-				await txn.put('foo', 'bar');
-				expect(db?.getOldestSnapshotTimestamp()).toBeGreaterThan(0);
-				await txn.get('foo');
-				expect(db?.getOldestSnapshotTimestamp()).toBeGreaterThan(0);
-			});
+		const promise = db.transaction(async (txn) => {
+			await txn.get('foo');
+			await delay(100);
+		});
 
-			expect(db.getOldestSnapshotTimestamp()).toBe(0);
-		} finally {
-			db?.close();
-			await rimraf(dbPath);
-		}
-	});
+		expect(db?.getOldestSnapshotTimestamp()).toBeGreaterThan(0);
+		await promise;
+		expect(db.getOldestSnapshotTimestamp()).toBe(0);
+	}));
+
+	it('should get oldest snapshot timestamp in pessimistic mode', () => dbRunner({
+		dbOptions: [ { pessimistic: true } ],
+	}, async ({ db }) => {
+		expect(db.getOldestSnapshotTimestamp()).toBe(0);
+
+		await db.transaction(async (txn) => {
+			expect(db?.getOldestSnapshotTimestamp()).toBe(0);
+			await txn.put('foo', 'bar');
+			expect(db?.getOldestSnapshotTimestamp()).toBeGreaterThan(0);
+			await txn.get('foo');
+			expect(db?.getOldestSnapshotTimestamp()).toBeGreaterThan(0);
+		});
+
+		expect(db.getOldestSnapshotTimestamp()).toBe(0);
+	}));
 });

--- a/test/transactions.test.ts
+++ b/test/transactions.test.ts
@@ -1,9 +1,7 @@
-import { assert, describe, expect, it } from 'vitest';
-import { rimraf } from 'rimraf';
-import { RocksDatabase } from '../src/index.js';
-import { generateDBPath } from './lib/util.js';
-import type { Transaction } from '../src/transaction.js';
+import { describe, expect, it } from 'vitest';
+import { dbRunner, generateDBPath } from './lib/util.js';
 import { withResolvers } from '../src/util.js';
+import type { Transaction } from '../src/transaction.js';
 
 const testOptions = [
 	{
@@ -26,811 +24,527 @@ const testOptions = [
 
 for (const { name, options, txnOptions } of testOptions) {
 	describe(`transaction() (${name})`, () => {
-		it(`${name} async should error if callback is not a function`, async () => {
-			let db: RocksDatabase | null = null;
-			const dbPath = generateDBPath();
+		it(`${name} async should error if callback is not a function`, () => dbRunner({
+			dbOptions: [ options ]
+		}, async ({ db }) => {
+			await expect(db.transaction('foo' as any, txnOptions)).rejects.toThrow(
+				new TypeError('Callback must be a function')
+			);
+		}));
 
-			try {
-				db = RocksDatabase.open(dbPath, options);
-				await expect(db.transaction('foo' as any, txnOptions)).rejects.toThrow(
-					new TypeError('Callback must be a function')
-				);
-			} finally {
-				db?.close();
-				await rimraf(dbPath);
-			}
-		});
+		it(`${name} async should get a value`, () => dbRunner({
+			dbOptions: [ options ]
+		}, async ({ db }) => {
+			await db.put('foo', 'bar');
+			await db.transaction(async (txn: Transaction) => {
+				const value = await txn.get('foo');
+				expect(value).toBe('bar');
+			}, txnOptions);
+		}));
 
-		it(`${name} async should get a value`, async () => {
-			let db: RocksDatabase | null = null;
-			const dbPath = generateDBPath();
-
-			try {
-				db = RocksDatabase.open(dbPath, options);
-				await db.put('foo', 'bar');
-				await db.transaction(async (txn: Transaction) => {
-					const value = await txn.get('foo');
-					expect(value).toBe('bar');
-				}, txnOptions);
-			} finally {
-				db?.close();
-				await rimraf(dbPath);
-			}
-		});
-
-		it(`${name} async should set a value`, async () => {
-			let db: RocksDatabase | null = null;
-			const dbPath = generateDBPath();
+		it(`${name} async should set a value`, () => dbRunner({
+			dbOptions: [ options ]
+		}, async ({ db }) => {
 			const afterCommit = withResolvers();
 			const beforeCommit = withResolvers();
 			const beginTransaction = withResolvers();
 			const committed = withResolvers();
 
-			try {
-				db = RocksDatabase.open(dbPath, options)
-					.on('aftercommit', (result) => afterCommit.resolve(result))
-					.on('beforecommit', () => beforeCommit.resolve())
-					.on('begin-transaction', () => beginTransaction.resolve())
-					.on('committed', () => committed.resolve());
+			db.on('aftercommit', (result) => afterCommit.resolve(result));
+			db.on('beforecommit', () => beforeCommit.resolve());
+			db.on('begin-transaction', () => beginTransaction.resolve());
+			db.on('committed', () => committed.resolve());
 
-				await db.transaction(async (txn: Transaction) => {
-					await txn.put('foo', 'bar2');
-				}, txnOptions);
-				const value = await db.get('foo');
-				expect(value).toBe('bar2');
+			await db.transaction(async (txn: Transaction) => {
+				await txn.put('foo', 'bar2');
+			}, txnOptions);
+			const value = await db.get('foo');
+			expect(value).toBe('bar2');
 
-				await expect(Promise.all([
-					beginTransaction.promise,
-					beforeCommit.promise,
-					afterCommit.promise,
-					committed.promise,
-				])).resolves.toEqual([
-					undefined,
-					undefined,
-					{
-						next: null,
-						last: null,
-						txnId: expect.any(Number)
-					},
-					undefined,
-				]);
-			} finally {
-				db?.close();
-				await rimraf(dbPath);
-			}
-		});
+			await expect(Promise.all([
+				beginTransaction.promise,
+				beforeCommit.promise,
+				afterCommit.promise,
+				committed.promise,
+			])).resolves.toEqual([
+				undefined,
+				undefined,
+				{
+					next: null,
+					last: null,
+					txnId: expect.any(Number)
+				},
+				undefined,
+			]);
+		}));
 
-		it(`${name} async should remove a value`, async () => {
-			let db: RocksDatabase | null = null;
-			const dbPath = generateDBPath();
+		it(`${name} async should remove a value`, () => dbRunner({
+			dbOptions: [ options ]
+		}, async ({ db }) => {
+			await db.put('foo', 'bar');
 
-			try {
-				db = RocksDatabase.open(dbPath, options);
-				await db.put('foo', 'bar');
+			await db.transaction(async (txn: Transaction) => {
+				await txn.remove('foo');
+			});
 
-				await db.transaction(async (txn: Transaction) => {
-					await txn.remove('foo');
-				});
+			const value = await db.get('foo');
+			expect(value).toBeUndefined();
+		}));
 
-				const value = await db.get('foo');
-				expect(value).toBeUndefined();
-			} finally {
-				db?.close();
-				await rimraf(dbPath);
-			}
-		});
+		it(`${name} async should rollback on error`, () => dbRunner({
+			dbOptions: [ options ]
+		}, async ({ db }) => {
+			await db.put('foo', 'bar');
 
-		it(`${name} async should rollback on error`, async () => {
-			let db: RocksDatabase | null = null;
-			const dbPath = generateDBPath();
+			await expect(db.transaction(async (txn: Transaction) => {
+				await txn.put('foo', 'bar2');
+				throw new Error('test');
+			}, txnOptions)).rejects.toThrow('test');
 
-			try {
-				db = RocksDatabase.open(dbPath, options);
-				await db.put('foo', 'bar');
-
-				await expect(db.transaction(async (txn: Transaction) => {
-					await txn.put('foo', 'bar2');
-					throw new Error('test');
-				}, txnOptions)).rejects.toThrow('test');
-
-				const value = await db.get('foo');
-				expect(value).toBe('bar');
-			} finally {
-				db?.close();
-				await rimraf(dbPath);
-			}
-		});
+			const value = await db.get('foo');
+			expect(value).toBe('bar');
+		}));
 
 		if (txnOptions?.disableSnapshot) {
-			it(`${name} async should throw error if snapshot is disabled`, async () => {
-				let db: RocksDatabase | null = null;
-				const dbPath = generateDBPath();
+			it(`${name} async should throw error if snapshot is disabled`, () => dbRunner({
+				dbOptions: [ options ]
+			}, async ({ db }) => {
+				await db.put('foo', 'bar1');
+
+				setTimeout(() => db?.put('foo', 'bar2'));
 
 				try {
-					db = RocksDatabase.open(dbPath, options);
-					await db.put('foo', 'bar1');
+					await db.transaction(async (txn: Transaction) => {
+						const before = await txn.get('foo');
 
-					setTimeout(() => db?.put('foo', 'bar2'));
+						// let the first timeout set `bar2`
+						await new Promise((resolve) => setTimeout(resolve, 100));
 
-					try {
-						await db.transaction(async (txn: Transaction) => {
-							const before = await txn.get('foo');
+						// since there's no snapshot, the value should be the latest
+						const after = await txn.get('foo');
+						expect(before).not.toBe(after);
+						expect(after).toBe('bar2');
 
-							// let the first timeout set `bar2`
-							await new Promise((resolve) => setTimeout(resolve, 100));
-
-							// since there's no snapshot, the value should be the latest
-							const after = await txn.get('foo');
-							expect(before).not.toBe(after);
-							expect(after).toBe('bar2');
-
-							await txn.put('foo', 'bar3');
-						}, txnOptions);
-					} catch (error: unknown | Error & { code: string }) {
-						expect(error).toBeInstanceOf(Error);
-						if (error instanceof Error) {
-							expect(error.message).toBe(`Transaction ${
-								options?.pessimistic ? 'put' : 'commit'
-							} failed: Resource busy`);
-							if ('code' in error) {
-								expect(error.code).toBe('ERR_BUSY');
-							}
+						await txn.put('foo', 'bar3');
+					}, txnOptions);
+				} catch (error: unknown | Error & { code: string }) {
+					expect(error).toBeInstanceOf(Error);
+					if (error instanceof Error) {
+						expect(error.message).toBe(`Transaction ${
+							options?.pessimistic ? 'put' : 'commit'
+						} failed: Resource busy`);
+						if ('code' in error) {
+							expect(error.code).toBe('ERR_BUSY');
 						}
 					}
-
-					const value = await db.get('foo');
-					expect(value).toBe('bar3');
-				} finally {
-					db?.close();
-					await rimraf(dbPath);
 				}
-			});
+
+				const value = await db.get('foo');
+				expect(value).toBe('bar3');
+			}));
 		} else {
-			it(`${name} async should treat transaction as a snapshot`, async () => {
-				let db: RocksDatabase | null = null;
-				const dbPath = generateDBPath();
+			it(`${name} async should treat transaction as a snapshot`, () => dbRunner({
+				dbOptions: [ options ]
+			}, async ({ db }) => {
+				await db.put('foo', 'bar1');
+
+				setTimeout(() => db?.put('foo', 'bar2'));
 
 				try {
-					db = RocksDatabase.open(dbPath, options);
-					await db.put('foo', 'bar1');
+					await db.transaction(async (txn: Transaction) => {
+						const before = await txn.get('foo');
 
-					setTimeout(() => db?.put('foo', 'bar2'));
+						await new Promise((resolve) => setTimeout(resolve, 100));
+						const after = await txn.get('foo');
 
-					try {
-						await db.transaction(async (txn: Transaction) => {
-							const before = await txn.get('foo');
+						expect(before).toBe(after);
 
-							await new Promise((resolve) => setTimeout(resolve, 100));
-							const after = await txn.get('foo');
-
-							expect(before).toBe(after);
-
-							await txn.put('foo', 'bar3');
-						}, txnOptions);
-					} catch (error: unknown | Error & { code: string }) {
-						expect(error).toBeInstanceOf(Error);
-						if (error instanceof Error) {
-							expect(error.message).toBe(`Transaction ${
-								options?.pessimistic ? 'put' : 'commit'
-							} failed: Resource busy`);
-							if ('code' in error) {
-								expect(error.code).toBe('ERR_BUSY');
-							}
+						await txn.put('foo', 'bar3');
+					}, txnOptions);
+				} catch (error: unknown | Error & { code: string }) {
+					expect(error).toBeInstanceOf(Error);
+					if (error instanceof Error) {
+						expect(error.message).toBe(`Transaction ${
+							options?.pessimistic ? 'put' : 'commit'
+						} failed: Resource busy`);
+						if ('code' in error) {
+							expect(error.code).toBe('ERR_BUSY');
 						}
 					}
-
-					const value = await db.get('foo');
-					expect(value).toBe('bar2');
-				} finally {
-					db?.close();
-					await rimraf(dbPath);
 				}
-			});
+
+				const value = await db.get('foo');
+				expect(value).toBe('bar2');
+			}));
 		}
 
-		it(`${name} async should allow transactions across column families`, async () => {
-			let db: RocksDatabase | null = null;
-			let db2: RocksDatabase | null = null;
-			const dbPath = generateDBPath();
+		it(`${name} async should allow transactions across column families`, () => dbRunner({
+			dbOptions: [ options, { ...options, name: 'foo' } ]
+		}, async ({ db }, { db: db2 }) => {
+			await db.put('foo', 'bar');
+			await db2.put('foo2', 'baz');
 
-			try {
-				db = RocksDatabase.open(dbPath, options);
-				db2 = RocksDatabase.open(dbPath, { ...options, name: 'foo' });
+			await db.transaction(async (txn: Transaction) => {
+				await db.put('foo', 'bar2', { transaction: txn });
+				await db2.put('foo2', 'baz2', { transaction: txn });
+			}, txnOptions);
 
-				await db.put('foo', 'bar');
-				await db2.put('foo2', 'baz');
+			expect(await db.get('foo')).toBe('bar2');
+			expect(await db2.get('foo2')).toBe('baz2');
+		}));
 
-				await db.transaction(async (txn: Transaction) => {
-					assert(db);
-					assert(db2);
-					await db.put('foo', 'bar2', { transaction: txn });
-					await db2.put('foo2', 'baz2', { transaction: txn });
-				}, txnOptions);
+		it(`${name} async should allow multiple transactions to run in parallel`, () => dbRunner({
+			dbOptions: [ options, { ...options, path: generateDBPath() } ]
+		}, async ({ db }, { db: db2 }) => {
+			await Promise.all([
+				db.transaction(async (txn: Transaction) => {
+					await new Promise((resolve) => setTimeout(resolve, 100));
+					await db?.put('foo', 'bar2', { transaction: txn });
+				}, txnOptions),
+				db2.transaction(async (txn: Transaction) => {
+					await new Promise((resolve) => setTimeout(resolve, 100));
+					await db2?.put('foo2', 'baz3', { transaction: txn });
+				}, txnOptions),
+			]);
 
-				expect(await db.get('foo')).toBe('bar2');
-				expect(await db2.get('foo2')).toBe('baz2');
-			} finally {
-				db?.close();
-				db2?.close();
-				await rimraf(dbPath);
+			expect(await db.get('foo')).toBe('bar2');
+			expect(await db2.get('foo2')).toBe('baz3');
+		}));
+
+		it(`${name} async should close transaction and iterator if getRange throws`, () => dbRunner({
+			dbOptions: [ options ]
+		}, async ({ db }) => {
+			for (const key of ['a', 'b', 'c', 'd', 'e']) {
+				await db.put(key, `value ${key}`);
 			}
-		});
 
-		it(`${name} async should allow multiple transactions to run in parallel`, async () => {
-			let db: RocksDatabase | null = null;
-			let db2: RocksDatabase | null = null;
-			const dbPath = generateDBPath();
-			const dbPath2 = generateDBPath();
+			let txn: Transaction;
 
-			try {
-				db = RocksDatabase.open(dbPath, options);
-				db2 = RocksDatabase.open(dbPath2, options);
+			await expect(db.transaction(async (t: Transaction) => {
+				txn = t;
+				const iter = txn.getRange();
+				const results = iter
+					.map(_item => {
+						throw new Error('test');
+					});
+				const iterator = results[Symbol.asyncIterator]();
+				await iterator.next();
+			}, txnOptions)).rejects.toThrow('test');
 
-				await Promise.all([
-					db.transaction(async (txn: Transaction) => {
-						await new Promise((resolve) => setTimeout(resolve, 100));
-						await db?.put('foo', 'bar2', { transaction: txn });
-					}, txnOptions),
-					db2.transaction(async (txn: Transaction) => {
-						await new Promise((resolve) => setTimeout(resolve, 100));
-						await db2?.put('foo2', 'baz3', { transaction: txn });
-					}, txnOptions),
-				]);
+			expect(() => db.getSync('a', { transaction: txn })).toThrow('Transaction not found');
+		}));
 
-				expect(await db.get('foo')).toBe('bar2');
-				expect(await db2.get('foo2')).toBe('baz3');
-			} finally {
-				db?.close();
-				db2?.close();
-				await rimraf(dbPath);
-				await rimraf(dbPath2);
-			}
-		});
+		it(`${name} async should commit in the callback`, () => dbRunner({
+			dbOptions: [ options ]
+		}, async ({ db }) => {
+			await db.transaction(async (txn: Transaction) => {
+				await txn.put('foo', 'bar');
+				await txn.commit();
+			});
+			await expect(db.get('foo')).toBe('bar');
+		}));
 
-		it(`${name} async should close transaction and iterator if getRange throws`, async () => {
-			let db: RocksDatabase | null = null;
-			const dbPath = generateDBPath();
+		it(`${name} async should commit twice in the callback`, () => dbRunner({
+			dbOptions: [ options ]
+		}, async ({ db }) => {
+			await db.transaction(async (txn: Transaction) => {
+				await txn.put('foo', 'bar');
+				await txn.commit();
+				await txn.commit();
+			});
+			await expect(db.get('foo')).toBe('bar');
+		}));
 
-			try {
-				db = RocksDatabase.open(dbPath, options);
-				for (const key of ['a', 'b', 'c', 'd', 'e']) {
-					await db.put(key, `value ${key}`);
-				}
+		it(`${name} async should commit, then throw in the callback`, () => dbRunner({
+			dbOptions: [ options ]
+		}, async ({ db }) => {
+			await expect(db.transaction(async (txn: Transaction) => {
+				await txn.put('foo', 'bar');
+				await txn.commit();
+				throw new Error('test');
+			})).rejects.toThrow('test');
+			await expect(db.get('foo')).toBe('bar');
+		}));
 
-				let txn: Transaction;
+		it(`${name} async should commit, then error when aborting in the callback`, () => dbRunner({
+			dbOptions: [ options ]
+		}, async ({ db }) => {
+			await expect(db.transaction(async (txn: Transaction) => {
+				await txn.put('foo', 'bar');
+				await txn.commit();
+				txn.abort();
+			})).rejects.toThrow('Transaction has already been committed');
+			await expect(db.get('foo')).toBe('bar');
+		}));
 
-				await expect(db.transaction(async (t: Transaction) => {
-					txn = t;
-					const iter = txn.getRange();
-					const results = iter
-						.map(_item => {
-							throw new Error('test');
-						});
-					const iterator = results[Symbol.asyncIterator]();
-					await iterator.next();
-				}, txnOptions)).rejects.toThrow('test');
+		it(`${name} async should commit, then abort in the callback`, () => dbRunner({
+			dbOptions: [ options ]
+		}, async ({ db }) => {
+			await expect(db.transaction(async (txn: Transaction) => {
+				await txn.put('foo', 'bar');
+				await txn.commit();
+				txn.abort();
+			})).rejects.toThrow('Transaction has already been committed');
+			await expect(db.get('foo')).toBe('bar');
+		}));
 
-				expect(() => db!.getSync('a', { transaction: txn })).toThrow('Transaction not found');
-			} finally {
-				db?.close();
-				await rimraf(dbPath);
-			}
-		});
+		it(`${name} async should abort in the callback`, () => dbRunner({
+			dbOptions: [ options ]
+		}, async ({ db }) => {
+			await db.transaction(async (txn: Transaction) => {
+				await txn.put('foo', 'bar');
+				txn.abort();
+			});
+			await expect(db.get('foo')).toBeUndefined();
+		}));
 
-		it(`${name} async should commit in the callback`, async () => {
-			let db: RocksDatabase | null = null;
-			const dbPath = generateDBPath();
+		it(`${name} async should abort twice in the callback`, () => dbRunner({
+			dbOptions: [ options ]
+		}, async ({ db }) => {
+			await db.transaction(async (txn: Transaction) => {
+				await txn.put('foo', 'bar');
+				txn.abort();
+				txn.abort();
+			});
+			await expect(db.get('foo')).toBeUndefined();
+		}));
 
-			try {
-				db = RocksDatabase.open(dbPath, options);
-				await db.transaction(async (txn: Transaction) => {
-					await txn.put('foo', 'bar');
-					await txn.commit();
-				});
-				await expect(db.get('foo')).toBe('bar');
-			} finally {
-				db?.close();
-				await rimraf(dbPath);
-			}
-		});
+		it(`${name} async should abort, then throw in the callback`, () => dbRunner({
+			dbOptions: [ options ]
+		}, async ({ db }) => {
+			await expect(db.transaction(async (txn: Transaction) => {
+				await txn.put('foo', 'bar');
+				txn.abort();
+				throw new Error('test');
+			})).rejects.toThrow('test');
+			await expect(db.get('foo')).toBeUndefined();
+		}));
 
-		it(`${name} async should commit twice in the callback`, async () => {
-			let db: RocksDatabase | null = null;
-			const dbPath = generateDBPath();
-
-			try {
-				db = RocksDatabase.open(dbPath, options);
-				await db.transaction(async (txn: Transaction) => {
-					await txn.put('foo', 'bar');
-					await txn.commit();
-					await txn.commit();
-				});
-				await expect(db.get('foo')).toBe('bar');
-			} finally {
-				db?.close();
-				await rimraf(dbPath);
-			}
-		});
-
-		it(`${name} async should commit, then throw in the callback`, async () => {
-			let db: RocksDatabase | null = null;
-			const dbPath = generateDBPath();
-
-			try {
-				db = RocksDatabase.open(dbPath, options);
-				await expect(db.transaction(async (txn: Transaction) => {
-					await txn.put('foo', 'bar');
-					await txn.commit();
-					throw new Error('test');
-				})).rejects.toThrow('test');
-				await expect(db.get('foo')).toBe('bar');
-			} finally {
-				db?.close();
-				await rimraf(dbPath);
-			}
-		});
-
-		it(`${name} async should commit, then error when aborting in the callback`, async () => {
-			let db: RocksDatabase | null = null;
-			const dbPath = generateDBPath();
-
-			try {
-				db = RocksDatabase.open(dbPath, options);
-				await expect(db.transaction(async (txn: Transaction) => {
-					await txn.put('foo', 'bar');
-					await txn.commit();
-					txn.abort();
-				})).rejects.toThrow('Transaction has already been committed');
-				await expect(db.get('foo')).toBe('bar');
-			} finally {
-				db?.close();
-				await rimraf(dbPath);
-			}
-		});
-
-		it(`${name} async should commit, then abort in the callback`, async () => {
-			let db: RocksDatabase | null = null;
-			const dbPath = generateDBPath();
-
-			try {
-				db = RocksDatabase.open(dbPath, options);
-				await expect(db.transaction(async (txn: Transaction) => {
-					await txn.put('foo', 'bar');
-					await txn.commit();
-					txn.abort();
-				})).rejects.toThrow('Transaction has already been committed');
-				await expect(db.get('foo')).toBe('bar');
-			} finally {
-				db?.close();
-				await rimraf(dbPath);
-			}
-		});
-
-		it(`${name} async should abort in the callback`, async () => {
-			let db: RocksDatabase | null = null;
-			const dbPath = generateDBPath();
-
-			try {
-				db = RocksDatabase.open(dbPath, options);
-				await db.transaction(async (txn: Transaction) => {
-					await txn.put('foo', 'bar');
-					txn.abort();
-				});
-				await expect(db.get('foo')).toBeUndefined();
-			} finally {
-				db?.close();
-				await rimraf(dbPath);
-			}
-		});
-
-		it(`${name} async should abort twice in the callback`, async () => {
-			let db: RocksDatabase | null = null;
-			const dbPath = generateDBPath();
-
-			try {
-				db = RocksDatabase.open(dbPath, options);
-				await db.transaction(async (txn: Transaction) => {
-					await txn.put('foo', 'bar');
-					txn.abort();
-					txn.abort();
-				});
-				await expect(db.get('foo')).toBeUndefined();
-			} finally {
-				db?.close();
-				await rimraf(dbPath);
-			}
-		});
-
-		it(`${name} async should abort, then throw in the callback`, async () => {
-			let db: RocksDatabase | null = null;
-			const dbPath = generateDBPath();
-
-			try {
-				db = RocksDatabase.open(dbPath, options);
-				await expect(db.transaction(async (txn: Transaction) => {
-					await txn.put('foo', 'bar');
-					txn.abort();
-					throw new Error('test');
-				})).rejects.toThrow('test');
-				await expect(db.get('foo')).toBeUndefined();
-			} finally {
-				db?.close();
-				await rimraf(dbPath);
-			}
-		});
-
-		it(`${name} async should abort, then error when aborting in the callback`, async () => {
-			let db: RocksDatabase | null = null;
-			const dbPath = generateDBPath();
-
-			try {
-				db = RocksDatabase.open(dbPath, options);
-				await expect(db.transaction(async (txn: Transaction) => {
-					await txn.put('foo', 'bar');
-					txn.abort();
-					await txn.commit();
-				})).rejects.toThrow('Transaction has already been aborted');
-				await expect(db.get('foo')).toBeUndefined();
-			} finally {
-				db?.close();
-				await rimraf(dbPath);
-			}
-		});
+		it(`${name} async should abort, then error when aborting in the callback`, () => dbRunner({
+			dbOptions: [ options ]
+		}, async ({ db }) => {
+			await expect(db.transaction(async (txn: Transaction) => {
+				await txn.put('foo', 'bar');
+				txn.abort();
+				await txn.commit();
+			})).rejects.toThrow('Transaction has already been aborted');
+			await expect(db.get('foo')).toBeUndefined();
+		}));
 	});
 
 	describe(`transactionSync() (${name})`, () => {
-		it(`${name} sync should error if callback is not a function`, async () => {
-			let db: RocksDatabase | null = null;
-			const dbPath = generateDBPath();
+		it(`${name} sync should error if callback is not a function`, () => dbRunner({
+			dbOptions: [ options ]
+		}, async ({ db }) => {
+			expect(() => db.transactionSync('foo' as any, txnOptions))
+				.toThrow(new TypeError('Callback must be a function'));
+		}));
 
-			try {
-				db = RocksDatabase.open(dbPath, options);
-				expect(() => db!.transactionSync('foo' as any, txnOptions))
-					.toThrow(new TypeError('Callback must be a function'));
-			} finally {
-				db?.close();
-				await rimraf(dbPath);
-			}
-		});
-
-		it(`${name} sync should get a value`, async () => {
-			let db: RocksDatabase | null = null;
-			const dbPath = generateDBPath();
-
-			try {
-				db = RocksDatabase.open(dbPath, options);
-				await db.put('foo', 'bar');
-				db.transactionSync((txn: Transaction) => {
-					const value = txn.getSync('foo');
-					expect(value).toBe('bar');
-				}, txnOptions);
-			} finally {
-				db?.close();
-				await rimraf(dbPath);
-			}
-		});
-
-		it(`${name} sync should set a value`, async () => {
-			let db: RocksDatabase | null = null;
-			const dbPath = generateDBPath();
-
-			try {
-				db = RocksDatabase.open(dbPath, options);
-
-				db.transactionSync((txn: Transaction) => {
-					txn.putSync('foo', 'bar2');
-				}, txnOptions);
-
-				const value = await db.get('foo');
-				expect(value).toBe('bar2');
-			} finally {
-				db?.close();
-				await rimraf(dbPath);
-			}
-		});
-
-		it(`${name} sync should remove a value`, async () => {
-			let db: RocksDatabase | null = null;
-			const dbPath = generateDBPath();
-
-			try {
-				db = RocksDatabase.open(dbPath, options);
-				await db.put('foo', 'bar');
-
-				db.transactionSync((txn: Transaction) => {
-					txn.removeSync('foo');
-				}, txnOptions);
-
-				const value = await db.get('foo');
-				expect(value).toBeUndefined();
-			} finally {
-				db?.close();
-				await rimraf(dbPath);
-			}
-		});
-
-		it(`${name} sync should rollback on error`, async () => {
-			let db: RocksDatabase | null = null;
-			const dbPath = generateDBPath();
-
-			try {
-				db = RocksDatabase.open(dbPath, options);
-				await db.put('foo', 'bar');
-
-				expect(() => db!.transactionSync((txn: Transaction) => {
-					txn.putSync('foo', 'bar2');
-					throw new Error('test');
-				}, txnOptions)).toThrow('test');
-
-				const value = await db.get('foo');
+		it(`${name} sync should get a value`, () => dbRunner({
+			dbOptions: [ options ]
+		}, async ({ db }) => {
+			await db.put('foo', 'bar');
+			db.transactionSync((txn: Transaction) => {
+				const value = txn.getSync('foo');
 				expect(value).toBe('bar');
-			} finally {
-				db?.close();
-				await rimraf(dbPath);
+			}, txnOptions);
+		}));
+
+		it(`${name} sync should set a value`, () => dbRunner({
+			dbOptions: [ options ]
+		}, async ({ db }) => {
+			db.transactionSync((txn: Transaction) => {
+				txn.putSync('foo', 'bar2');
+			}, txnOptions);
+
+			const value = await db.get('foo');
+			expect(value).toBe('bar2');
+		}));
+
+		it(`${name} sync should remove a value`, () => dbRunner({
+			dbOptions: [ options ]
+		}, async ({ db }) => {
+			await db.put('foo', 'bar');
+
+			db.transactionSync((txn: Transaction) => {
+				txn.removeSync('foo');
+			}, txnOptions);
+
+			const value = await db.get('foo');
+			expect(value).toBeUndefined();
+		}));
+
+		it(`${name} sync should rollback on error`, () => dbRunner({
+			dbOptions: [ options ]
+		}, async ({ db }) => {
+			await db.put('foo', 'bar');
+
+			expect(() => db.transactionSync((txn: Transaction) => {
+				txn.putSync('foo', 'bar2');
+				throw new Error('test');
+			}, txnOptions)).toThrow('test');
+
+			const value = await db.get('foo');
+			expect(value).toBe('bar');
+		}));
+
+		it(`${name} sync should abort once`, () => dbRunner({
+			dbOptions: [ options ]
+		}, async ({ db }) => {
+			await db.put('foo', 'bar');
+
+			db.transactionSync((txn: Transaction) => {
+				txn.abort();
+			}, txnOptions);
+		}));
+
+		it(`${name} sync should allow transactions across column families`, () => dbRunner({
+			dbOptions: [ options, { ...options, name: 'foo' } ]
+		}, async ({ db }, { db: db2 }) => {
+			await db.put('foo', 'bar');
+			await db2.put('foo2', 'baz');
+
+			db.transactionSync((txn: Transaction) => {
+				db.putSync('foo', 'bar2', { transaction: txn });
+				db2.putSync('foo2', 'baz2', { transaction: txn });
+			}, txnOptions);
+
+			expect(await db.get('foo')).toBe('bar2');
+			expect(await db2.get('foo2')).toBe('baz2');
+		}));
+
+		it(`${name} sync should close transaction and iterator if getRange throws`, () => dbRunner({
+			dbOptions: [ options ]
+		}, async ({ db }) => {
+			for (const key of ['a', 'b', 'c', 'd', 'e']) {
+				db.putSync(key, `value ${key}`);
 			}
-		});
 
-		it(`${name} sync should abort once`, async () => {
-			let db: RocksDatabase | null = null;
-			const dbPath = generateDBPath();
+			let txn: Transaction;
 
-			try {
-				db = RocksDatabase.open(dbPath, options);
-				await db.put('foo', 'bar');
+			expect(() => db.transactionSync((t: Transaction) => {
+				txn = t;
+				const iter = txn.getRange();
+				const results = iter
+					.map(_item => {
+						throw new Error('test');
+					});
+				const iterator = results[Symbol.iterator]();
+				iterator.next();
+			}, txnOptions)).toThrow('test');
 
-				db!.transactionSync((txn: Transaction) => {
-					txn.abort();
-				}, txnOptions);
-			} finally {
-				db?.close();
-				await rimraf(dbPath);
-			}
-		});
+			expect(() => db.getSync('a', { transaction: txn })).toThrow('Transaction not found');
+		}));
 
-		it(`${name} sync should allow transactions across column families`, async () => {
-			let db: RocksDatabase | null = null;
-			let db2: RocksDatabase | null = null;
-			const dbPath = generateDBPath();
+		it(`${name} sync should commit in the callback`, () => dbRunner({
+			dbOptions: [ options ]
+		}, async ({ db }) => {
+			db.transactionSync((txn: Transaction) => {
+				txn.putSync('foo', 'bar');
+				txn.commitSync();
+			});
+			await expect(db.get('foo')).toBe('bar');
+		}));
 
-			try {
-				db = RocksDatabase.open(dbPath, options);
-				db2 = RocksDatabase.open(dbPath, { ...options, name: 'foo' });
+		it(`${name} sync should commit twice in the callback`, () => dbRunner({
+			dbOptions: [ options ]
+		}, async ({ db }) => {
+			db.transactionSync((txn: Transaction) => {
+				txn.putSync('foo', 'bar');
+				txn.commitSync();
+				txn.commitSync();
+			});
+			await expect(db.get('foo')).toBe('bar');
+		}));
 
-				await db.put('foo', 'bar');
-				await db2.put('foo2', 'baz');
+		it(`${name} sync should commit, then throw in the callback`, () => dbRunner({
+			dbOptions: [ options ]
+		}, async ({ db }) => {
+			expect(() => db.transactionSync((txn: Transaction) => {
+				txn.putSync('foo', 'bar');
+				txn.commitSync();
+				throw new Error('test');
+			})).toThrow('test');
+			expect(db.getSync('foo')).toBe('bar');
+		}));
 
-				db.transactionSync((txn: Transaction) => {
-					assert(db);
-					assert(db2);
-					db.putSync('foo', 'bar2', { transaction: txn });
-					db2.putSync('foo2', 'baz2', { transaction: txn });
-				}, txnOptions);
+		it(`${name} sync should commit, then error when aborting in the callback`, () => dbRunner({
+			dbOptions: [ options ]
+		}, async ({ db }) => {
+			expect(() => db.transactionSync((txn: Transaction) => {
+				txn.putSync('foo', 'bar');
+				txn.commitSync();
+				txn.abort();
+			})).toThrow('Transaction has already been committed');
+			expect(db.getSync('foo')).toBe('bar');
+		}));
 
-				expect(await db.get('foo')).toBe('bar2');
-				expect(await db2.get('foo2')).toBe('baz2');
-			} finally {
-				db?.close();
-				db2?.close();
-				await rimraf(dbPath);
-			}
-		});
+		it(`${name} sync should commit, then abort in the callback`, () => dbRunner({
+			dbOptions: [ options ]
+		}, async ({ db }) => {
+			expect(() => db.transactionSync((txn: Transaction) => {
+				txn.putSync('foo', 'bar');
+				txn.commitSync();
+				txn.abort();
+			})).toThrow('Transaction has already been committed');
+			expect(db.getSync('foo')).toBe('bar');
+		}));
 
-		it(`${name} sync should close transaction and iterator if getRange throws`, async () => {
-			let db: RocksDatabase | null = null;
-			const dbPath = generateDBPath();
+		it(`${name} sync should abort in the callback`, () => dbRunner({
+			dbOptions: [ options ]
+		}, async ({ db }) => {
+			db.transactionSync((txn: Transaction) => {
+				txn.putSync('foo', 'bar');
+				txn.abort();
+			});
+			expect(db.getSync('foo')).toBeUndefined();
+		}));
 
-			try {
-				db = RocksDatabase.open(dbPath, options);
-				for (const key of ['a', 'b', 'c', 'd', 'e']) {
-					db.putSync(key, `value ${key}`);
-				}
+		it(`${name} sync should abort twice in the callback`, () => dbRunner({
+			dbOptions: [ options ]
+		}, async ({ db }) => {
+			db.transactionSync((txn: Transaction) => {
+				txn.putSync('foo', 'bar');
+				txn.abort();
+				txn.abort();
+			});
+			expect(db.getSync('foo')).toBeUndefined();
+		}));
 
-				let txn: Transaction;
+		it(`${name} sync should abort, then throw in the callback`, () => dbRunner({
+			dbOptions: [ options ]
+		}, async ({ db }) => {
+			expect(() => db.transactionSync((txn: Transaction) => {
+				txn.putSync('foo', 'bar');
+				txn.abort();
+				throw new Error('test');
+			})).toThrow('test');
+			expect(db.getSync('foo')).toBeUndefined();
+		}));
 
-				expect(() => db!.transactionSync((t: Transaction) => {
-					txn = t;
-					const iter = txn.getRange();
-					const results = iter
-						.map(_item => {
-							throw new Error('test');
-						});
-					const iterator = results[Symbol.iterator]();
-					iterator.next();
-				}, txnOptions)).toThrow('test');
-
-				expect(() => db!.getSync('a', { transaction: txn })).toThrow('Transaction not found');
-			} finally {
-				db?.close();
-				await rimraf(dbPath);
-			}
-		});
-
-		it(`${name} sync should commit in the callback`, async () => {
-			let db: RocksDatabase | null = null;
-			const dbPath = generateDBPath();
-
-			try {
-				db = RocksDatabase.open(dbPath, options);
-				db.transactionSync((txn: Transaction) => {
-					txn.putSync('foo', 'bar');
-					txn.commitSync();
-				});
-				await expect(db.get('foo')).toBe('bar');
-			} finally {
-				db?.close();
-				await rimraf(dbPath);
-			}
-		});
-
-		it(`${name} sync should commit twice in the callback`, async () => {
-			let db: RocksDatabase | null = null;
-			const dbPath = generateDBPath();
-
-			try {
-				db = RocksDatabase.open(dbPath, options);
-				db.transactionSync((txn: Transaction) => {
-					txn.putSync('foo', 'bar');
-					txn.commitSync();
-					txn.commitSync();
-				});
-				await expect(db.get('foo')).toBe('bar');
-			} finally {
-				db?.close();
-				await rimraf(dbPath);
-			}
-		});
-
-		it(`${name} sync should commit, then throw in the callback`, async () => {
-			let db: RocksDatabase | null = null;
-			const dbPath = generateDBPath();
-
-			try {
-				db = RocksDatabase.open(dbPath, options);
-				expect(() => db!.transactionSync((txn: Transaction) => {
-					txn.putSync('foo', 'bar');
-					txn.commitSync();
-					throw new Error('test');
-				})).toThrow('test');
-				expect(db.getSync('foo')).toBe('bar');
-			} finally {
-				db?.close();
-				await rimraf(dbPath);
-			}
-		});
-
-		it(`${name} sync should commit, then error when aborting in the callback`, async () => {
-			let db: RocksDatabase | null = null;
-			const dbPath = generateDBPath();
-
-			try {
-				db = RocksDatabase.open(dbPath, options);
-				expect(() => db!.transactionSync((txn: Transaction) => {
-					txn.putSync('foo', 'bar');
-					txn.commitSync();
-					txn.abort();
-				})).toThrow('Transaction has already been committed');
-				expect(db.getSync('foo')).toBe('bar');
-			} finally {
-				db?.close();
-				await rimraf(dbPath);
-			}
-		});
-
-		it(`${name} sync should commit, then abort in the callback`, async () => {
-			let db: RocksDatabase | null = null;
-			const dbPath = generateDBPath();
-
-			try {
-				db = RocksDatabase.open(dbPath, options);
-				expect(() => db!.transactionSync((txn: Transaction) => {
-					txn.putSync('foo', 'bar');
-					txn.commitSync();
-					txn.abort();
-				})).toThrow('Transaction has already been committed');
-				expect(db.getSync('foo')).toBe('bar');
-			} finally {
-				db?.close();
-				await rimraf(dbPath);
-			}
-		});
-
-		it(`${name} sync should abort in the callback`, async () => {
-			let db: RocksDatabase | null = null;
-			const dbPath = generateDBPath();
-
-			try {
-				db = RocksDatabase.open(dbPath, options);
-				db.transactionSync((txn: Transaction) => {
-					txn.putSync('foo', 'bar');
-					txn.abort();
-				});
-				expect(db.getSync('foo')).toBeUndefined();
-			} finally {
-				db?.close();
-				await rimraf(dbPath);
-			}
-		});
-
-		it(`${name} sync should abort twice in the callback`, async () => {
-			let db: RocksDatabase | null = null;
-			const dbPath = generateDBPath();
-
-			try {
-				db = RocksDatabase.open(dbPath, options);
-				db.transactionSync((txn: Transaction) => {
-					txn.putSync('foo', 'bar');
-					txn.abort();
-					txn.abort();
-				});
-				expect(db.getSync('foo')).toBeUndefined();
-			} finally {
-				db?.close();
-				await rimraf(dbPath);
-			}
-		});
-
-		it(`${name} sync should abort, then throw in the callback`, async () => {
-			let db: RocksDatabase | null = null;
-			const dbPath = generateDBPath();
-
-			try {
-				db = RocksDatabase.open(dbPath, options);
-				expect(() => db!.transactionSync((txn: Transaction) => {
-					txn.putSync('foo', 'bar');
-					txn.abort();
-					throw new Error('test');
-				})).toThrow('test');
-				expect(db.getSync('foo')).toBeUndefined();
-			} finally {
-				db?.close();
-				await rimraf(dbPath);
-			}
-		});
-
-		it(`${name} sync should abort, then error when aborting in the callback`, async () => {
-			let db: RocksDatabase | null = null;
-			const dbPath = generateDBPath();
-
-			try {
-				db = RocksDatabase.open(dbPath, options);
-				expect(() => db!.transactionSync((txn: Transaction) => {
-					txn.putSync('foo', 'bar');
-					txn.abort();
-					txn.commitSync();
-				})).toThrow('Transaction has already been aborted');
-				expect(db.getSync('foo')).toBeUndefined();
-			} finally {
-				db?.close();
-				await rimraf(dbPath);
-			}
-		});
+		it(`${name} sync should abort, then error when aborting in the callback`, () => dbRunner({
+			dbOptions: [ options ]
+		}, async ({ db }) => {
+			expect(() => db.transactionSync((txn: Transaction) => {
+				txn.putSync('foo', 'bar');
+				txn.abort();
+				txn.commitSync();
+			})).toThrow('Transaction has already been aborted');
+			expect(db.getSync('foo')).toBeUndefined();
+		}));
 	});
 
 	describe(`Error handling (${name})`, () => {
-		it('should error if transaction is invalid', async () => {
-			let db: RocksDatabase | null = null;
-			const dbPath = generateDBPath();
+		it('should error if transaction is invalid', () => dbRunner({
+			dbOptions: [ options ]
+		}, async ({ db }) => {
+			await expect(db.get('foo', { transaction: 'bar' as any })).rejects.toThrow('Invalid transaction');
+		}));
 
-			try {
-				db = RocksDatabase.open(dbPath, options);
-				await expect(db.get('foo', { transaction: 'bar' as any })).rejects.toThrow('Invalid transaction');
-			} finally {
-				db?.close();
-				await rimraf(dbPath);
-			}
-		});
-
-		it('should error if transaction is not found', async () => {
-			let db: RocksDatabase | null = null;
-			const dbPath = generateDBPath();
-
-			try {
-				db = RocksDatabase.open(dbPath, options);
-				await expect(db.get('foo', { transaction: { id: 9926 } as any })).rejects.toThrow('Transaction not found');
-			} finally {
-				db?.close();
-				await rimraf(dbPath);
-			}
-		});
+		it('should error if transaction is not found', () => dbRunner({
+			dbOptions: [ options ]
+		}, async ({ db }) => {
+			await expect(db.get('foo', { transaction: { id: 9926 } as any })).rejects.toThrow('Transaction not found');
+		}));
 	});
 }

--- a/test/versions.test.ts
+++ b/test/versions.test.ts
@@ -3,9 +3,9 @@ import { versions } from '../src/index.js';
 
 describe('versions', () => {
 	it('should get the versions', () => {
-		expect(versions).toMatchObject({
-			rocksdb: /^\d+\.\d+\.\d+$/,
-			'rocksdb-js': 'ROCKSDB_JS_VERSION', // note: this is a placeholder
-		});
+		expect(versions).toHaveProperty('rocksdb');
+		expect(versions.rocksdb).toMatch(/^\d+\.\d+\.\d+$/);
+		expect(versions).toHaveProperty('rocksdb-js');
+		expect(versions['rocksdb-js']).toBe('ROCKSDB_JS_VERSION');
 	});
 });

--- a/test/write.test.ts
+++ b/test/write.test.ts
@@ -1,190 +1,80 @@
 import { describe, expect, it } from 'vitest';
-import { rimraf } from 'rimraf';
-import { RocksDatabase } from '../src/index.js';
-import { generateDBPath } from './lib/util.js';
+import { dbRunner } from './lib/util.js';
 
 describe('Write operations', () => {
 	describe('put()', () => {
-		it('should set and get a value using default column family', async () => {
-			const dbPath = generateDBPath();
-			let db: RocksDatabase | null = null;
+		it('should set and get a value using default column family', () => dbRunner(async ({ db }) => {
+			await db.put('foo', 'bar1');
+			const value = await db.get('foo');
+			expect(value).toBe('bar1');
+		}));
 
-			try {
-				db = RocksDatabase.open(dbPath);
-				await db.put('foo', 'bar1');
-				const value = await db.get('foo');
-				expect(value).toBe('bar1');
-			} finally {
-				db?.close();
-				await rimraf(dbPath);
-			}
-		});
+		it('should set and get a value using custom column family', () => dbRunner({
+			dbOptions: [ { name: 'foo' } ]
+		}, async ({ db }) => {
+			await db.put('foo', 'bar2');
+			const value = await db.get('foo');
+			expect(value).toBe('bar2');
+		}));
 
-		it('should set and get a value using custom column family', async () => {
-			const dbPath = generateDBPath();
-			let db: RocksDatabase | null = null;
+		it('should throw an error if key is not specified', () => dbRunner(async ({ db }) => {
+			await expect((db.put as any)()).rejects.toThrow('Key is required');
+		}));
 
-			try {
-				db = RocksDatabase.open(dbPath, {
-					name: 'foo'
-				});
-				await db.put('foo', 'bar2');
-				const value = await db.get('foo');
-				expect(value).toBe('bar2');
-			} finally {
-				db?.close();
-				await rimraf(dbPath);
-			}
-		});
-
-		it('should throw an error if key is not specified', async () => {
-			const dbPath = generateDBPath();
-			let db: RocksDatabase | null = null;
-
-			try {
-				db = RocksDatabase.open(dbPath);
-				await expect((db.put as any)()).rejects.toThrow('Key is required');
-			} finally {
-				db?.close();
-				await rimraf(dbPath);
-			}
-		});
-
-		it('should throw an error if database is closed', async () => {
-			const dbPath = generateDBPath();
-			let db: RocksDatabase | null = null;
-
-			try {
-				db = RocksDatabase.open(dbPath);
-				await db.close();
-				await expect((db.put as any)()).rejects.toThrow('Database not open');
-			} finally {
-				db?.close();
-				await rimraf(dbPath);
-			}
-		});
+		it('should throw an error if database is closed', () => dbRunner(async ({ db }) => {
+			await db.close();
+			await expect((db.put as any)()).rejects.toThrow('Database not open');
+		}));
 	});
 
 	describe('putSync()', () => {
-		it('should set and get a value using default column family', async () => {
-			const dbPath = generateDBPath();
-			let db: RocksDatabase | null = null;
+		it('should set and get a value using default column family', () => dbRunner(async ({ db }) => {
+			db.putSync('foo', 'bar1');
+			const value = await db.get('foo');
+			expect(value).toBe('bar1');
+		}));
 
-			try {
-				db = RocksDatabase.open(dbPath);
-				db.putSync('foo', 'bar1');
-				const value = await db.get('foo');
-				expect(value).toBe('bar1');
-			} finally {
-				db?.close();
-				await rimraf(dbPath);
-			}
-		});
+		it('should set and get a value using custom column family', () => dbRunner({
+			dbOptions: [ { name: 'foo' } ]
+		}, async ({ db }) => {
+			db.putSync('foo', 'bar2');
+			const value = await db.get('foo');
+			expect(value).toBe('bar2');
+		}));
 
-		it('should set and get a value using custom column family', async () => {
-			const dbPath = generateDBPath();
-			let db: RocksDatabase | null = null;
+		it('should throw an error if key is not specified', () => dbRunner(async ({ db }) => {
+			expect(() => (db.putSync as any)()).toThrow('Key is required');
+		}));
 
-			try {
-				db = RocksDatabase.open(dbPath, {
-					name: 'foo'
-				});
-				db.putSync('foo', 'bar2');
-				const value = await db.get('foo');
-				expect(value).toBe('bar2');
-			} finally {
-				db?.close();
-				await rimraf(dbPath);
-			}
-		});
-
-		it('should throw an error if key is not specified', async () => {
-			const dbPath = generateDBPath();
-			let db: RocksDatabase | null = null;
-
-			try {
-				db = RocksDatabase.open(dbPath);
-				expect(() => (db!.putSync as any)()).toThrow('Key is required');
-			} finally {
-				db?.close();
-				await rimraf(dbPath);
-			}
-		});
-
-		it('should throw an error if database is closed', async () => {
-			const dbPath = generateDBPath();
-			let db: RocksDatabase | null = null;
-
-			try {
-				db = RocksDatabase.open(dbPath);
-				await db.close();
-				expect(() => (db!.putSync as any)()).toThrow('Database not open');
-			} finally {
-				db?.close();
-				await rimraf(dbPath);
-			}
-		});
+		it('should throw an error if database is closed', () => dbRunner(async ({ db }) => {
+			await db.close();
+			expect(() => (db.putSync as any)()).toThrow('Database not open');
+		}));
 	});
 
 	describe('remove()', () => {
-		it('should not error if removing a non-existent key', async () => {
-			const dbPath = generateDBPath();
-			let db: RocksDatabase | null = null;
+		it('should not error if removing a non-existent key', () => dbRunner(async ({ db }) => {
+			await db.remove('baz');
+		}));
 
-			try {
-				db = RocksDatabase.open(dbPath);
-				await db.remove('baz');
-			} finally {
-				db?.close();
-				await rimraf(dbPath);
-			}
-		});
+		it('should remove a key', () => dbRunner(async ({ db }) => {
+			let value = await db.get('foo');
+			expect(value).toBeUndefined();
+			await db.put('foo', 'bar3');
+			value = await db.get('foo');
+			expect(value).toBe('bar3');
+			await db.remove('foo');
+			value = await db.get('foo');
+			expect(value).toBeUndefined();
+		}));
 
-		it('should remove a key', async () => {
-			const dbPath = generateDBPath();
-			let db: RocksDatabase | null = null;
+		it('should throw an error if key is not specified', () => dbRunner(async ({ db }) => {
+			await expect((db.remove as any)()).rejects.toThrow('Key is required');
+		}));
 
-			try {
-				db = RocksDatabase.open(dbPath);
-				let value = await db.get('foo');
-				expect(value).toBeUndefined();
-				await db.put('foo', 'bar3');
-				value = await db.get('foo');
-				expect(value).toBe('bar3');
-				await db.remove('foo');
-				value = await db.get('foo');
-				expect(value).toBeUndefined();
-			} finally {
-				db?.close();
-				await rimraf(dbPath);
-			}
-		});
-
-		it('should throw an error if key is not specified', async () => {
-			const dbPath = generateDBPath();
-			let db: RocksDatabase | null = null;
-
-			try {
-				db = RocksDatabase.open(dbPath);
-				await expect((db.remove as any)()).rejects.toThrow('Key is required');
-			} finally {
-				db?.close();
-				await rimraf(dbPath);
-			}
-		});
-
-		it('should throw an error if database is closed', async () => {
-			const dbPath = generateDBPath();
-			let db: RocksDatabase | null = null;
-
-			try {
-				db = RocksDatabase.open(dbPath);
-				await db.close();
-				await expect((db.remove as any)()).rejects.toThrow('Database not open');
-			} finally {
-				db?.close();
-				await rimraf(dbPath);
-			}
-		});
+		it('should throw an error if database is closed', () => dbRunner(async ({ db }) => {
+			await db.close();
+			await expect((db.remove as any)()).rejects.toThrow('Database not open');
+		}));
 	});
 });


### PR DESCRIPTION
The `dbRunner()` helper greatly reduces the amount of code in unit tests. This PR does not add/remove any unit tests.