### PR TITLE
Init `DBRegistry` in the module init

### DIFF
--- a/src/binding/binding.cpp
+++ b/src/binding/binding.cpp
@@ -33,11 +33,8 @@ NAPI_MODULE_INIT() {
 	[[maybe_unused]] int refCount = ++moduleRefCount;
 	DEBUG_LOG("Binding::Init Module ref count: %d\n", refCount);
 
-	// initialize the DBRegistry singleton early to avoid race conditions
-	if (!DBRegistry::instance) {
-		DBRegistry::instance = std::unique_ptr<DBRegistry>(new DBRegistry());
-		DEBUG_LOG("%p Binding::Init Initialized DBRegistry\n", DBRegistry::instance.get());
-	}
+	// initialize the registry
+	DBRegistry::Init();
 
 	// registry cleanup
 	NAPI_STATUS_THROWS(::napi_add_env_cleanup_hook(env, [](void* data) {

--- a/src/binding/db_registry.cpp
+++ b/src/binding/db_registry.cpp
@@ -86,6 +86,16 @@ void DBRegistry::CloseDB(const std::shared_ptr<DBHandle> handle) {
 }
 
 /**
+ * Initialize the singleton instance of the registry.
+ */
+ void DBRegistry::Init() {
+	if (!instance) {
+		instance = std::unique_ptr<DBRegistry>(new DBRegistry());
+		DEBUG_LOG("%p DBRegistry::Initialize Initialized DBRegistry\n", instance.get());
+	}
+}
+
+/**
  * Open a RocksDB database with column family, caches it in the registry, and
  * return a handle to it.
  *
@@ -95,8 +105,9 @@ void DBRegistry::CloseDB(const std::shared_ptr<DBHandle> handle) {
  * column family handle.
  */
 std::unique_ptr<DBHandle> DBRegistry::OpenDB(const std::string& path, const DBOptions& options) {
-	// registry should already be initialized by module init
+	// ensure the registry has already been initialized
 	if (!instance) {
+		DEBUG_LOG("DBRegistry::OpenDB Registry not initialized!\n")
 		throw std::runtime_error("DBRegistry not initialized!");
 	}
 

--- a/src/binding/db_registry.h
+++ b/src/binding/db_registry.h
@@ -55,6 +55,7 @@ private:
 
 public:
 	static void CloseDB(const std::shared_ptr<DBHandle> handle);
+	static void Init();
 	static std::unique_ptr<DBHandle> OpenDB(const std::string& path, const DBOptions& options);
 	static void PurgeAll();
 	static size_t Size();


### PR DESCRIPTION
There's a race condition where two threads could be creating the singleton registry in `OpenDB()` before the mutex is locked. To make things worse, the lock is owned by the registry instance, so it's a chicken and egg problem.

To fix this, move the registry initialization to the module initializaiton before `OpenDB()` is even called.