### PR TITLE
Don't minify (by default)

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "build:binding": "node-gyp build",
     "build:binding:debug": "node-gyp build --coverage --debug --verbose",
     "build:bundle": "node scripts/clean-dist.mjs && tsdown -c tsdown.config.ts",
-    "build:debug": "cross-env SKIP_MINIFY=1 pnpm build:bundle",
+    "build:bundle:minify": "cross-env MINIFY=1 pnpm build:bundle",
     "check": "pnpm type-check && pnpm lint",
     "clean": "node-gyp clean",
     "coverage": "tsx scripts/coverage/main.ts",

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -11,7 +11,7 @@ const config: UserConfig = defineConfig({
 	],
 	entry: './src/index.ts',
 	format: ['es', 'cjs'],
-	minify: !process.env.SKIP_MINIFY,
+	minify: Boolean(process.env.MINIFY),
 	platform: 'node',
 	plugins: [
 		replace({


### PR DESCRIPTION
I think we originally thought minification would improve load speed. It turns out that it does not. I measured load time with and without minification, and it is consistently 12-13ms regardless of minification. Any impact of minification is less than statistical noise, less than a millisecond, and negligible. Avoiding minification makes it much easier to debug, and doesn't seem to incur any performance regresssion.
I did still include a script for doing minification, but it isn't used by default.