### PR TITLE
Prune old stale update-rocksdb branch

### DIFF
--- a/.github/workflows/update-rocksdb.yml
+++ b/.github/workflows/update-rocksdb.yml
@@ -62,6 +62,9 @@ jobs:
             git push origin --delete $BRANCH_NAME || true
           fi
 
+          # Prune stale remote-tracking branches
+          git fetch --prune origin
+
       - name: Update package.json
         if: steps.latest-release.outputs.should_update == 'true'
         run: |


### PR DESCRIPTION
When there's a new RocksDB prebuild and there's already an existing update RocksDB PR for a previous release, the old PR and branch are deleted, but the branches are stale and prevents the new branch from being created.