### PR TITLE
Use new download URL

### DIFF
--- a/scripts/init-rocksdb/download-rocksdb.ts
+++ b/scripts/init-rocksdb/download-rocksdb.ts
@@ -7,18 +7,23 @@ import { pipeline } from 'node:stream';
 import { promisify } from 'node:util';
 import type { Prebuild } from './get-prebuild';
 
-const platformMap = {
-	darwin: 'osx',
+const platformMap: Record<string, string> = {
 	win32: 'windows',
 };
 
 const streamPipeline = promisify(pipeline);
 
 export async function downloadRocksDB(prebuild: Prebuild, dest: string): Promise<void> {
-	const filename = `rocksdb-${prebuild.version}-${process.arch}-${platformMap[process.platform] || process.platform}`;
-	const [asset] = prebuild.assets.filter((asset) => asset.name.startsWith(filename));
+	let filename = `rocksdb-${prebuild.version}-${platformMap[process.platform] || process.platform}-${process.arch}`;
+	let [asset] = prebuild.assets.filter((asset) => asset.name.startsWith(filename));
 	if (!asset) {
-		throw new Error('No asset found');
+		// try the old filename
+		platformMap.darwin = 'osx';
+		filename = `rocksdb-${prebuild.version}-${process.arch}-${platformMap[process.platform] || process.platform}`;
+		([asset] = prebuild.assets.filter((asset) => asset.name.startsWith(filename)));
+		if (!asset) {
+			throw new Error('No asset found');
+		}
 	}
 
 	const { name, url } = asset;


### PR DESCRIPTION
The RocksDB prebuild artifact URL changed (swapped platform and arch), so the download script needs to be updated.