### PR TITLE
Add `DBDescriptor::close()`

### DIFF
--- a/src/binding/db_descriptor.h
+++ b/src/binding/db_descriptor.h
@@ -179,6 +179,9 @@ public:
     static std::shared_ptr<DBDescriptor> open(const std::string& path, const DBOptions& options);
     ~DBDescriptor();
 
+	void close();
+	bool isClosing() const { return this->closing.load(); }
+
 	void attach(Closable* closable);
 	void detach(Closable* closable);
 


### PR DESCRIPTION
Adding a `close()` method to `DBDescriptor` to reducing leaking internal properties as well as share logic between `DBRegistry::CloseDB()` and `DBRegistry::Shutdown()`.

Fixes #280.