### PR TITLE
Clean up macros, require semicolons, remove unused macros

### DIFF
--- a/src/binding/binding.cpp
+++ b/src/binding/binding.cpp
@@ -24,7 +24,7 @@ namespace rocksdb_js {
 napi_value Shutdown(napi_env env, napi_callback_info info) {
 	DBRegistry::Shutdown();
 	napi_value result;
-	NAPI_STATUS_THROWS(::napi_get_undefined(env, &result))
+	NAPI_STATUS_THROWS(::napi_get_undefined(env, &result));
 	return result;
 }
 
@@ -57,13 +57,13 @@ NAPI_MODULE_INIT() {
 	NAPI_STATUS_THROWS(::napi_add_env_cleanup_hook(env, [](void* data) {
 		int32_t newRefCount = --moduleRefCount;
 		if (newRefCount == 0) {
-			DEBUG_LOG("Binding::Init Cleaning up last instance, purging all databases\n")
+			DEBUG_LOG("Binding::Init Cleaning up last instance, purging all databases\n");
 			rocksdb_js::DBRegistry::PurgeAll();
-			DEBUG_LOG("Binding::Init env cleanup done\n")
+			DEBUG_LOG("Binding::Init env cleanup done\n");
 		} else if (newRefCount < 0) {
-			DEBUG_LOG("Binding::Init WARNING: Module ref count went negative!\n")
+			DEBUG_LOG("Binding::Init WARNING: Module ref count went negative!\n");
 		} else {
-			DEBUG_LOG("Binding::Init Skipping cleanup, %d remaining instances\n", newRefCount)
+			DEBUG_LOG("Binding::Init Skipping cleanup, %d remaining instances\n", newRefCount);
 		}
 	}, nullptr));
 

--- a/src/binding/database.cpp
+++ b/src/binding/database.cpp
@@ -21,13 +21,13 @@ namespace rocksdb_js {
  * ```
  */
 napi_value Database::Constructor(napi_env env, napi_callback_info info) {
-	NAPI_CONSTRUCTOR_WITH_DATA("Database")
+	NAPI_CONSTRUCTOR_WITH_DATA("Database");
 
 	// create shared_ptr on heap so it persists after function returns
 	napi_ref exportsRef = reinterpret_cast<napi_ref>(data);
 	auto* dbHandle = new std::shared_ptr<DBHandle>(std::make_shared<DBHandle>(env, exportsRef));
 
-	DEBUG_LOG("Database::Constructor Creating NativeDatabase DBHandle=%p\n", dbHandle->get())
+	DEBUG_LOG("Database::Constructor Creating NativeDatabase DBHandle=%p\n", dbHandle->get());
 
 	try {
 		NAPI_STATUS_THROWS(::napi_wrap(
@@ -35,7 +35,7 @@ napi_value Database::Constructor(napi_env env, napi_callback_info info) {
 			jsThis,
 			reinterpret_cast<void*>(dbHandle),
 			[](napi_env env, void* data, void* hint) {
-				DEBUG_LOG("Database::Constructor NativeDatabase GC'd dbHandle=%p\n", data)
+				DEBUG_LOG("Database::Constructor NativeDatabase GC'd dbHandle=%p\n", data);
 				auto* dbHandle = static_cast<std::shared_ptr<DBHandle>*>(data);
 				if (*dbHandle) {
 					DBRegistry::CloseDB(*dbHandle);
@@ -64,8 +64,8 @@ napi_value Database::Constructor(napi_env env, napi_callback_info info) {
  * ```
  */
 napi_value Database::Clear(napi_env env, napi_callback_info info) {
-	NAPI_METHOD_ARGV(3)
-	UNWRAP_DB_HANDLE_AND_OPEN()
+	NAPI_METHOD_ARGV(3);
+	UNWRAP_DB_HANDLE_AND_OPEN();
 
 	napi_value resolve = argv[0];
 	napi_value reject = argv[1];
@@ -76,11 +76,11 @@ napi_value Database::Clear(napi_env env, napi_callback_info info) {
 		"database.clear",
 		NAPI_AUTO_LENGTH,
 		&name
-	))
+	));
 
 	auto state = new AsyncClearState(env, *dbHandle);
-	NAPI_STATUS_THROWS(::napi_create_reference(env, resolve, 1, &state->resolveRef))
-	NAPI_STATUS_THROWS(::napi_create_reference(env, reject, 1, &state->rejectRef))
+	NAPI_STATUS_THROWS(::napi_create_reference(env, resolve, 1, &state->resolveRef));
+	NAPI_STATUS_THROWS(::napi_create_reference(env, reject, 1, &state->rejectRef));
 
 	NAPI_STATUS_THROWS(::napi_create_async_work(
 		env,       // node_env
@@ -104,14 +104,14 @@ napi_value Database::Clear(napi_env env, napi_callback_info info) {
 
 			if (status != napi_cancelled) {
 				napi_value global;
-				NAPI_STATUS_THROWS_VOID(::napi_get_global(env, &global))
+				NAPI_STATUS_THROWS_VOID(::napi_get_global(env, &global));
 
 				if (state->status.ok()) {
 					napi_value undefined;
-					NAPI_STATUS_THROWS_VOID(::napi_get_undefined(env, &undefined))
+					NAPI_STATUS_THROWS_VOID(::napi_get_undefined(env, &undefined));
 					state->callResolve(undefined);
 				} else {
-					ROCKSDB_STATUS_CREATE_NAPI_ERROR_VOID(state->status, "Clear failed")
+					ROCKSDB_STATUS_CREATE_NAPI_ERROR_VOID(state->status, "Clear failed");
 					state->callReject(error);
 				}
 			}
@@ -125,9 +125,9 @@ napi_value Database::Clear(napi_env env, napi_callback_info info) {
 	// Register the async work with the database handle
 	(*dbHandle)->registerAsyncWork();
 
-	NAPI_STATUS_THROWS(::napi_queue_async_work(env, state->asyncWork))
+	NAPI_STATUS_THROWS(::napi_queue_async_work(env, state->asyncWork));
 
-	NAPI_RETURN_UNDEFINED()
+	NAPI_RETURN_UNDEFINED();
 }
 
 /**
@@ -140,15 +140,15 @@ napi_value Database::Clear(napi_env env, napi_callback_info info) {
  * ```
  */
 napi_value Database::ClearSync(napi_env env, napi_callback_info info) {
-	NAPI_METHOD_ARGV(1)
-	UNWRAP_DB_HANDLE_AND_OPEN()
+	NAPI_METHOD_ARGV(1);
+	UNWRAP_DB_HANDLE_AND_OPEN();
 	rocksdb::Status status = (*dbHandle)->clear();
 	if (!status.ok()) {
-		ROCKSDB_STATUS_CREATE_NAPI_ERROR(status, "Clear failed to write batch")
+		ROCKSDB_STATUS_CREATE_NAPI_ERROR(status, "Clear failed to write batch");
 		::napi_throw(env, error);
 		return nullptr;
 	}
-	NAPI_RETURN_UNDEFINED()
+	NAPI_RETURN_UNDEFINED();
 }
 
 /**
@@ -163,18 +163,18 @@ napi_value Database::ClearSync(napi_env env, napi_callback_info info) {
  * ```
  */
 napi_value Database::Close(napi_env env, napi_callback_info info) {
-	NAPI_METHOD()
-	UNWRAP_DB_HANDLE()
+	NAPI_METHOD();
+	UNWRAP_DB_HANDLE();
 
 	if (*dbHandle && (*dbHandle)->descriptor) {
-		DEBUG_LOG("%p Database::Close closing database: %s\n", dbHandle->get(), (*dbHandle)->descriptor->path.c_str())
+		DEBUG_LOG("%p Database::Close closing database: %s\n", dbHandle->get(), (*dbHandle)->descriptor->path.c_str());
 		DBRegistry::CloseDB(*dbHandle);
-		DEBUG_LOG("%p Database::Close closed database\n", dbHandle->get())
+		DEBUG_LOG("%p Database::Close closed database\n", dbHandle->get());
 	} else {
-		DEBUG_LOG("%p Database::Close Database not opened\n", dbHandle->get())
+		DEBUG_LOG("%p Database::Close Database not opened\n", dbHandle->get());
 	}
 
-	NAPI_RETURN_UNDEFINED()
+	NAPI_RETURN_UNDEFINED();
 }
 
 /**
@@ -187,12 +187,12 @@ napi_value Database::Close(napi_env env, napi_callback_info info) {
  * ```
  */
 napi_value Database::FlushSync(napi_env env, napi_callback_info info) {
-	NAPI_METHOD()
-	UNWRAP_DB_HANDLE_AND_OPEN()
+	NAPI_METHOD();
+	UNWRAP_DB_HANDLE_AND_OPEN();
 
-	ROCKSDB_STATUS_THROWS_ERROR_LIKE((*dbHandle)->descriptor->flush(), "Flush failed")
+	ROCKSDB_STATUS_THROWS_ERROR_LIKE((*dbHandle)->descriptor->flush(), "Flush failed");
 
-	NAPI_RETURN_UNDEFINED()
+	NAPI_RETURN_UNDEFINED();
 }
 
 /**
@@ -205,8 +205,8 @@ napi_value Database::FlushSync(napi_env env, napi_callback_info info) {
  * ```
  */
 napi_value Database::Flush(napi_env env, napi_callback_info info) {
-	NAPI_METHOD_ARGV(2)
-	UNWRAP_DB_HANDLE_AND_OPEN()
+	NAPI_METHOD_ARGV(2);
+	UNWRAP_DB_HANDLE_AND_OPEN();
 
 	napi_value resolve = argv[0];
 	napi_value reject = argv[1];
@@ -217,11 +217,11 @@ napi_value Database::Flush(napi_env env, napi_callback_info info) {
 		"database.flush",
 		NAPI_AUTO_LENGTH,
 		&name
-	))
+	));
 
 	auto state = new AsyncFlushState(env, *dbHandle);
-	NAPI_STATUS_THROWS(::napi_create_reference(env, resolve, 1, &state->resolveRef))
-	NAPI_STATUS_THROWS(::napi_create_reference(env, reject, 1, &state->rejectRef))
+	NAPI_STATUS_THROWS(::napi_create_reference(env, resolve, 1, &state->resolveRef));
+	NAPI_STATUS_THROWS(::napi_create_reference(env, reject, 1, &state->rejectRef));
 
 	NAPI_STATUS_THROWS(::napi_create_async_work(
 		env,       // node_env
@@ -246,10 +246,10 @@ napi_value Database::Flush(napi_env env, napi_callback_info info) {
 			if (status != napi_cancelled) {
 				if (state->status.ok()) {
 					napi_value undefined;
-					NAPI_STATUS_THROWS_VOID(::napi_get_undefined(env, &undefined))
+					NAPI_STATUS_THROWS_VOID(::napi_get_undefined(env, &undefined));
 					state->callResolve(undefined);
 				} else {
-					ROCKSDB_STATUS_CREATE_NAPI_ERROR_VOID(state->status, "Flush failed")
+					ROCKSDB_STATUS_CREATE_NAPI_ERROR_VOID(state->status, "Flush failed");
 					state->callReject(error);
 				}
 			}
@@ -258,13 +258,13 @@ napi_value Database::Flush(napi_env env, napi_callback_info info) {
 		},
 		state,
 		&state->asyncWork
-	))
+	));
 
 	(*dbHandle)->registerAsyncWork();
 
-	NAPI_STATUS_THROWS(::napi_queue_async_work(env, state->asyncWork))
+	NAPI_STATUS_THROWS(::napi_queue_async_work(env, state->asyncWork));
 
-	NAPI_RETURN_UNDEFINED()
+	NAPI_RETURN_UNDEFINED();
 }
 
 /**
@@ -284,11 +284,11 @@ napi_value Database::Flush(napi_env env, napi_callback_info info) {
  * ```
  */
 napi_value Database::Get(napi_env env, napi_callback_info info) {
-	NAPI_METHOD_ARGV(4)
-	NAPI_GET_BUFFER(argv[0], key, "Key is required")
+	NAPI_METHOD_ARGV(4);
+	NAPI_GET_BUFFER(argv[0], key, "Key is required");
 	napi_value resolve = argv[1];
 	napi_value reject = argv[2];
-	UNWRAP_DB_HANDLE_AND_OPEN()
+	UNWRAP_DB_HANDLE_AND_OPEN();
 
 	rocksdb::Slice keySlice(key + keyStart, keyEnd - keyStart);
 
@@ -303,7 +303,7 @@ napi_value Database::Get(napi_env env, napi_callback_info info) {
 		if (!txnHandle) {
 			std::string errorMsg = "Get failed: Transaction not found (txnId: " + std::to_string(txnId) + ")";
 			::napi_throw_error(env, nullptr, errorMsg.c_str());
-			NAPI_RETURN_UNDEFINED()
+			NAPI_RETURN_UNDEFINED();
 		}
 		return txnHandle->get(env, keySlice, resolve, reject, *dbHandle);
 	}
@@ -331,12 +331,12 @@ napi_value Database::Get(napi_env env, napi_callback_info info) {
 		"rocksdb-js.get",
 		NAPI_AUTO_LENGTH,
 		&name
-	))
+	));
 
 	readOptions.read_tier = rocksdb::kReadAllTier;
 	auto state = new AsyncGetState<std::shared_ptr<DBHandle>>(env, *dbHandle, readOptions, keySlice);
-	NAPI_STATUS_THROWS(::napi_create_reference(env, resolve, 1, &state->resolveRef))
-	NAPI_STATUS_THROWS(::napi_create_reference(env, reject, 1, &state->rejectRef))
+	NAPI_STATUS_THROWS(::napi_create_reference(env, resolve, 1, &state->resolveRef));
+	NAPI_STATUS_THROWS(::napi_create_reference(env, reject, 1, &state->rejectRef));
 
 	NAPI_STATUS_THROWS(::napi_create_async_work(
 		env,       // node_env
@@ -373,10 +373,10 @@ napi_value Database::Get(napi_env env, napi_callback_info info) {
 		&state->asyncWork // -> result
 	));
 
-	NAPI_STATUS_THROWS(::napi_queue_async_work(env, state->asyncWork))
+	NAPI_STATUS_THROWS(::napi_queue_async_work(env, state->asyncWork));
 
 	napi_value returnStatus;
-	NAPI_STATUS_THROWS(::napi_create_uint32(env, 1, &returnStatus))
+	NAPI_STATUS_THROWS(::napi_create_uint32(env, 1, &returnStatus));
 	return returnStatus;
 }
 
@@ -391,8 +391,8 @@ napi_value Database::Get(napi_env env, napi_callback_info info) {
  * ```
  */
 napi_value Database::GetCount(napi_env env, napi_callback_info info) {
-	NAPI_METHOD_ARGV(2)
-	UNWRAP_DB_HANDLE_AND_OPEN()
+	NAPI_METHOD_ARGV(2);
+	UNWRAP_DB_HANDLE_AND_OPEN();
 
 	DBIteratorOptions itOptions;
 	itOptions.initFromNapiObject(env, argv[0]);
@@ -411,7 +411,7 @@ napi_value Database::GetCount(napi_env env, napi_callback_info info) {
 		if (!txnHandle) {
 			std::string errorMsg = "Get count failed: Transaction not found (txnId: " + std::to_string(txnId) + ")";
 			::napi_throw_error(env, nullptr, errorMsg.c_str());
-			NAPI_RETURN_UNDEFINED()
+			NAPI_RETURN_UNDEFINED();
 		}
 		txnHandle->getCount(itOptions, count, *dbHandle);
 	} else {
@@ -432,20 +432,20 @@ napi_value Database::GetCount(napi_env env, napi_callback_info info) {
 		}
 	}
 
-	DEBUG_LOG("%p Database::GetCount count=%llu\n", dbHandle->get(), count)
+	DEBUG_LOG("%p Database::GetCount count=%llu\n", dbHandle->get(), count);
 
 	napi_value result;
-	NAPI_STATUS_THROWS(::napi_create_int64(env, count, &result))
+	NAPI_STATUS_THROWS(::napi_create_int64(env, count, &result));
 	return result;
 }
 
 napi_value Database::GetMonotonicTimestamp(napi_env env, napi_callback_info info) {
-	NAPI_METHOD()
-	UNWRAP_DB_HANDLE_AND_OPEN()
+	NAPI_METHOD();
+	UNWRAP_DB_HANDLE_AND_OPEN();
 
 	double timestamp = rocksdb_js::getMonotonicTimestamp();
 	napi_value result;
-	NAPI_STATUS_THROWS(::napi_create_double(env, timestamp, &result))
+	NAPI_STATUS_THROWS(::napi_create_double(env, timestamp, &result));
 	return result;
 }
 
@@ -459,8 +459,8 @@ napi_value Database::GetMonotonicTimestamp(napi_env env, napi_callback_info info
  * ```
  */
 napi_value Database::GetOldestSnapshotTimestamp(napi_env env, napi_callback_info info) {
-	NAPI_METHOD()
-	UNWRAP_DB_HANDLE_AND_OPEN()
+	NAPI_METHOD();
+	UNWRAP_DB_HANDLE_AND_OPEN();
 
 	uint64_t timestamp = 0;
 	bool success = (*dbHandle)->descriptor->db->GetIntProperty(
@@ -471,11 +471,11 @@ napi_value Database::GetOldestSnapshotTimestamp(napi_env env, napi_callback_info
 
 	if (!success) {
 		::napi_throw_error(env, nullptr, "Failed to get oldest snapshot timestamp");
-		NAPI_RETURN_UNDEFINED()
+		NAPI_RETURN_UNDEFINED();
 	}
 
 	napi_value result;
-	NAPI_STATUS_THROWS(::napi_create_int64(env, timestamp, &result))
+	NAPI_STATUS_THROWS(::napi_create_int64(env, timestamp, &result));
 	return result;
 }
 
@@ -489,10 +489,10 @@ napi_value Database::GetOldestSnapshotTimestamp(napi_env env, napi_callback_info
  * ```
  */
 napi_value Database::GetDBProperty(napi_env env, napi_callback_info info) {
-	NAPI_METHOD_ARGV(1)
-	UNWRAP_DB_HANDLE_AND_OPEN()
+	NAPI_METHOD_ARGV(1);
+	UNWRAP_DB_HANDLE_AND_OPEN();
 
-	NAPI_GET_STRING(argv[0], propertyName, "Property name is required")
+	NAPI_GET_STRING(argv[0], propertyName, "Property name is required");
 
 	std::string value;
 	bool success = (*dbHandle)->descriptor->db->GetProperty(
@@ -503,7 +503,7 @@ napi_value Database::GetDBProperty(napi_env env, napi_callback_info info) {
 
 	if (!success) {
 		::napi_throw_error(env, nullptr, "Failed to get database property");
-		NAPI_RETURN_UNDEFINED()
+		NAPI_RETURN_UNDEFINED();
 	}
 
 	napi_value result;
@@ -512,7 +512,7 @@ napi_value Database::GetDBProperty(napi_env env, napi_callback_info info) {
 		value.c_str(),
 		value.length(),
 		&result
-	))
+	));
 	return result;
 }
 
@@ -526,10 +526,10 @@ napi_value Database::GetDBProperty(napi_env env, napi_callback_info info) {
  * ```
  */
 napi_value Database::GetDBIntProperty(napi_env env, napi_callback_info info) {
-	NAPI_METHOD_ARGV(1)
-	UNWRAP_DB_HANDLE_AND_OPEN()
+	NAPI_METHOD_ARGV(1);
+	UNWRAP_DB_HANDLE_AND_OPEN();
 
-	NAPI_GET_STRING(argv[0], propertyName, "Property name is required")
+	NAPI_GET_STRING(argv[0], propertyName, "Property name is required");
 
 	uint64_t value = 0;
 	bool success = (*dbHandle)->descriptor->db->GetIntProperty(
@@ -540,11 +540,11 @@ napi_value Database::GetDBIntProperty(napi_env env, napi_callback_info info) {
 
 	if (!success) {
 		::napi_throw_error(env, nullptr, "Failed to get database integer property");
-		NAPI_RETURN_UNDEFINED()
+		NAPI_RETURN_UNDEFINED();
 	}
 
 	napi_value result;
-	NAPI_STATUS_THROWS(::napi_create_int64(env, value, &result))
+	NAPI_STATUS_THROWS(::napi_create_int64(env, value, &result));
 	return result;
 }
 
@@ -565,9 +565,9 @@ napi_value Database::GetDBIntProperty(napi_env env, napi_callback_info info) {
  * ```
  */
 napi_value Database::GetSync(napi_env env, napi_callback_info info) {
-	NAPI_METHOD_ARGV(2)
-	NAPI_GET_BUFFER(argv[0], key, "Key is required")
-	UNWRAP_DB_HANDLE_AND_OPEN()
+	NAPI_METHOD_ARGV(2);
+	NAPI_GET_BUFFER(argv[0], key, "Key is required");
+	UNWRAP_DB_HANDLE_AND_OPEN();
 
 	rocksdb::Slice keySlice(key + keyStart, keyEnd - keyStart);
 	std::string value;
@@ -584,7 +584,7 @@ napi_value Database::GetSync(napi_env env, napi_callback_info info) {
 		if (!txnHandle) {
 			std::string errorMsg = "Get sync failed: Transaction not found (txnId: " + std::to_string(txnId) + ")";
 			::napi_throw_error(env, nullptr, errorMsg.c_str());
-			NAPI_RETURN_UNDEFINED()
+			NAPI_RETURN_UNDEFINED();
 		}
 		status = txnHandle->getSync(keySlice, value, *dbHandle);
 	} else {
@@ -597,11 +597,11 @@ napi_value Database::GetSync(napi_env env, napi_callback_info info) {
 	}
 
 	if (status.IsNotFound()) {
-		NAPI_RETURN_UNDEFINED()
+		NAPI_RETURN_UNDEFINED();
 	}
 
 	if (!status.ok()) {
-		ROCKSDB_STATUS_CREATE_NAPI_ERROR(status, "Get failed")
+		ROCKSDB_STATUS_CREATE_NAPI_ERROR(status, "Get failed");
 		::napi_throw(env, error);
 		return nullptr;
 	}
@@ -613,7 +613,7 @@ napi_value Database::GetSync(napi_env env, napi_callback_info info) {
 		value.data(),
 		nullptr,
 		&result
-	))
+	));
 
 	return result;
 }
@@ -622,19 +622,19 @@ napi_value Database::GetSync(napi_env env, napi_callback_info info) {
  * Gets or creates a buffer that an be shared across worker threads.
  */
 napi_value Database::GetUserSharedBuffer(napi_env env, napi_callback_info info) {
-	NAPI_METHOD_ARGV(3)
-	NAPI_GET_BUFFER(argv[0], key, "Key is required")
+	NAPI_METHOD_ARGV(3);
+	NAPI_GET_BUFFER(argv[0], key, "Key is required");
 	std::string keyStr(key + keyStart, keyEnd - keyStart);
-	UNWRAP_DB_HANDLE_AND_OPEN()
+	UNWRAP_DB_HANDLE_AND_OPEN();
 
 	// if we have a callback, add it as a listener
 	napi_ref callbackRef = nullptr;
 	napi_valuetype type;
-	NAPI_STATUS_THROWS(::napi_typeof(env, argv[2], &type))
+	NAPI_STATUS_THROWS(::napi_typeof(env, argv[2], &type));
 	if (type != napi_undefined) {
 		if (type == napi_function) {
-			DEBUG_LOG("Database::GetUserSharedBuffer key start=%u end=%u:\n", keyStart, keyEnd)
-			DEBUG_LOG_KEY_LN(keyStr)
+			DEBUG_LOG("Database::GetUserSharedBuffer key start=%u end=%u:\n", keyStart, keyEnd);
+			DEBUG_LOG_KEY_LN(keyStr);
 			callbackRef = (*dbHandle)->descriptor->addListener(env, keyStr, argv[2], *dbHandle);
 		} else {
 			::napi_throw_error(env, nullptr, "Callback must be a function");
@@ -655,9 +655,9 @@ napi_value Database::GetUserSharedBuffer(napi_env env, napi_callback_info info) 
  * ```
  */
 napi_value Database::HasLock(napi_env env, napi_callback_info info) {
-	NAPI_METHOD_ARGV(1)
-	NAPI_GET_BUFFER(argv[0], key, "Key is required")
-	UNWRAP_DB_HANDLE_AND_OPEN()
+	NAPI_METHOD_ARGV(1);
+	NAPI_GET_BUFFER(argv[0], key, "Key is required");
+	UNWRAP_DB_HANDLE_AND_OPEN();
 
 	std::string keyStr(key + keyStart, keyEnd - keyStart);
 	bool hasLock = (*dbHandle)->descriptor->lockExistsByKey(keyStr);
@@ -667,7 +667,7 @@ napi_value Database::HasLock(napi_env env, napi_callback_info info) {
 		env,
 		hasLock,
 		&result
-	))
+	));
 	return result;
 }
 
@@ -675,11 +675,11 @@ napi_value Database::HasLock(napi_env env, napi_callback_info info) {
  * Checks if the RocksDB database is open.
  */
 napi_value Database::IsOpen(napi_env env, napi_callback_info info) {
-	NAPI_METHOD()
-	UNWRAP_DB_HANDLE()
+	NAPI_METHOD();
+	UNWRAP_DB_HANDLE();
 
 	napi_value result;
-	NAPI_STATUS_THROWS(::napi_get_boolean(env, (*dbHandle)->opened(), &result))
+	NAPI_STATUS_THROWS(::napi_get_boolean(env, (*dbHandle)->opened(), &result));
 	return result;
 }
 
@@ -687,8 +687,8 @@ napi_value Database::IsOpen(napi_env env, napi_callback_info info) {
  * Lists all transaction logs in the database.
  */
 napi_value Database::ListLogs(napi_env env, napi_callback_info info) {
-	NAPI_METHOD()
-	UNWRAP_DB_HANDLE_AND_OPEN()
+	NAPI_METHOD();
+	UNWRAP_DB_HANDLE_AND_OPEN();
 	return (*dbHandle)->descriptor->listTransactionLogStores(env);
 }
 
@@ -696,15 +696,15 @@ napi_value Database::ListLogs(napi_env env, napi_callback_info info) {
  * Opens the RocksDB database. This must be called before any data methods are called.
  */
 napi_value Database::Open(napi_env env, napi_callback_info info) {
-	NAPI_METHOD_ARGV(2)
-	UNWRAP_DB_HANDLE()
+	NAPI_METHOD_ARGV(2);
+	UNWRAP_DB_HANDLE();
 
 	if ((*dbHandle)->opened()) {
 		// already open
-		NAPI_RETURN_UNDEFINED()
+		NAPI_RETURN_UNDEFINED();
 	}
 
-	NAPI_GET_STRING(argv[0], path, "Database path is required")
+	NAPI_GET_STRING(argv[0], path, "Database path is required");
 	const napi_value options = argv[1];
 
 	bool disableWAL = false;
@@ -763,20 +763,20 @@ napi_value Database::Open(napi_env env, napi_callback_info info) {
 	try {
 		(*dbHandle)->open(path, dbHandleOptions);
 	} catch (const std::exception& e) {
-		DEBUG_LOG("%p Database::Open Error: %s\n", dbHandle->get(), e.what())
+		DEBUG_LOG("%p Database::Open Error: %s\n", dbHandle->get(), e.what());
 		::napi_throw_error(env, nullptr, e.what());
 		return nullptr;
 	}
 
-	NAPI_RETURN_UNDEFINED()
+	NAPI_RETURN_UNDEFINED();
 }
 
 /**
  * Purges transaction logs.
  */
 napi_value Database::PurgeLogs(napi_env env, napi_callback_info info) {
-	NAPI_METHOD_ARGV(1)
-	UNWRAP_DB_HANDLE_AND_OPEN()
+	NAPI_METHOD_ARGV(1);
+	UNWRAP_DB_HANDLE_AND_OPEN();
 
 	return (*dbHandle)->descriptor->purgeTransactionLogs(env, argv[0]);
 }
@@ -785,10 +785,10 @@ napi_value Database::PurgeLogs(napi_env env, napi_callback_info info) {
  * Puts a key-value pair into the RocksDB database.
  */
 napi_value Database::PutSync(napi_env env, napi_callback_info info) {
-	NAPI_METHOD_ARGV(3)
-	NAPI_GET_BUFFER(argv[0], key, "Key is required")
-	NAPI_GET_BUFFER(argv[1], value, nullptr)
-	UNWRAP_DB_HANDLE_AND_OPEN()
+	NAPI_METHOD_ARGV(3);
+	NAPI_GET_BUFFER(argv[0], key, "Key is required");
+	NAPI_GET_BUFFER(argv[1], value, nullptr);
+	UNWRAP_DB_HANDLE_AND_OPEN();
 
 	rocksdb::Status status;
 
@@ -798,11 +798,11 @@ napi_value Database::PutSync(napi_env env, napi_callback_info info) {
 	rocksdb::Slice keySlice(key + keyStart, keyEnd - keyStart);
 	rocksdb::Slice valueSlice(value + valueStart, valueEnd - valueStart);
 
-	DEBUG_LOG("%p Database::PutSync key:", dbHandle->get())
-	DEBUG_LOG_KEY_LN(keySlice)
+	DEBUG_LOG("%p Database::PutSync key:", dbHandle->get());
+	DEBUG_LOG_KEY_LN(keySlice);
 
-	DEBUG_LOG("%p Database::PutSync value:", dbHandle->get())
-	DEBUG_LOG_KEY_LN(valueSlice)
+	DEBUG_LOG("%p Database::PutSync value:", dbHandle->get());
+	DEBUG_LOG_KEY_LN(valueSlice);
 
 	if (txnIdType == napi_number) {
 		uint32_t txnId;
@@ -812,7 +812,7 @@ napi_value Database::PutSync(napi_env env, napi_callback_info info) {
 		if (!txnHandle) {
 			std::string errorMsg = "Put sync failed: Transaction not found (txnId: " + std::to_string(txnId) + ")";
 			::napi_throw_error(env, nullptr, errorMsg.c_str());
-			NAPI_RETURN_UNDEFINED()
+			NAPI_RETURN_UNDEFINED();
 		}
 		status = txnHandle->putSync(
 			keySlice,
@@ -831,12 +831,12 @@ napi_value Database::PutSync(napi_env env, napi_callback_info info) {
 	}
 
 	if (!status.ok()) {
-		ROCKSDB_STATUS_CREATE_NAPI_ERROR(status, "Put failed")
+		ROCKSDB_STATUS_CREATE_NAPI_ERROR(status, "Put failed");
 		::napi_throw(env, error);
 		return nullptr;
 	}
 
-	NAPI_RETURN_UNDEFINED()
+	NAPI_RETURN_UNDEFINED();
 }
 
 
@@ -844,9 +844,9 @@ napi_value Database::PutSync(napi_env env, napi_callback_info info) {
  * Removes a key from the RocksDB database.
  */
 napi_value Database::RemoveSync(napi_env env, napi_callback_info info) {
-	NAPI_METHOD_ARGV(2)
-	NAPI_GET_BUFFER(argv[0], key, "Key is required")
-	UNWRAP_DB_HANDLE_AND_OPEN()
+	NAPI_METHOD_ARGV(2);
+	NAPI_GET_BUFFER(argv[0], key, "Key is required");
+	UNWRAP_DB_HANDLE_AND_OPEN();
 
 	rocksdb::Status status;
 
@@ -863,7 +863,7 @@ napi_value Database::RemoveSync(napi_env env, napi_callback_info info) {
 		if (!txnHandle) {
 			std::string errorMsg = "Remove sync failed: Transaction not found (txnId: " + std::to_string(txnId) + ")";
 			::napi_throw_error(env, nullptr, errorMsg.c_str());
-			NAPI_RETURN_UNDEFINED()
+			NAPI_RETURN_UNDEFINED();
 		}
 		status = txnHandle->removeSync(keySlice, *dbHandle);
 	} else {
@@ -877,12 +877,12 @@ napi_value Database::RemoveSync(napi_env env, napi_callback_info info) {
 	}
 
 	if (!status.ok()) {
-		ROCKSDB_STATUS_CREATE_NAPI_ERROR(status, "Remove failed")
+		ROCKSDB_STATUS_CREATE_NAPI_ERROR(status, "Remove failed");
 		::napi_throw(env, error);
 		return nullptr;
 	}
 
-	NAPI_RETURN_UNDEFINED()
+	NAPI_RETURN_UNDEFINED();
 }
 
 /**
@@ -903,9 +903,9 @@ napi_value Database::RemoveSync(napi_env env, napi_callback_info info) {
  * ```
  */
 napi_value Database::TryLock(napi_env env, napi_callback_info info) {
-	NAPI_METHOD_ARGV(2)
-	NAPI_GET_BUFFER(argv[0], key, "Key is required")
-	UNWRAP_DB_HANDLE_AND_OPEN()
+	NAPI_METHOD_ARGV(2);
+	NAPI_GET_BUFFER(argv[0], key, "Key is required");
+	UNWRAP_DB_HANDLE_AND_OPEN();
 
 	napi_value result;
 	std::string keyStr(key + keyStart, keyEnd - keyStart);
@@ -921,7 +921,7 @@ napi_value Database::TryLock(napi_env env, napi_callback_info info) {
 		&isNewLock // [out] isNewLock
 	);
 
-	NAPI_STATUS_THROWS(::napi_get_boolean(env, isNewLock, &result))
+	NAPI_STATUS_THROWS(::napi_get_boolean(env, isNewLock, &result));
 	return result;
 }
 
@@ -944,14 +944,14 @@ napi_value Database::TryLock(napi_env env, napi_callback_info info) {
  * ```
  */
 napi_value Database::Unlock(napi_env env, napi_callback_info info) {
-	NAPI_METHOD_ARGV(1)
-	NAPI_GET_BUFFER(argv[0], key, "Key is required")
-	UNWRAP_DB_HANDLE_AND_OPEN()
+	NAPI_METHOD_ARGV(1);
+	NAPI_GET_BUFFER(argv[0], key, "Key is required");
+	UNWRAP_DB_HANDLE_AND_OPEN();
 
 	napi_value result;
 	std::string keyStr(key + keyStart, keyEnd - keyStart);
 	bool unlocked = (*dbHandle)->descriptor->lockReleaseByKey(keyStr);
-	NAPI_STATUS_THROWS(::napi_get_boolean(env, unlocked, &result))
+	NAPI_STATUS_THROWS(::napi_get_boolean(env, unlocked, &result));
 	return result;
 }
 
@@ -959,9 +959,9 @@ napi_value Database::Unlock(napi_env env, napi_callback_info info) {
  * Get or create a transaction log.
  */
 napi_value Database::UseLog(napi_env env, napi_callback_info info) {
-	NAPI_METHOD_ARGV(1)
-	NAPI_GET_STRING(argv[0], name, "Name is required")
-	UNWRAP_DB_HANDLE_AND_OPEN()
+	NAPI_METHOD_ARGV(1);
+	NAPI_GET_STRING(argv[0], name, "Name is required");
+	UNWRAP_DB_HANDLE_AND_OPEN();
 
 	return (*dbHandle)->useLog(env, jsThis, name);
 }
@@ -970,30 +970,30 @@ napi_value Database::UseLog(napi_env env, napi_callback_info info) {
  * Mutually exclusive execution of a function across threads for a given key.
  */
 napi_value Database::WithLock(napi_env env, napi_callback_info info) {
-	NAPI_METHOD_ARGV(2)
-	NAPI_GET_BUFFER(argv[0], key, "Key is required")
+	NAPI_METHOD_ARGV(2);
+	NAPI_GET_BUFFER(argv[0], key, "Key is required");
 
 	// Create a promise first, then check if database is open
 	napi_deferred deferred;
 	napi_value promise;
-	NAPI_STATUS_THROWS(::napi_create_promise(env, &deferred, &promise))
+	NAPI_STATUS_THROWS(::napi_create_promise(env, &deferred, &promise));
 
 	// Check if database is open
 	std::shared_ptr<DBHandle>* dbHandle = nullptr;
-	NAPI_STATUS_THROWS(::napi_unwrap(env, jsThis, reinterpret_cast<void**>(&dbHandle)))
+	NAPI_STATUS_THROWS(::napi_unwrap(env, jsThis, reinterpret_cast<void**>(&dbHandle)));
 	if (dbHandle == nullptr || !(*dbHandle)->opened()) {
 		napi_value error;
-		napi_create_string_utf8(env, "Database not open", NAPI_AUTO_LENGTH, &error);
-		napi_reject_deferred(env, deferred, error);
+		NAPI_STATUS_THROWS(::napi_create_string_utf8(env, "Database not open", NAPI_AUTO_LENGTH, &error));
+		NAPI_STATUS_THROWS(::napi_reject_deferred(env, deferred, error));
 		return promise;
 	}
 
 	napi_valuetype type;
-	NAPI_STATUS_THROWS(::napi_typeof(env, argv[1], &type))
+	NAPI_STATUS_THROWS(::napi_typeof(env, argv[1], &type));
 	if (type != napi_function) {
 		napi_value error;
-		napi_create_string_utf8(env, "Callback must be a function", NAPI_AUTO_LENGTH, &error);
-		napi_reject_deferred(env, deferred, error);
+		NAPI_STATUS_THROWS(::napi_create_string_utf8(env, "Callback must be a function", NAPI_AUTO_LENGTH, &error));
+		NAPI_STATUS_THROWS(::napi_reject_deferred(env, deferred, error));
 		return promise;
 	}
 
@@ -1042,7 +1042,7 @@ void Database::Init(napi_env env, napi_value exports) {
 	constexpr size_t len = sizeof("Database") - 1;
 
 	napi_ref exportsRef;
-	NAPI_STATUS_THROWS_VOID(::napi_create_reference(env, exports, 1, &exportsRef))
+	NAPI_STATUS_THROWS_VOID(::napi_create_reference(env, exports, 1, &exportsRef));
 
 	napi_value ctor;
 	NAPI_STATUS_THROWS_VOID(::napi_define_class(
@@ -1054,9 +1054,9 @@ void Database::Init(napi_env env, napi_value exports) {
 		sizeof(properties) / sizeof(napi_property_descriptor), // number of properties
 		properties,                          // properties array
 		&ctor                                // [out] constructor
-	))
+	));
 
-	NAPI_STATUS_THROWS_VOID(::napi_set_named_property(env, exports, className, ctor))
+	NAPI_STATUS_THROWS_VOID(::napi_set_named_property(env, exports, className, ctor));
 }
 
 /**
@@ -1071,16 +1071,16 @@ napi_value resolveGetSyncResult(
 	napi_value reject
 ) {
 	napi_value global;
-	NAPI_STATUS_THROWS(::napi_get_global(env, &global))
+	NAPI_STATUS_THROWS(::napi_get_global(env, &global));
 
 	napi_value result;
 
 	if (status.IsNotFound()) {
 		napi_get_undefined(env, &result);
-		NAPI_STATUS_THROWS(::napi_call_function(env, global, resolve, 1, &result, nullptr))
+		NAPI_STATUS_THROWS(::napi_call_function(env, global, resolve, 1, &result, nullptr));
 	} else if (!status.ok()) {
-		ROCKSDB_STATUS_CREATE_NAPI_ERROR(status, errorMsg)
-		NAPI_STATUS_THROWS(::napi_call_function(env, global, reject, 1, &error, nullptr))
+		ROCKSDB_STATUS_CREATE_NAPI_ERROR(status, errorMsg);
+		NAPI_STATUS_THROWS(::napi_call_function(env, global, reject, 1, &error, nullptr));
 	} else {
 		// TODO: when in "fast" mode, use the shared buffer
 		NAPI_STATUS_THROWS(::napi_create_buffer_copy(
@@ -1089,12 +1089,12 @@ napi_value resolveGetSyncResult(
 			value.data(),
 			nullptr,
 			&result
-		))
-		NAPI_STATUS_THROWS(::napi_call_function(env, global, resolve, 1, &result, nullptr))
+		));
+		NAPI_STATUS_THROWS(::napi_call_function(env, global, resolve, 1, &result, nullptr));
 	}
 
 	napi_value returnStatus;
-	NAPI_STATUS_THROWS(::napi_create_uint32(env, 0, &returnStatus))
+	NAPI_STATUS_THROWS(::napi_create_uint32(env, 0, &returnStatus));
 	return returnStatus;
 }
 

--- a/src/binding/database.h
+++ b/src/binding/database.h
@@ -15,11 +15,13 @@ namespace rocksdb_js {
 	NAPI_STATUS_THROWS(::napi_unwrap(env, jsThis, reinterpret_cast<void**>(&dbHandle)))
 
 #define UNWRAP_DB_HANDLE_AND_OPEN() \
-	UNWRAP_DB_HANDLE() \
-	if (dbHandle == nullptr || !(*dbHandle)->opened()) { \
-		::napi_throw_error(env, nullptr, "Database not open"); \
-		NAPI_RETURN_UNDEFINED() \
-	}
+	UNWRAP_DB_HANDLE(); \
+	do { \
+		if (dbHandle == nullptr || !(*dbHandle)->opened()) { \
+			::napi_throw_error(env, nullptr, "Database not open"); \
+			NAPI_RETURN_UNDEFINED(); \
+		} \
+	} while (0)
 
 /**
  * The `NativeDatabase` JavaScript class implementation.
@@ -126,7 +128,7 @@ void resolveGetResult(
 	AsyncGetState<T>* state
 ) {
 	napi_value global;
-	NAPI_STATUS_THROWS_VOID(::napi_get_global(env, &global))
+	NAPI_STATUS_THROWS_VOID(::napi_get_global(env, &global));
 
 	if (state->status.IsNotFound() || state->status.ok()) {
 		napi_value result;
@@ -134,12 +136,12 @@ void resolveGetResult(
 			napi_get_undefined(env, &result);
 		} else {
 			// TODO: when in "fast" mode, use the shared buffer
-			NAPI_STATUS_THROWS_VOID(::napi_create_buffer_copy(env, state->value.size(), state->value.data(), nullptr, &result))
+			NAPI_STATUS_THROWS_VOID(::napi_create_buffer_copy(env, state->value.size(), state->value.data(), nullptr, &result));
 		}
 
 		state->callResolve(result);
 	} else {
-		ROCKSDB_STATUS_CREATE_NAPI_ERROR_VOID(state->status, "Get failed")
+		ROCKSDB_STATUS_CREATE_NAPI_ERROR_VOID(state->status, "Get failed");
 		state->callReject(error);
 	}
 }

--- a/src/binding/database_events.cpp
+++ b/src/binding/database_events.cpp
@@ -17,11 +17,11 @@ namespace rocksdb_js {
  * ```
  */
 napi_value Database::AddListener(napi_env env, napi_callback_info info) {
-	NAPI_METHOD_ARGV(2)
-	NAPI_GET_STRING(argv[0], key, "Event is required")
-	UNWRAP_DB_HANDLE_AND_OPEN()
+	NAPI_METHOD_ARGV(2);
+	NAPI_GET_STRING(argv[0], key, "Event is required");
+	UNWRAP_DB_HANDLE_AND_OPEN();
 	(*dbHandle)->addListener(env, key, argv[1]);
-	NAPI_RETURN_UNDEFINED()
+	NAPI_RETURN_UNDEFINED();
 }
 
 /**
@@ -39,19 +39,19 @@ napi_value Database::AddListener(napi_env env, napi_callback_info info) {
  * ```
  */
 napi_value Database::Notify(napi_env env, napi_callback_info info) {
-	NAPI_METHOD_ARGV(2)
-	NAPI_GET_STRING(argv[0], key, "Event is required")
-	UNWRAP_DB_HANDLE_AND_OPEN()
+	NAPI_METHOD_ARGV(2);
+	NAPI_GET_STRING(argv[0], key, "Event is required");
+	UNWRAP_DB_HANDLE_AND_OPEN();
 	napi_value result;
 	DEBUG_LOG("Database::Notify calling notify env=%p args=%p\n", env, argv[1]);
 	ListenerData* data = nullptr;
 
 	// need to serialize the args to a string
 	bool isArray = false;
-	NAPI_STATUS_THROWS(::napi_is_array(env, argv[1], &isArray))
+	NAPI_STATUS_THROWS(::napi_is_array(env, argv[1], &isArray));
 	if (isArray) {
 		uint32_t argc = 0;
-		NAPI_STATUS_THROWS(::napi_get_array_length(env, argv[1], &argc))
+		NAPI_STATUS_THROWS(::napi_get_array_length(env, argv[1], &argc));
 		if (argc > 0) {
 			napi_value global;
 			napi_value json;
@@ -89,9 +89,9 @@ napi_value Database::Notify(napi_env env, napi_callback_info info) {
  * ```
  */
 napi_value Database::Listeners(napi_env env, napi_callback_info info) {
-	NAPI_METHOD_ARGV(1)
-	NAPI_GET_STRING(argv[0], key, "Event is required")
-	UNWRAP_DB_HANDLE_AND_OPEN()
+	NAPI_METHOD_ARGV(1);
+	NAPI_GET_STRING(argv[0], key, "Event is required");
+	UNWRAP_DB_HANDLE_AND_OPEN();
 	return (*dbHandle)->descriptor->listeners(env, key);
 }
 
@@ -107,9 +107,9 @@ napi_value Database::Listeners(napi_env env, napi_callback_info info) {
  * ```
  */
 napi_value Database::RemoveListener(napi_env env, napi_callback_info info) {
-	NAPI_METHOD_ARGV(2)
-	NAPI_GET_STRING(argv[0], key, "Event is required")
-	UNWRAP_DB_HANDLE_AND_OPEN()
+	NAPI_METHOD_ARGV(2);
+	NAPI_GET_STRING(argv[0], key, "Event is required");
+	UNWRAP_DB_HANDLE_AND_OPEN();
 	return (*dbHandle)->descriptor->removeListener(env, key, argv[1]);
 }
 

--- a/src/binding/db_descriptor.cpp
+++ b/src/binding/db_descriptor.cpp
@@ -47,7 +47,7 @@ public:
 			tracker.flushedSequence = flushedSequence;
 			this->jobTrackers[flush_info.job_id] = tracker;
 			DEBUG_LOG("%p TransactionLogEventListener::OnFlushBegin flushedSequence=%llu\n",
-				desc.get(), (unsigned long long)flushedSequence)
+				desc.get(), (unsigned long long)flushedSequence);
 
 			std::lock_guard<std::mutex> lock(desc->transactionLogMutex);
 			for (auto& [name, store] : desc->transactionLogStores) {
@@ -79,7 +79,7 @@ public:
 		auto it = this->jobTrackers.find(flush_info.job_id);
 		if (it == this->jobTrackers.end()) {
 			DEBUG_LOG("%p TransactionLogEventListener::OnFlushCompleted unable to find job id=%d\n",
-				desc.get(), flush_info.job_id)
+				desc.get(), flush_info.job_id);
 		} else {
 			// we find the highest sequence number; this represents the overall sequence
 			// number for the flush job
@@ -131,13 +131,13 @@ DBDescriptor::DBDescriptor(
  */
 DBDescriptor::~DBDescriptor() {
 	DEBUG_LOG("%p DBDescriptor::~DBDescriptor Closing \"%s\" (closables=%zu columns=%zu transactions=%zu transactionLogStores=%zu)\n",
-		this, this->path.c_str(), this->closables.size(), this->columns.size(), this->transactions.size(), this->transactionLogStores.size())
+		this, this->path.c_str(), this->closables.size(), this->columns.size(), this->transactions.size(), this->transactionLogStores.size());
 
 	std::unique_lock<std::mutex> txnsLock(this->txnsMutex);
 
 	while (!this->closables.empty()) {
 		Closable* handle = *this->closables.begin();
-		DEBUG_LOG("%p DBDescriptor::~DBDescriptor Closing closable %p\n", this, handle)
+		DEBUG_LOG("%p DBDescriptor::~DBDescriptor Closing closable %p\n", this, handle);
 		this->closables.erase(handle);
 
 		// release the mutex before calling close() to avoid a deadlock
@@ -148,9 +148,9 @@ DBDescriptor::~DBDescriptor() {
 
 	if (!this->transactionLogStores.empty()) {
 		std::lock_guard<std::mutex> logLock(this->transactionLogMutex);
-		DEBUG_LOG("%p DBDescriptor::~DBDescriptor Closing transaction log stores (size=%zu)\n", this, this->transactionLogStores.size())
+		DEBUG_LOG("%p DBDescriptor::~DBDescriptor Closing transaction log stores (size=%zu)\n", this, this->transactionLogStores.size());
 		for (auto& [name, transactionLogStore] : this->transactionLogStores) {
-			DEBUG_LOG("%p DBDescriptor::~DBDescriptor Closing transaction log store \"%s\"\n", this, name.c_str())
+			DEBUG_LOG("%p DBDescriptor::~DBDescriptor Closing transaction log store \"%s\"\n", this, name.c_str());
 			transactionLogStore->close();
 		}
 		this->transactionLogStores.clear();
@@ -164,12 +164,12 @@ DBDescriptor::~DBDescriptor() {
 void DBDescriptor::close() {
 	// check if already closing
 	if (this->closing.exchange(true)) {
-		DEBUG_LOG("%p DBDescriptor::close Already closing \"%s\"\n", this, this->path.c_str())
+		DEBUG_LOG("%p DBDescriptor::close Already closing \"%s\"\n", this, this->path.c_str());
 		return;
 	}
 
 	DEBUG_LOG("%p DBDescriptor::close Closing \"%s\" (closables=%zu columns=%zu transactions=%zu transactionLogStores=%zu)\n",
-		this, this->path.c_str(), this->closables.size(), this->columns.size(), this->transactions.size(), this->transactionLogStores.size())
+		this, this->path.c_str(), this->closables.size(), this->columns.size(), this->transactions.size(), this->transactionLogStores.size());
 
 	// We want to ensure that all in-memory data is written to disk
 	this->flush();
@@ -224,8 +224,8 @@ void DBDescriptor::lockCall(
 	);
 
 	if (!isNewLock) {
-		DEBUG_LOG("%p DBDescriptor::lockCall callback queued for key:", this)
-		DEBUG_LOG_KEY_LN(key)
+		DEBUG_LOG("%p DBDescriptor::lockCall callback queued for key:", this);
+		DEBUG_LOG_KEY_LN(key);
 		return;
 	}
 
@@ -234,8 +234,8 @@ void DBDescriptor::lockCall(
 	auto lockHandle = this->locks.find(key);
 
 	if (lockHandle == this->locks.end()) {
-		DEBUG_LOG("%p DBDescriptor::lockCall no lock found for key:", this)
-		DEBUG_LOG_KEY_LN(key)
+		DEBUG_LOG("%p DBDescriptor::lockCall no lock found for key:", this);
+		DEBUG_LOG_KEY_LN(key);
 		return;
 	}
 
@@ -245,16 +245,16 @@ void DBDescriptor::lockCall(
 	bool expected = false;
 	if (!handle->isRunning.compare_exchange_strong(expected, true)) {
 		// another callback is already running
-		DEBUG_LOG("%p DBDescriptor::lockCall another callback is already running for key:", this)
-		DEBUG_LOG_KEY_LN(key)
+		DEBUG_LOG("%p DBDescriptor::lockCall another callback is already running for key:", this);
+		DEBUG_LOG_KEY_LN(key);
 		return;
 	}
 
 	// we now "own" the execution for this key
 	if (handle->threadsafeCallbacks.empty()) {
 		handle->isRunning.store(false);
-		DEBUG_LOG("%p DBDescriptor::lockCall no callbacks left, removing lock for key:", this)
-		DEBUG_LOG_KEY_LN(key)
+		DEBUG_LOG("%p DBDescriptor::lockCall no callbacks left, removing lock for key:", this);
+		DEBUG_LOG_KEY_LN(key);
 		// remove the empty lock handle from the map
 		this->locks.erase(key);
 		return;
@@ -269,13 +269,13 @@ void DBDescriptor::lockCall(
 	locksMutex.unlock();
 
 	if (!threadsafeCallback) {
-		DEBUG_LOG("%p DBDescriptor::lockCall threadsafe lock callback is null for key:", this)
-		DEBUG_LOG_KEY_LN(key)
+		DEBUG_LOG("%p DBDescriptor::lockCall threadsafe lock callback is null for key:", this);
+		DEBUG_LOG_KEY_LN(key);
 		return;
 	}
 
-	DEBUG_LOG("%p DBDescriptor::lockCall calling callback for key:", this)
-	DEBUG_LOG_KEY_LN(key)
+	DEBUG_LOG("%p DBDescriptor::lockCall calling callback for key:", this);
+	DEBUG_LOG_KEY_LN(key);
 
 	// create callback data that includes the key for completion and deferred promise
 	auto* callbackData = new LockCallbackCompletionData(key, weak_from_this(), lockCallback.deferred);
@@ -311,25 +311,25 @@ void DBDescriptor::lockEnqueueCallback(
 
 	if (lockHandleIterator == this->locks.end()) {
 		// no lock found
-		DEBUG_LOG("%p DBDescriptor::lockEnqueueCallback no lock found for key:", this)
-		DEBUG_LOG_KEY_LN(key)
+		DEBUG_LOG("%p DBDescriptor::lockEnqueueCallback no lock found for key:", this);
+		DEBUG_LOG_KEY_LN(key);
 		lockHandle = std::make_shared<LockHandle>(owner, env);
 		this->locks.emplace(key, lockHandle);
 		if (isNewLock != nullptr) {
 			*isNewLock = true;
 		}
 		if (skipEnqueueIfNewLock) {
-			DEBUG_LOG("%p DBDescriptor::lockEnqueueCallback skipping enqueue because lock already exists\n", this)
+			DEBUG_LOG("%p DBDescriptor::lockEnqueueCallback skipping enqueue because lock already exists\n", this);
 			return;
 		}
 	} else {
-		DEBUG_LOG("%p DBDescriptor::lockEnqueueCallback lock found for key %s\n", this, key.c_str())
+		DEBUG_LOG("%p DBDescriptor::lockEnqueueCallback lock found for key %s\n", this, key.c_str());
 		lockHandle = lockHandleIterator->second;
 	}
 
 	// lock found
 	napi_valuetype type;
-	NAPI_STATUS_THROWS_VOID(::napi_typeof(env, callback, &type))
+	NAPI_STATUS_THROWS_VOID(::napi_typeof(env, callback, &type));
 	if (type == napi_function) {
 		napi_value resource_name;
 		NAPI_STATUS_THROWS_VOID(::napi_create_string_latin1(
@@ -337,7 +337,7 @@ void DBDescriptor::lockEnqueueCallback(
 			"rocksdb-js.lock",
 			NAPI_AUTO_LENGTH,
 			&resource_name
-		))
+		));
 
 		napi_threadsafe_function threadsafeCallback;
 		NAPI_STATUS_THROWS_VOID(::napi_create_threadsafe_function(
@@ -352,10 +352,10 @@ void DBDescriptor::lockEnqueueCallback(
 			nullptr,            // context
 			callJsCallback,     // call_js_cb
 			&threadsafeCallback // [out] callback
-		))
+		));
 
-		DEBUG_LOG("%p DBDescriptor::lockEnqueueCallback enqueuing callback %p\n", this, threadsafeCallback)
-		NAPI_STATUS_THROWS_VOID(::napi_unref_threadsafe_function(env, threadsafeCallback))
+		DEBUG_LOG("%p DBDescriptor::lockEnqueueCallback enqueuing callback %p\n", this, threadsafeCallback);
+		NAPI_STATUS_THROWS_VOID(::napi_unref_threadsafe_function(env, threadsafeCallback));
 
 		// Create LockCallback and add to queue
 		lockHandle->threadsafeCallbacks.push(LockCallback(threadsafeCallback, deferred));
@@ -369,7 +369,7 @@ bool DBDescriptor::lockExistsByKey(std::string& key) {
 	std::lock_guard<std::mutex> lock(this->locksMutex);
 	auto lockHandle = this->locks.find(key);
 	bool exists = lockHandle != this->locks.end();
-	DEBUG_LOG("%p DBDescriptor::hasLock %s lock for key \"%s\"\n", this, exists ? "found" : "not found", key.c_str())
+	DEBUG_LOG("%p DBDescriptor::hasLock %s lock for key \"%s\"\n", this, exists ? "found" : "not found", key.c_str());
 	return exists;
 }
 
@@ -385,23 +385,23 @@ bool DBDescriptor::lockReleaseByKey(std::string& key) {
 
 		if (lockHandle == this->locks.end()) {
 			// no lock found
-			DEBUG_LOG("%p DBDescriptor::lockReleaseByKey no lock found\n", this)
+			DEBUG_LOG("%p DBDescriptor::lockReleaseByKey no lock found\n", this);
 			return false;
 		}
 
 		// lock found, remove it
 		threadsafeCallbacks = std::move(lockHandle->second->threadsafeCallbacks);
-		DEBUG_LOG("%p DBDescriptor::lockReleaseByKey removing lock\n", this)
+		DEBUG_LOG("%p DBDescriptor::lockReleaseByKey removing lock\n", this);
 		this->locks.erase(key);
 	}
 
-	DEBUG_LOG("%p DBDescriptor::lockReleaseByKey calling %zu unlock callbacks\n", this, threadsafeCallbacks.size())
+	DEBUG_LOG("%p DBDescriptor::lockReleaseByKey calling %zu unlock callbacks\n", this, threadsafeCallbacks.size());
 
 	// call the callbacks in order, but stop if any callback fails
 	while (!threadsafeCallbacks.empty()) {
 		auto lockCallback = threadsafeCallbacks.front();
 		threadsafeCallbacks.pop();
-		DEBUG_LOG("%p DBDescriptor::lockReleaseByKey calling callback %p\n", this, lockCallback.callback)
+		DEBUG_LOG("%p DBDescriptor::lockReleaseByKey calling callback %p\n", this, lockCallback.callback);
 		napi_status status = ::napi_call_threadsafe_function(lockCallback.callback, nullptr, napi_tsfn_blocking);
 		if (status == napi_closing) {
 			continue;
@@ -420,11 +420,11 @@ void DBDescriptor::lockReleaseByOwner(DBHandle* owner) {
 
 	{
 		std::lock_guard<std::mutex> lock(this->locksMutex);
-			DEBUG_LOG("%p DBDescriptor::lockReleaseByOwner checking %zu locks if they are owned handle %p\n", this, this->locks.size(), owner)
+			DEBUG_LOG("%p DBDescriptor::lockReleaseByOwner checking %zu locks if they are owned handle %p\n", this, this->locks.size(), owner);
 		for (auto it = this->locks.begin(); it != this->locks.end();) {
 			auto lockOwner = it->second->owner.lock();
 			if (!lockOwner || lockOwner.get() == owner) {
-				DEBUG_LOG("%p DBDescriptor::lockReleaseByOwner found lock %p with %zu callbacks\n", this, it->second.get(), it->second->threadsafeCallbacks.size())
+				DEBUG_LOG("%p DBDescriptor::lockReleaseByOwner found lock %p with %zu callbacks\n", this, it->second.get(), it->second->threadsafeCallbacks.size());
 				// move all callbacks from the queue
 				while (!it->second->threadsafeCallbacks.empty()) {
 					threadsafeCallbacks.insert(it->second->threadsafeCallbacks.front().callback);
@@ -437,11 +437,11 @@ void DBDescriptor::lockReleaseByOwner(DBHandle* owner) {
 		}
 	}
 
-	DEBUG_LOG("%p DBDescriptor::lockReleaseByOwner calling %zu unlock callbacks\n", this, threadsafeCallbacks.size())
+	DEBUG_LOG("%p DBDescriptor::lockReleaseByOwner calling %zu unlock callbacks\n", this, threadsafeCallbacks.size());
 
 	// call the callbacks in order, but stop if any callback fails
 	for (auto& callback : threadsafeCallbacks) {
-		DEBUG_LOG("%p DBDescriptor::lockReleaseByOwner calling callback %p\n", this, callback)
+		DEBUG_LOG("%p DBDescriptor::lockReleaseByOwner calling callback %p\n", this, callback);
 		napi_status status = ::napi_call_threadsafe_function(callback, nullptr, napi_tsfn_blocking);
 		if (status == napi_closing) {
 			continue;
@@ -455,7 +455,7 @@ void DBDescriptor::lockReleaseByOwner(DBHandle* owner) {
  */
 std::shared_ptr<DBDescriptor> DBDescriptor::open(const std::string& path, const DBOptions& options) {
 	std::string name = options.name.empty() ? "default" : options.name;
-	DEBUG_LOG("DBDescriptor::open Opening \"%s\" (column family: \"%s\")\n", path.c_str(), name.c_str())
+	DEBUG_LOG("DBDescriptor::open Opening \"%s\" (column family: \"%s\")\n", path.c_str(), name.c_str());
 
 	// set or disable the block cache
 	rocksdb::BlockBasedTableOptions tableOptions;
@@ -498,17 +498,17 @@ std::shared_ptr<DBDescriptor> DBDescriptor::open(const std::string& path, const 
 	std::vector<std::string> columnFamilyNames;
 
 	// try to list existing column families
-	DEBUG_LOG("DBDescriptor::open Listing column families for \"%s\"\n", path.c_str())
+	DEBUG_LOG("DBDescriptor::open Listing column families for \"%s\"\n", path.c_str());
 	rocksdb::Status listStatus = rocksdb::DB::ListColumnFamilies(rocksdb::DBOptions(), path, &columnFamilyNames);
 	if (listStatus.ok() && !columnFamilyNames.empty()) {
 		// database exists, use existing column families
 		for (const auto& cfName : columnFamilyNames) {
-			DEBUG_LOG("DBDescriptor::open Opening column family \"%s\"\n", cfName.c_str())
+			DEBUG_LOG("DBDescriptor::open Opening column family \"%s\"\n", cfName.c_str());
 			cfDescriptors.emplace_back(cfName, cfOptions); // Use cfOptions here
 		}
 	} else {
 		// database doesn't exist or no column families found, use default
-		DEBUG_LOG("DBDescriptor::open Database doesn't exist or no column families found, using default\n")
+		DEBUG_LOG("DBDescriptor::open Database doesn't exist or no column families found, using default\n");
 		cfDescriptors = {
 			rocksdb::ColumnFamilyDescriptor(rocksdb::kDefaultColumnFamilyName, cfOptions) // Use cfOptions here
 		};
@@ -524,23 +524,23 @@ std::shared_ptr<DBDescriptor> DBDescriptor::open(const std::string& path, const 
 		txndbOptions.transaction_lock_timeout = 10000;
 
 		rocksdb::TransactionDB* rdb;
-		DEBUG_LOG("DBDescriptor::open Opening pessimistic transaction db for \"%s\"\n", path.c_str())
+		DEBUG_LOG("DBDescriptor::open Opening pessimistic transaction db for \"%s\"\n", path.c_str());
 		rocksdb::Status status = rocksdb::TransactionDB::Open(dbOptions, txndbOptions, path, cfDescriptors, &cfHandles, &rdb);
 		if (!status.ok()) {
-			DEBUG_LOG("DBDescriptor::open Failed to open pessimistic transaction db for \"%s\": %s\n", path.c_str(), status.ToString().c_str())
+			DEBUG_LOG("DBDescriptor::open Failed to open pessimistic transaction db for \"%s\": %s\n", path.c_str(), status.ToString().c_str());
 			throw std::runtime_error(status.ToString().c_str());
 		}
-		DEBUG_LOG("DBDescriptor::open Opened pessimistic transaction db for \"%s\"\n", path.c_str())
+		DEBUG_LOG("DBDescriptor::open Opened pessimistic transaction db for \"%s\"\n", path.c_str());
 		db = std::shared_ptr<rocksdb::DB>(rdb, DBDeleter{});
 	} else {
 		rocksdb::OptimisticTransactionDB* rdb;
-		DEBUG_LOG("DBDescriptor::open Opening optimistic transaction db for \"%s\"\n", path.c_str())
+		DEBUG_LOG("DBDescriptor::open Opening optimistic transaction db for \"%s\"\n", path.c_str());
 		rocksdb::Status status = rocksdb::OptimisticTransactionDB::Open(dbOptions, path, cfDescriptors, &cfHandles, &rdb);
 		if (!status.ok()) {
-			DEBUG_LOG("DBDescriptor::open Failed to open optimistic transaction db for \"%s\": %s\n", path.c_str(), status.ToString().c_str())
+			DEBUG_LOG("DBDescriptor::open Failed to open optimistic transaction db for \"%s\": %s\n", path.c_str(), status.ToString().c_str());
 			throw std::runtime_error(status.ToString().c_str());
 		}
-		DEBUG_LOG("DBDescriptor::open Opened optimistic transaction db for \"%s\"\n", path.c_str())
+		DEBUG_LOG("DBDescriptor::open Opened optimistic transaction db for \"%s\"\n", path.c_str());
 		db = std::shared_ptr<rocksdb::DB>(rdb, DBDeleter{});
 	}
 
@@ -556,7 +556,7 @@ std::shared_ptr<DBDescriptor> DBDescriptor::open(const std::string& path, const 
 		columns[options.name] = rocksdb_js::createRocksDBColumnFamily(db, options.name);
 	}
 
-	DEBUG_LOG("DBDescriptor::open Creating DBDescriptor for \"%s\"\n", path.c_str())
+	DEBUG_LOG("DBDescriptor::open Creating DBDescriptor for \"%s\"\n", path.c_str());
 	auto descriptor = std::shared_ptr<DBDescriptor>(new DBDescriptor(path, options, db, std::move(columns)));
 
 	// set the weak pointer for the event listener
@@ -601,7 +601,7 @@ void DBDescriptor::transactionRemove(std::shared_ptr<TransactionHandle> txnHandl
 	auto it = this->transactions.find(txnHandle->id);
 	if (it != this->transactions.end()) {
 		if (it->second != txnHandle) {
-			DEBUG_LOG("%p DBDescriptor::transactionRemove txnId %u mismatch! expected %p, got %p\n", this, txnHandle->id, it->second.get(), txnHandle.get())
+			DEBUG_LOG("%p DBDescriptor::transactionRemove txnId %u mismatch! expected %p, got %p\n", this, txnHandle->id, it->second.get(), txnHandle.get());
 		}
 		this->transactions.erase(it);
 	}
@@ -636,7 +636,7 @@ void DBDescriptor::onCallbackComplete(const std::string& key) {
 		// builds, so we need to use the `maybe_unused` attribute and this will
 		// be optimized out in release builds
 		[[maybe_unused]] auto msg = e.what();
-		DEBUG_LOG("%p DBDescriptor::onCallbackComplete failed to acquire lock (key=\"%s\"): %s\n", this, key.c_str(), msg)
+		DEBUG_LOG("%p DBDescriptor::onCallbackComplete failed to acquire lock (key=\"%s\"): %s\n", this, key.c_str(), msg);
 		return; // mutex is invalid, descriptor is likely being destroyed
 	}
 
@@ -657,14 +657,14 @@ void DBDescriptor::onCallbackComplete(const std::string& key) {
 		bool expected = false;
 		if (!handle->isRunning.compare_exchange_strong(expected, true)) {
 			// another callback is already running
-			DEBUG_LOG("%p DBDescriptor::onCallbackComplete another callback is already running (key=\"%s\")\n", this, key.c_str())
+			DEBUG_LOG("%p DBDescriptor::onCallbackComplete another callback is already running (key=\"%s\")\n", this, key.c_str());
 			return;
 		}
 
 		// we now "own" the execution for this key
 		if (handle->threadsafeCallbacks.empty()) {
 			handle->isRunning.store(false);
-			DEBUG_LOG("%p DBDescriptor::onCallbackComplete no callbacks left (key=\"%s\"), removing lock\n", this, key.c_str())
+			DEBUG_LOG("%p DBDescriptor::onCallbackComplete no callbacks left (key=\"%s\"), removing lock\n", this, key.c_str());
 			// remove the empty lock handle from the map
 			this->locks.erase(key);
 			return;
@@ -677,7 +677,7 @@ void DBDescriptor::onCallbackComplete(const std::string& key) {
 		// release the mutex before calling the callback to avoid holding locks during callback execution
 		lock.unlock();
 
-		DEBUG_LOG("%p DBDescriptor::onCallbackComplete calling callback %p (key=\"%s\")\n", this, callback, key.c_str())
+		DEBUG_LOG("%p DBDescriptor::onCallbackComplete calling callback %p (key=\"%s\")\n", this, callback, key.c_str());
 
 		// create callback data that includes the key for completion and deferred promise
 		auto* callbackData = new LockCallbackCompletionData(key, weak_from_this(), lockCallback.deferred);
@@ -697,7 +697,7 @@ void DBDescriptor::onCallbackComplete(const std::string& key) {
 		// builds, so we need to use the `maybe_unused` attribute and this will
 		// be optimized out in release builds
 		[[maybe_unused]] auto msg = e.what();
-		DEBUG_LOG("%p DBDescriptor::onCallbackComplete failed to fire next callback (key=\"%s\"): %s\n", this, key.c_str(), msg)
+		DEBUG_LOG("%p DBDescriptor::onCallbackComplete failed to fire next callback (key=\"%s\"): %s\n", this, key.c_str(), msg);
 	}
 }
 
@@ -706,23 +706,26 @@ void DBDescriptor::onCallbackComplete(const std::string& key) {
  */
 #ifdef DEBUG
 	#define CALL_JS_CB_DEBUG_LOG(msg, ...) \
-		{ \
+		do { \
 			std::string errorStr = rocksdb_js::getNapiExtendedError(env, status); \
 			rocksdb_js::debugLog("callJsCallback() " msg ": %s (key=\"%s\")", ##__VA_ARGS__, errorStr.c_str(), callbackData->key.c_str()); \
-		}
+		} while (0)
 #else
-	#define CALL_JS_CB_DEBUG_LOG(msg, ...)
+	#define CALL_JS_CB_DEBUG_LOG(msg, ...) \
+		do { \
+			; \
+		} while (0)
 #endif
 
 #define CALL_JS_CB_NAPI_STATUS_CHECK(call, code, msg, ...) \
-	{ \
+	do { \
 		napi_status status = (call); \
 		if (status != napi_ok) { \
 			CALL_JS_CB_DEBUG_LOG(msg, ##__VA_ARGS__); \
 			code; \
 			return; \
 		} \
-	}
+	} while (0)
 
 /**
  * Custom wrapper used by `napi_call_threadsafe_function()` to call user-
@@ -748,7 +751,7 @@ static void callJsCallback(napi_env env, napi_value jsCallback, void* context, v
 	// get the callback data from the function's data
 	LockCallbackCompletionData* callbackData = static_cast<LockCallbackCompletionData*>(data);
 	if (callbackData == nullptr) {
-		DEBUG_LOG("callJsCallback callbackData is nullptr - calling js callback\n")
+		DEBUG_LOG("callJsCallback callbackData is nullptr - calling js callback\n");
 		// this is a tryLock callback - call it without completion callback
 		napi_value global;
 		napi_status status = ::napi_get_global(env, &global);
@@ -787,14 +790,14 @@ static void callJsCallback(napi_env env, napi_value jsCallback, void* context, v
 					delete callbackData;
 				}
 
-				NAPI_RETURN_UNDEFINED()
+				NAPI_RETURN_UNDEFINED();
 			},
 			callbackData,
 			&completionCallback
 		),
 		delete callbackData,
 		"failed to create completion callback"
-	)
+	);
 
 	// call the original callback without any arguments
 	napi_value global;
@@ -802,10 +805,10 @@ static void callJsCallback(napi_env env, napi_value jsCallback, void* context, v
 		::napi_get_global(env, &global),
 		delete callbackData,
 		"napi_get_global() failed"
-	)
+	);
 
 	napi_value result;
-	DEBUG_LOG("callJsCallback calling js callback (key=\"%s\")\n", callbackData->key.c_str())
+	DEBUG_LOG("callJsCallback calling js callback (key=\"%s\")\n", callbackData->key.c_str());
 	CALL_JS_CB_NAPI_STATUS_CHECK(
 		::napi_call_function(env, global, jsCallback, 0, nullptr, &result),
 		{
@@ -815,7 +818,7 @@ static void callJsCallback(napi_env env, napi_value jsCallback, void* context, v
 			delete callbackData;
 		},
 		"napi_call_function() failed"
-	)
+	);
 
 	// check if the result is a Promise
 	napi_value promiseCtor;
@@ -827,7 +830,7 @@ static void callJsCallback(napi_env env, napi_value jsCallback, void* context, v
 		}
 		delete callbackData,
 		"failed to get Promise constructor"
-	)
+	);
 
 	bool isPromise;
 	CALL_JS_CB_NAPI_STATUS_CHECK(
@@ -838,10 +841,10 @@ static void callJsCallback(napi_env env, napi_value jsCallback, void* context, v
 		}
 		delete callbackData,
 		"napi_instanceof() failed"
-	)
+	);
 
 	if (!isPromise) {
-		DEBUG_LOG("callJsCallback result is not a Promise, completing immediately (key=\"%s\")\n", callbackData->key.c_str())
+		DEBUG_LOG("callJsCallback result is not a Promise, completing immediately (key=\"%s\")\n", callbackData->key.c_str());
 
 		// If this is a withLock call with a deferred promise, resolve it
 		if (callbackData->deferred != nullptr) {
@@ -857,7 +860,7 @@ static void callJsCallback(napi_env env, napi_value jsCallback, void* context, v
 		return;
 	}
 
-	DEBUG_LOG("callJsCallback result is a Promise, attaching .then() callback (key=\"%s\")\n", callbackData->key.c_str())
+	DEBUG_LOG("callJsCallback result is a Promise, attaching .then() callback (key=\"%s\")\n", callbackData->key.c_str());
 
 	// get the 'then' method from the promise
 	napi_value thenMethod;
@@ -868,7 +871,7 @@ static void callJsCallback(napi_env env, napi_value jsCallback, void* context, v
 		}
 		delete callbackData,
 		"failed to get .then() method"
-	)
+	);
 
 	// create resolve and reject callbacks that both complete the lock
 	// we need to store the shared_ptr in a way N-API callbacks can access it
@@ -884,7 +887,7 @@ static void callJsCallback(napi_env env, napi_value jsCallback, void* context, v
 				napi_value result;
 				::napi_get_undefined(env, &result);
 
-				DEBUG_LOG("callJsCallback promise resolve callback\n")
+				DEBUG_LOG("callJsCallback promise resolve callback\n");
 
 				void* data;
 				::napi_get_cb_info(env, info, nullptr, nullptr, nullptr, &data);
@@ -924,7 +927,7 @@ static void callJsCallback(napi_env env, napi_value jsCallback, void* context, v
 			delete resolveDataPtr;
 		},
 		"failed to create resolve callback"
-	)
+	);
 
 	// create reject callback - shared_ptr handles safe sharing between resolve/reject
 	auto* rejectDataPtr = new std::shared_ptr<LockCallbackCompletionData>(callbackDataPtr);
@@ -981,7 +984,7 @@ static void callJsCallback(napi_env env, napi_value jsCallback, void* context, v
 			delete resolveDataPtr;
 		},
 		"failed to create reject callback"
-	)
+	);
 
 	// call `promise.then(resolveCallback, rejectCallback)` for key "key"
 	napi_value thenArgs[] = { resolveCallback, rejectCallback };
@@ -996,7 +999,7 @@ static void callJsCallback(napi_env env, napi_value jsCallback, void* context, v
 			delete rejectDataPtr;
 		},
 		"failed to call .then()"
-	)
+	);
 }
 
 /**
@@ -1008,14 +1011,14 @@ static void userSharedBufferFinalize(napi_env env, void* data, void* hint) {
 	auto* finalizeData = static_cast<UserSharedBufferFinalizeData*>(hint);
 
 	if (auto descriptor = finalizeData->descriptor.lock()) {
-		DEBUG_LOG("%p userSharedBufferFinalize for key:", descriptor.get())
-		DEBUG_LOG_KEY(finalizeData->key)
+		DEBUG_LOG("%p userSharedBufferFinalize for key:", descriptor.get());
+		DEBUG_LOG_KEY(finalizeData->key);
 		DEBUG_LOG_MSG(" (use_count: %ld)\n", finalizeData->sharedData ? finalizeData->sharedData.use_count() : 0);
 
 		if (finalizeData->callbackRef) {
 			napi_value callback;
 			if (::napi_get_reference_value(env, finalizeData->callbackRef, &callback) == napi_ok) {
-				DEBUG_LOG("%p userSharedBufferFinalize removing listener", descriptor.get())
+				DEBUG_LOG("%p userSharedBufferFinalize removing listener", descriptor.get());
 				descriptor->removeListener(env, finalizeData->key, callback);
 			}
 		}
@@ -1030,13 +1033,13 @@ static void userSharedBufferFinalize(napi_env env, void* data, void* hint) {
 			// (map entry + this finalizer's copy = 2, after finalizer exits only map = 1)
 			if (finalizeData->sharedData.use_count() <= 2) {
 				descriptor->userSharedBuffers.erase(key);
-				DEBUG_LOG("%p userSharedBufferFinalize removed user shared buffer for key:", descriptor.get())
-				DEBUG_LOG_KEY_LN(key)
+				DEBUG_LOG("%p userSharedBufferFinalize removed user shared buffer for key:", descriptor.get());
+				DEBUG_LOG_KEY_LN(key);
 			}
 		}
 	} else {
-		DEBUG_LOG("userSharedBufferFinalize descriptor was already destroyed for key:")
-		DEBUG_LOG_KEY_LN(finalizeData->key)
+		DEBUG_LOG("userSharedBufferFinalize descriptor was already destroyed for key:");
+		DEBUG_LOG_KEY_LN(finalizeData->key);
 	}
 
 	delete finalizeData;
@@ -1085,14 +1088,14 @@ napi_value DBDescriptor::getUserSharedBuffer(
 			defaultBuffer,
 			&data,
 			&size
-		))
+		));
 
-		DEBUG_LOG("%p DBDescriptor::getUserSharedBuffer Initializing user shared buffer with default buffer size: %zu\n", this, size)
+		DEBUG_LOG("%p DBDescriptor::getUserSharedBuffer Initializing user shared buffer with default buffer size: %zu\n", this, size);
 		it = this->userSharedBuffers.emplace(key, std::make_shared<UserSharedBufferData>(data, size)).first;
 	}
 
-	DEBUG_LOG("%p DBDescriptor::getUserSharedBuffer Creating external ArrayBuffer with size %zu for key:", this, it->second->size)
-	DEBUG_LOG_KEY_LN(key)
+	DEBUG_LOG("%p DBDescriptor::getUserSharedBuffer Creating external ArrayBuffer with size %zu for key:", this, it->second->size);
+	DEBUG_LOG_KEY_LN(key);
 
 	// create finalize data that holds the key, a weak reference to this
 	// descriptor, and a shared_ptr to keep the data alive
@@ -1106,23 +1109,23 @@ napi_value DBDescriptor::getUserSharedBuffer(
 		userSharedBufferFinalize, // finalize_cb
 		finalizeData,             // finalize_hint
 		&result                   // [out] result
-	))
+	));
 	return result;
 }
 
 #define NAPI_STATUS_THROWS_FREE_DATA(call) \
-	{ \
+	do { \
 		napi_status status = (call); \
 		if (status != napi_ok) { \
 			std::string errorStr = rocksdb_js::getNapiExtendedError(env, status); \
 			::napi_throw_error(env, nullptr, errorStr.c_str()); \
-			DEBUG_LOG("callListenerCallback error: %s\n", errorStr.c_str()) \
+			DEBUG_LOG("callListenerCallback error: %s\n", errorStr.c_str()); \
 			if (listenerData) { \
 				delete listenerData; \
 			} \
 			return; \
 		} \
-	}
+	} while (0)
 
 /**
  * Custom wrapper used by `napi_call_threadsafe_function()` to call user-
@@ -1138,7 +1141,7 @@ static void callListenerCallback(napi_env env, napi_value jsCallback, void* cont
 	napi_value* argv = nullptr;
 	napi_value global;
 
-	NAPI_STATUS_THROWS_FREE_DATA(::napi_get_global(env, &global))
+	NAPI_STATUS_THROWS_FREE_DATA(::napi_get_global(env, &global));
 
 	if (listenerData != nullptr) {
 		// only deserialize the emitted data if it exists
@@ -1146,16 +1149,16 @@ static void callListenerCallback(napi_env env, napi_value jsCallback, void* cont
 		napi_value parse;
 		napi_value jsonString;
 		napi_value arrayArgs;
-		NAPI_STATUS_THROWS_FREE_DATA(::napi_get_named_property(env, global, "JSON", &json))
-		NAPI_STATUS_THROWS_FREE_DATA(::napi_get_named_property(env, json, "parse", &parse))
-		NAPI_STATUS_THROWS_FREE_DATA(::napi_create_string_utf8(env, listenerData->args.c_str(), listenerData->args.length(), &jsonString))
-		NAPI_STATUS_THROWS_FREE_DATA(::napi_call_function(env, json, parse, 1, &jsonString, &arrayArgs))
-		NAPI_STATUS_THROWS_FREE_DATA(::napi_get_array_length(env, arrayArgs, &argc))
+		NAPI_STATUS_THROWS_FREE_DATA(::napi_get_named_property(env, global, "JSON", &json));
+		NAPI_STATUS_THROWS_FREE_DATA(::napi_get_named_property(env, json, "parse", &parse));
+		NAPI_STATUS_THROWS_FREE_DATA(::napi_create_string_utf8(env, listenerData->args.c_str(), listenerData->args.length(), &jsonString));;
+		NAPI_STATUS_THROWS_FREE_DATA(::napi_call_function(env, json, parse, 1, &jsonString, &arrayArgs));
+		NAPI_STATUS_THROWS_FREE_DATA(::napi_get_array_length(env, arrayArgs, &argc));
 
 		// need to convert from a js array to an array of napi values
 		argv = new napi_value[argc];
 		for (uint32_t i = 0; i < argc; i++) {
-			NAPI_STATUS_THROWS_FREE_DATA(::napi_get_element(env, arrayArgs, i, &argv[i]))
+			NAPI_STATUS_THROWS_FREE_DATA(::napi_get_element(env, arrayArgs, i, &argv[i]));
 		}
 
 		delete listenerData;
@@ -1164,7 +1167,7 @@ static void callListenerCallback(napi_env env, napi_value jsCallback, void* cont
 
 	// call the listener
 	napi_value result;
-	NAPI_STATUS_THROWS_FREE_DATA(::napi_call_function(env, global, jsCallback, argc, argv, &result))
+	NAPI_STATUS_THROWS_FREE_DATA(::napi_call_function(env, global, jsCallback, argc, argv, &result));
 }
 
 /**
@@ -1181,7 +1184,7 @@ napi_ref DBDescriptor::addListener(
 	std::weak_ptr<DBHandle> owner
 ) {
 	napi_valuetype type;
-	NAPI_STATUS_THROWS(::napi_typeof(env, callback, &type))
+	NAPI_STATUS_THROWS(::napi_typeof(env, callback, &type));
 	if (type != napi_function) {
 		::napi_throw_error(env, nullptr, "Callback must be a function");
 		return nullptr;
@@ -1193,7 +1196,7 @@ napi_ref DBDescriptor::addListener(
 		"rocksdb-js.listener",
 		NAPI_AUTO_LENGTH,
 		&resource_name
-	))
+	));
 
 	napi_threadsafe_function threadsafeCallback;
 	NAPI_STATUS_THROWS(::napi_create_threadsafe_function(
@@ -1208,9 +1211,9 @@ napi_ref DBDescriptor::addListener(
 		nullptr,              // context
 		callListenerCallback, // call_js_cb
 		&threadsafeCallback   // [out] callback
-	))
+	));
 
-	NAPI_STATUS_THROWS(::napi_unref_threadsafe_function(env, threadsafeCallback))
+	NAPI_STATUS_THROWS(::napi_unref_threadsafe_function(env, threadsafeCallback));
 
 	std::lock_guard<std::mutex> lock(this->listenerCallbacksMutex);
 	auto it = this->listenerCallbacks.find(key);
@@ -1219,12 +1222,12 @@ napi_ref DBDescriptor::addListener(
 	}
 
 	napi_ref callbackRef;
-	NAPI_STATUS_THROWS(::napi_create_reference(env, callback, 1, &callbackRef))
+	NAPI_STATUS_THROWS(::napi_create_reference(env, callback, 1, &callbackRef));
 	it->second.emplace_back(std::make_shared<ListenerCallback>(env, threadsafeCallback, callbackRef, owner));
 
-	DEBUG_LOG("%p DBDescriptor::addListener added listener for key:", this)
+	DEBUG_LOG("%p DBDescriptor::addListener added listener for key:", this);
 	DEBUG_LOG_KEY(key);
-	DEBUG_LOG_MSG(" (listeners=%zu)\n", it->second.size())
+	DEBUG_LOG_MSG(" (listeners=%zu)\n", it->second.size());
 
 	return callbackRef;
 }
@@ -1260,8 +1263,8 @@ bool DBDescriptor::notify(std::string key, ListenerData* data) {
 				delete data;
 			}
 
-			DEBUG_LOG("%p DBDescriptor::notify key has no listeners:", this)
-			DEBUG_LOG_KEY_LN(key)
+			DEBUG_LOG("%p DBDescriptor::notify key has no listeners:", this);
+			DEBUG_LOG_KEY_LN(key);
 
 			return false;
 		}
@@ -1273,8 +1276,8 @@ bool DBDescriptor::notify(std::string key, ListenerData* data) {
 		}
 
 		DEBUG_LOG("%p DBDescriptor::notify calling %zu listener%s for key:",
-			this, listenersToCall.size(), listenersToCall.size() == 1 ? "" : "s")
-		DEBUG_LOG_KEY_LN(key)
+			this, listenersToCall.size(), listenersToCall.size() == 1 ? "" : "s");
+		DEBUG_LOG_KEY_LN(key);
 	}
 
 	for (auto& weakListener : listenersToCall) {
@@ -1311,8 +1314,8 @@ napi_value DBDescriptor::listeners(napi_env env, std::string& key) {
 		count = it->second.size();
 	}
 
-	DEBUG_LOG("%p DBDescriptor::listeners key has %zu listener%s:", this, count, count == 1 ? "" : "s")
-	DEBUG_LOG_KEY_LN(key)
+	DEBUG_LOG("%p DBDescriptor::listeners key has %zu listener%s:", this, count, count == 1 ? "" : "s");
+	DEBUG_LOG_KEY_LN(key);
 
 	napi_value result;
 	NAPI_STATUS_THROWS(::napi_create_uint32(env, static_cast<uint32_t>(count), &result));
@@ -1328,7 +1331,7 @@ napi_value DBDescriptor::listeners(napi_env env, std::string& key) {
  */
 napi_value DBDescriptor::removeListener(napi_env env, std::string& key, napi_value callback) {
 	napi_valuetype type;
-	NAPI_STATUS_THROWS(::napi_typeof(env, callback, &type))
+	NAPI_STATUS_THROWS(::napi_typeof(env, callback, &type));
 	if (type != napi_function) {
 		::napi_throw_error(env, nullptr, "Callback must be a function");
 		return nullptr;
@@ -1346,14 +1349,14 @@ napi_value DBDescriptor::removeListener(napi_env env, std::string& key, napi_val
 			}
 
 			napi_value fn;
-			NAPI_STATUS_THROWS(::napi_get_reference_value((*listener)->env, (*listener)->callbackRef, &fn))
+			NAPI_STATUS_THROWS(::napi_get_reference_value((*listener)->env, (*listener)->callbackRef, &fn));
 			bool isEqual = false;
-			NAPI_STATUS_THROWS(::napi_strict_equals(env, fn, callback, &isEqual))
+			NAPI_STATUS_THROWS(::napi_strict_equals(env, fn, callback, &isEqual));
 			if (isEqual) {
 				listener = it->second.erase(listener);
-				DEBUG_LOG("%p DBDescriptor::removeListener removed listener for key:", this)
+				DEBUG_LOG("%p DBDescriptor::removeListener removed listener for key:", this);
 				DEBUG_LOG_KEY(key);
-				DEBUG_LOG_MSG(" (listeners=%zu)\n", it->second.size())
+				DEBUG_LOG_MSG(" (listeners=%zu)\n", it->second.size());
 				found = true;
 				break;
 			}
@@ -1362,13 +1365,13 @@ napi_value DBDescriptor::removeListener(napi_env env, std::string& key, napi_val
 		}
 
 		if (it->second.empty()) {
-			DEBUG_LOG("%p DBDescriptor::removeListener All listeners removed, removing key:", this)
+			DEBUG_LOG("%p DBDescriptor::removeListener All listeners removed, removing key:", this);
 			DEBUG_LOG_KEY_LN(key);
 			this->listenerCallbacks.erase(it);
 		}
 	} else {
-		DEBUG_LOG("%p DBDescriptor::removeListener No listeners found for key:", this)
-		DEBUG_LOG_KEY_LN(key)
+		DEBUG_LOG("%p DBDescriptor::removeListener No listeners found for key:", this);
+		DEBUG_LOG_KEY_LN(key);
 	}
 
 	napi_value result;
@@ -1384,7 +1387,7 @@ napi_value DBDescriptor::removeListener(napi_env env, std::string& key, napi_val
 void DBDescriptor::removeListenersByOwner(DBHandle* owner) {
 	std::lock_guard<std::mutex> lock(this->listenerCallbacksMutex);
 
-	DEBUG_LOG("%p DBDescriptor::removeListenersByOwner removing listeners for owner %p\n", this, owner)
+	DEBUG_LOG("%p DBDescriptor::removeListenersByOwner removing listeners for owner %p\n", this, owner);
 
 	for (auto keyIt = this->listenerCallbacks.begin(); keyIt != this->listenerCallbacks.end(); ) {
 		auto& listeners = keyIt->second;
@@ -1396,7 +1399,7 @@ void DBDescriptor::removeListenersByOwner(DBHandle* owner) {
 					auto sharedOwner = callback->owner.lock();
 					bool shouldRemove = (sharedOwner.get() == owner) || callback->owner.expired();
 					if (shouldRemove) {
-						DEBUG_LOG("%p DBDescriptor::removeListenersByOwner removing listener", owner)
+						DEBUG_LOG("%p DBDescriptor::removeListenersByOwner removing listener", owner);
 						// note: can't safely log key here as we're in iterator
 					}
 					return shouldRemove;
@@ -1406,7 +1409,7 @@ void DBDescriptor::removeListenersByOwner(DBHandle* owner) {
 
 		// remove the key entirely if no listeners remain
 		if (listeners.empty()) {
-			DEBUG_LOG("%p DBDescriptor::removeListenersByOwner removing empty key\n", this)
+			DEBUG_LOG("%p DBDescriptor::removeListenersByOwner removing empty key\n", this);
 			keyIt = this->listenerCallbacks.erase(keyIt);
 		} else {
 			++keyIt;
@@ -1420,7 +1423,7 @@ void DBDescriptor::removeListenersByOwner(DBHandle* owner) {
  */
 void DBDescriptor::discoverTransactionLogStores() {
 	if (this->transactionLogsPath.empty() || !std::filesystem::exists(this->transactionLogsPath)) {
-		DEBUG_LOG("%p DBDescriptor::discoverTransactionLogStores No transaction logs path set or directory does not exist\n", this)
+		DEBUG_LOG("%p DBDescriptor::discoverTransactionLogStores No transaction logs path set or directory does not exist\n", this);
 		return;
 	}
 
@@ -1452,7 +1455,7 @@ napi_value DBDescriptor::listTransactionLogStores(napi_env env) {
 	std::lock_guard<std::mutex> lock(this->transactionLogMutex);
 	NAPI_STATUS_THROWS(::napi_create_array_with_length(env, this->transactionLogStores.size(), &result));
 
-	DEBUG_LOG("%p DBDescriptor::listTransactionLogStores Returning %u transaction log store names\n", this, this->transactionLogStores.size())
+	DEBUG_LOG("%p DBDescriptor::listTransactionLogStores Returning %u transaction log store names\n", this, this->transactionLogStores.size());
 	for (auto& log : this->transactionLogStores) {
 		napi_value name;
 		NAPI_STATUS_THROWS(::napi_create_string_utf8(env, log.second->name.c_str(), log.second->name.length(), &name));
@@ -1467,13 +1470,13 @@ napi_value DBDescriptor::listTransactionLogStores(napi_env env) {
  */
 napi_value DBDescriptor::purgeTransactionLogs(napi_env env, napi_value options) {
 	bool destroy = false;
-	NAPI_STATUS_THROWS(rocksdb_js::getProperty(env, options, "destroy", destroy))
+	NAPI_STATUS_THROWS(rocksdb_js::getProperty(env, options, "destroy", destroy));
 
 	std::string name;
-	NAPI_STATUS_THROWS(rocksdb_js::getProperty(env, options, "name", name))
+	NAPI_STATUS_THROWS(rocksdb_js::getProperty(env, options, "name", name));
 
 	napi_value removed;
-	NAPI_STATUS_THROWS(::napi_create_array(env, &removed))
+	NAPI_STATUS_THROWS(::napi_create_array(env, &removed));
 
 	size_t i = 0;
 	std::vector<std::shared_ptr<TransactionLogStore>> storesToRemove;
@@ -1501,10 +1504,10 @@ napi_value DBDescriptor::purgeTransactionLogs(napi_env env, napi_value options) 
 			std::filesystem::remove_all(store->path);
 		} catch (const std::filesystem::filesystem_error& e) {
 			DEBUG_LOG("%p DBDescriptor::purgeTransactionLogs Failed to remove log directory %s: %s\n",
-				this, store->path.string().c_str(), e.what())
+				this, store->path.string().c_str(), e.what());
 		} catch (...) {
 			DEBUG_LOG("%p DBDescriptor::purgeTransactionLogs Unknown error removing log directory %s\n",
-				this, store->path.string().c_str())
+				this, store->path.string().c_str());
 		}
 		this->transactionLogStores.erase(store->name);
 	}
@@ -1523,13 +1526,13 @@ std::shared_ptr<TransactionLogStore> DBDescriptor::resolveTransactionLogStore(co
 
 	auto it = this->transactionLogStores.find(name);
 	if (it != this->transactionLogStores.end()) {
-		DEBUG_LOG("%p DBDescriptor::resolveTransactionLogStore Found transaction log store \"%s\"\n", this, name.c_str())
+		DEBUG_LOG("%p DBDescriptor::resolveTransactionLogStore Found transaction log store \"%s\"\n", this, name.c_str());
 		return it->second;
 	}
 
 	auto logDirectory = std::filesystem::path(this->transactionLogsPath) / name;
 	DEBUG_LOG("%p DBDescriptor::resolveTransactionLogStore Creating new transaction log store \"%s\"\n",
-		this, name.c_str())
+		this, name.c_str());
 
 	// ensure the directory exists
 	DEBUG_LOG("%p DBDescriptor::resolveTransactionLogStore Creating directory: %s\n", this, logDirectory.string().c_str());

--- a/src/binding/db_descriptor.h
+++ b/src/binding/db_descriptor.h
@@ -283,7 +283,7 @@ struct LockHandle final {
 		while (!threadsafeCallbacks.empty()) {
 			LockCallback lockCallback = threadsafeCallbacks.front();
 			threadsafeCallbacks.pop();
-			::napi_release_threadsafe_function(lockCallback.callback, napi_tsfn_release);
+			NAPI_STATUS_THROWS_VOID(::napi_release_threadsafe_function(lockCallback.callback, napi_tsfn_release));
 		}
 	}
 
@@ -425,13 +425,13 @@ struct ListenerCallback final {
 
 	~ListenerCallback() {
 		DEBUG_LOG("%p ListenerCallback::~ListenerCallback callbackRef=%p, threadsafeCallback=%p\n",
-			this, this->callbackRef, this->threadsafeCallback)
+			this, this->callbackRef, this->threadsafeCallback);
 		this->release();
 	}
 
 	void release() {
 		DEBUG_LOG("%p ListenerCallback::release callbackRef=%p, threadsafeCallback=%p\n",
-			this, this->callbackRef, this->threadsafeCallback)
+			this, this->callbackRef, this->threadsafeCallback);
 
 		if (this->callbackRef && this->env) {
 			::napi_delete_reference(this->env, this->callbackRef);

--- a/src/binding/db_iterator_handle.cpp
+++ b/src/binding/db_iterator_handle.cpp
@@ -14,7 +14,7 @@ DBIteratorHandle::DBIteratorHandle(
 	reverse(options.reverse),
 	values(options.values)
 {
-	DEBUG_LOG("%p DBIteratorHandle::Constructor dbHandle=%p\n", this, dbHandle.get())
+	DEBUG_LOG("%p DBIteratorHandle::Constructor dbHandle=%p\n", this, dbHandle.get());
 	this->init(options);
 
 	this->iterator = std::unique_ptr<rocksdb::Iterator>(
@@ -37,7 +37,7 @@ DBIteratorHandle::DBIteratorHandle(
 	reverse(options.reverse),
 	values(options.values)
 {
-	DEBUG_LOG("DBIteratorHandle::Constructor txnHandle=%p dbDescriptor=%p\n", txnHandle, dbHandle->descriptor.get())
+	DEBUG_LOG("DBIteratorHandle::Constructor txnHandle=%p dbDescriptor=%p\n", txnHandle, dbHandle->descriptor.get());
 	this->init(options);
 
 	this->iterator = std::unique_ptr<rocksdb::Iterator>(
@@ -55,7 +55,7 @@ DBIteratorHandle::~DBIteratorHandle() {
 }
 
 void DBIteratorHandle::close() {
-	DEBUG_LOG("%p DBIteratorHandle::close dbHandle=%p dbDescriptor=%p\n", this, this->dbHandle.get(), this->dbHandle->descriptor.get())
+	DEBUG_LOG("%p DBIteratorHandle::close dbHandle=%p dbDescriptor=%p\n", this, this->dbHandle.get(), this->dbHandle->descriptor.get());
 	if (this->iterator) {
 		if (this->dbHandle && this->dbHandle->descriptor) {
 			this->dbHandle->descriptor->detach(this);
@@ -70,10 +70,10 @@ void DBIteratorHandle::init(DBIteratorOptions& options) {
 		this->startKey = rocksdb::Slice(options.startKeyStr + options.startKeyStart, options.startKeyEnd - options.startKeyStart);
 		options.readOptions.iterate_lower_bound = &this->startKey;
 
-		DEBUG_LOG("%p DBIteratorHandle::init Start key:", this)
-		DEBUG_LOG_KEY_LN(this->startKey)
+		DEBUG_LOG("%p DBIteratorHandle::init Start key:", this);
+		DEBUG_LOG_KEY_LN(this->startKey);
 	} else {
-		DEBUG_LOG("%p DBIteratorHandle::init No start key\n", this)
+		DEBUG_LOG("%p DBIteratorHandle::init No start key\n", this);
 	}
 
 	if (options.endKeyStr != nullptr) {
@@ -84,10 +84,10 @@ void DBIteratorHandle::init(DBIteratorOptions& options) {
 		this->endKey = rocksdb::Slice(this->endKeyStr);
 		options.readOptions.iterate_upper_bound = &this->endKey;
 
-		DEBUG_LOG("%p DBIteratorHandle::init End key:", this)
-		DEBUG_LOG_KEY_LN(this->endKey)
+		DEBUG_LOG("%p DBIteratorHandle::init End key:", this);
+		DEBUG_LOG_KEY_LN(this->endKey);
 	} else {
-		DEBUG_LOG("%p DBIteratorHandle::init No end key\n", this)
+		DEBUG_LOG("%p DBIteratorHandle::init No end key\n", this);
 	}
 
 	this->dbHandle->descriptor->attach(this);

--- a/src/binding/db_registry.cpp
+++ b/src/binding/db_registry.cpp
@@ -13,17 +13,17 @@ std::unique_ptr<DBRegistry> DBRegistry::instance;
  */
 void DBRegistry::CloseDB(const std::shared_ptr<DBHandle> handle) {
 	if (!instance) {
-		DEBUG_LOG("%p DBRegistry::CloseDB Registry not initialized\n", instance.get())
+		DEBUG_LOG("%p DBRegistry::CloseDB Registry not initialized\n", instance.get());
 		return;
 	}
 
 	if (!handle) {
-		DEBUG_LOG("%p DBRegistry::CloseDB Invalid handle\n", instance.get())
+		DEBUG_LOG("%p DBRegistry::CloseDB Invalid handle\n", instance.get());
 		return;
 	}
 
 	if (!handle->descriptor) {
-		DEBUG_LOG("%p DBRegistry::CloseDB Database not opened\n", instance.get())
+		DEBUG_LOG("%p DBRegistry::CloseDB Database not opened\n", instance.get());
 		return;
 	}
 
@@ -37,23 +37,23 @@ void DBRegistry::CloseDB(const std::shared_ptr<DBHandle> handle) {
 		if (entryIterator != instance->databases.end()) {
 			weakDescriptor = entryIterator->second.descriptor;
 			pathCondition = entryIterator->second.condition;
-			DEBUG_LOG("%p DBRegistry::CloseDB Found DBDescriptor for \"%s\" (ref count = %ld)\n", instance.get(), path.c_str(), weakDescriptor.use_count())
+			DEBUG_LOG("%p DBRegistry::CloseDB Found DBDescriptor for \"%s\" (ref count = %ld)\n", instance.get(), path.c_str(), weakDescriptor.use_count());
 		} else {
-			DEBUG_LOG("%p DBRegistry::CloseDB DBDescriptor not found! \"%s\"\n", instance.get(), path.c_str())
+			DEBUG_LOG("%p DBRegistry::CloseDB DBDescriptor not found! \"%s\"\n", instance.get(), path.c_str());
 		}
 	}
 
 	// close the handle, decrements the descriptor ref count
 	handle->close();
 
-	DEBUG_LOG("%p DBRegistry::CloseDB Closed DBHandle %p for \"%s\" (ref count = %ld)\n", instance.get(), handle.get(), path.c_str(), weakDescriptor.use_count())
+	DEBUG_LOG("%p DBRegistry::CloseDB Closed DBHandle %p for \"%s\" (ref count = %ld)\n", instance.get(), handle.get(), path.c_str(), weakDescriptor.use_count());
 
 	// re-acquire the mutex to check and potentially remove the descriptor
 	{
 		std::lock_guard<std::mutex> lock(instance->databasesMutex);
 		// since the registry itself always has a ref, we need to check for ref count 1
 		if (weakDescriptor.use_count() <= 1) {
-			DEBUG_LOG("%p DBRegistry::CloseDB Purging descriptor for \"%s\"\n", instance.get(), path.c_str())
+			DEBUG_LOG("%p DBRegistry::CloseDB Purging descriptor for \"%s\"\n", instance.get(), path.c_str());
 			if (auto descriptor = weakDescriptor.lock()) {
 				descriptor->close();
 			}
@@ -64,7 +64,7 @@ void DBRegistry::CloseDB(const std::shared_ptr<DBHandle> handle) {
 				pathCondition->notify_all();
 			}
 		} else {
-			DEBUG_LOG("%p DBRegistry::CloseDB DBDescriptor is still active (ref count = %ld)\n", instance.get(), weakDescriptor.use_count())
+			DEBUG_LOG("%p DBRegistry::CloseDB DBDescriptor is still active (ref count = %ld)\n", instance.get(), weakDescriptor.use_count());
 		}
 	}
 }
@@ -91,7 +91,7 @@ void DBRegistry::CloseDB(const std::shared_ptr<DBHandle> handle) {
 std::unique_ptr<DBHandleParams> DBRegistry::OpenDB(const std::string& path, const DBOptions& options) {
 	// ensure the registry has already been initialized
 	if (!instance) {
-		DEBUG_LOG("DBRegistry::OpenDB Registry not initialized!\n")
+		DEBUG_LOG("DBRegistry::OpenDB Registry not initialized!\n");
 		throw std::runtime_error("DBRegistry not initialized!");
 	}
 
@@ -117,7 +117,7 @@ std::unique_ptr<DBHandleParams> DBRegistry::OpenDB(const std::string& path, cons
 		if (entry.descriptor) {
 			descriptor = entry.descriptor;
 			if (descriptor->isClosing()) {
-				DEBUG_LOG("%p DBRegistry::OpenDB Database \"%s\" is closing, waiting for removal\n", instance.get(), path.c_str())
+				DEBUG_LOG("%p DBRegistry::OpenDB Database \"%s\" is closing, waiting for removal\n", instance.get(), path.c_str());
 				descriptor.reset();
 				return false; // keep waiting
 			}
@@ -141,20 +141,20 @@ std::unique_ptr<DBHandleParams> DBRegistry::OpenDB(const std::string& path, cons
 			);
 		}
 
-		DEBUG_LOG("%p DBRegistry::OpenDB Database \"%s\" already open\n", instance.get(), path.c_str())
-		DEBUG_LOG("%p DBRegistry::OpenDB Checking for column family \"%s\"\n", instance.get(), name.c_str())
+		DEBUG_LOG("%p DBRegistry::OpenDB Database \"%s\" already open\n", instance.get(), path.c_str());
+		DEBUG_LOG("%p DBRegistry::OpenDB Checking for column family \"%s\"\n", instance.get(), name.c_str());
 
 		// manually copy the columns because we don't know which ones are valid
 		bool columnExists = false;
 		for (auto& column : descriptor->columns) {
 			columns[column.first] = column.second;
 			if (column.first == name) {
-				DEBUG_LOG("%p DBRegistry::OpenDB Column family \"%s\" already exists\n", instance.get(), name.c_str())
+				DEBUG_LOG("%p DBRegistry::OpenDB Column family \"%s\" already exists\n", instance.get(), name.c_str());
 				columnExists = true;
 			}
 		}
 		if (!columnExists) {
-			DEBUG_LOG("%p DBRegistry::OpenDB Creating column family \"%s\"\n", instance.get(), name.c_str())
+			DEBUG_LOG("%p DBRegistry::OpenDB Creating column family \"%s\"\n", instance.get(), name.c_str());
 			columns[name] = rocksdb_js::createRocksDBColumnFamily(descriptor->db, name);
 			descriptor->columns[name] = columns[name];
 		}
@@ -162,7 +162,7 @@ std::unique_ptr<DBHandleParams> DBRegistry::OpenDB(const std::string& path, cons
 		descriptor = DBDescriptor::open(path, options);	// store the descriptor in the existing entry
 		entry.descriptor = descriptor;
 		columns = descriptor->columns;
-		DEBUG_LOG("%p DBRegistry::OpenDB Stored DBDescriptor %p for \"%s\" (ref count = %ld)\n", instance.get(), descriptor.get(), path.c_str(), descriptor.use_count())
+		DEBUG_LOG("%p DBRegistry::OpenDB Stored DBDescriptor %p for \"%s\" (ref count = %ld)\n", instance.get(), descriptor.get(), path.c_str(), descriptor.use_count());
 	}
 
 	// handle the column family
@@ -170,16 +170,16 @@ std::unique_ptr<DBHandleParams> DBRegistry::OpenDB(const std::string& path, cons
 	auto colIterator = columns.find(name);
 	if (colIterator != columns.end()) {
 		// column family already exists
-		DEBUG_LOG("%p DBRegistry::OpenDB Column family \"%s\" found\n", instance.get(), name.c_str())
+		DEBUG_LOG("%p DBRegistry::OpenDB Column family \"%s\" found\n", instance.get(), name.c_str());
 		column = colIterator->second;
 	} else {
 		// use the default column family
-		DEBUG_LOG("%p DBRegistry::OpenDB Column family \"%s\" not found, using \"default\"\n", instance.get(), name.c_str())
+		DEBUG_LOG("%p DBRegistry::OpenDB Column family \"%s\" not found, using \"default\"\n", instance.get(), name.c_str());
 		column = columns[rocksdb::kDefaultColumnFamilyName];
 	}
 
 	std::unique_ptr<DBHandleParams> handle = std::make_unique<DBHandleParams>(descriptor, column);
-	DEBUG_LOG("%p DBRegistry::OpenDB Created DBHandleParams %p for \"%s\"\n", instance.get(), handle.get(), path.c_str())
+	DEBUG_LOG("%p DBRegistry::OpenDB Created DBHandleParams %p for \"%s\"\n", instance.get(), handle.get(), path.c_str());
 	return handle;
 }
 
@@ -193,7 +193,7 @@ void DBRegistry::PurgeAll() {
 		size_t initialSize = instance->databases.size();
 #endif
 		for (auto it = instance->databases.begin(); it != instance->databases.end();) {
-			DEBUG_LOG("%p DBRegistry::PurgeAll Purging \"%s\"\n", instance.get(), it->first.c_str())
+			DEBUG_LOG("%p DBRegistry::PurgeAll Purging \"%s\"\n", instance.get(), it->first.c_str());
 			it = instance->databases.erase(it);
 		}
 #ifdef DEBUG
@@ -217,7 +217,7 @@ void DBRegistry::Shutdown() {
 
 		{
 			std::lock_guard<std::mutex> lock(instance->databasesMutex);
-			DEBUG_LOG("%p DBRegistry::Shutdown Shutting down %zu databases\n", instance.get(), instance->databases.size())
+			DEBUG_LOG("%p DBRegistry::Shutdown Shutting down %zu databases\n", instance.get(), instance->databases.size());
 
 			// Collect all descriptors to close
 			for (auto& [path, entry] : instance->databases) {
@@ -229,14 +229,14 @@ void DBRegistry::Shutdown() {
 
 		// Close all descriptors without holding the lock
 		for (auto& descriptor : descriptorsToClose) {
-			DEBUG_LOG("%p DBRegistry::Shutdown Closing database: %s\n", instance.get(), descriptor->path.c_str())
+			DEBUG_LOG("%p DBRegistry::Shutdown Closing database: %s\n", instance.get(), descriptor->path.c_str());
 			descriptor->close();
 		}
 
 		// Purge the registry
 		PurgeAll();
 
-		DEBUG_LOG("%p DBRegistry::Shutdown Shutdown complete\n", instance.get())
+		DEBUG_LOG("%p DBRegistry::Shutdown Shutdown complete\n", instance.get());
 	}
 }
 

--- a/src/binding/db_settings.cpp
+++ b/src/binding/db_settings.cpp
@@ -50,8 +50,8 @@ std::shared_ptr<rocksdb::Cache> DBSettings::getBlockCache() {
  * ```
  */
 napi_value DBSettings::Config(napi_env env, napi_callback_info info) {
-	NAPI_METHOD_ARGV(1)
-	
+	NAPI_METHOD_ARGV(1);
+
 	DBSettings& settings = DBSettings::getInstance();
 	napi_value params = argv[0];
 
@@ -70,7 +70,7 @@ napi_value DBSettings::Config(napi_env env, napi_callback_info info) {
 		}
 	}
 
-	NAPI_RETURN_UNDEFINED()
+	NAPI_RETURN_UNDEFINED();
 }
 
 /**

--- a/src/binding/transaction.cpp
+++ b/src/binding/transaction.cpp
@@ -11,17 +11,19 @@
 
 #define UNWRAP_TRANSACTION_HANDLE(fnName) \
 	std::shared_ptr<TransactionHandle>* txnHandle = nullptr; \
-	NAPI_STATUS_THROWS(::napi_unwrap(env, jsThis, reinterpret_cast<void**>(&txnHandle))) \
-	if (!txnHandle || !(*txnHandle)) { \
-		::napi_throw_error(env, nullptr, fnName " failed: Transaction has already been closed"); \
-		return nullptr; \
-	}
+	do { \
+		NAPI_STATUS_THROWS(::napi_unwrap(env, jsThis, reinterpret_cast<void**>(&txnHandle))); \
+		if (!txnHandle || !(*txnHandle)) { \
+			::napi_throw_error(env, nullptr, fnName " failed: Transaction has already been closed"); \
+			return nullptr; \
+		} \
+	} while (0)
 
 #define NAPI_THROW_JS_ERROR(code, message) \
 	napi_value error; \
 	rocksdb_js::createJSError(env, code, message, error); \
 	::napi_throw(env, error); \
-	return nullptr;
+	return nullptr
 
 namespace rocksdb_js {
 
@@ -41,23 +43,23 @@ namespace rocksdb_js {
  * ```
  */
 napi_value Transaction::Constructor(napi_env env, napi_callback_info info) {
-	NAPI_CONSTRUCTOR_ARGV_WITH_DATA("Transaction", 2)
+	NAPI_CONSTRUCTOR_ARGV_WITH_DATA("Transaction", 2);
 
 	napi_ref exportsRef = reinterpret_cast<napi_ref>(data);
 	napi_value exports;
-	NAPI_STATUS_THROWS(::napi_get_reference_value(env, exportsRef, &exports))
+	NAPI_STATUS_THROWS(::napi_get_reference_value(env, exportsRef, &exports));
 
 	napi_value databaseCtor;
 	bool isDatabase = false;
-	NAPI_STATUS_THROWS(::napi_get_named_property(env, exports, "Database", &databaseCtor))
-	NAPI_STATUS_THROWS(::napi_instanceof(env, argv[0], databaseCtor, &isDatabase))
+	NAPI_STATUS_THROWS(::napi_get_named_property(env, exports, "Database", &databaseCtor));
+	NAPI_STATUS_THROWS(::napi_instanceof(env, argv[0], databaseCtor, &isDatabase));
 	if (!isDatabase) {
 		::napi_throw_error(env, nullptr, "Invalid argument, expected Database instance");
 		return nullptr;
 	}
 
 	std::shared_ptr<DBHandle>* dbHandle = nullptr;
-	NAPI_STATUS_THROWS(::napi_unwrap(env, argv[0], reinterpret_cast<void**>(&dbHandle)))
+	NAPI_STATUS_THROWS(::napi_unwrap(env, argv[0], reinterpret_cast<void**>(&dbHandle)));
 
 	if (dbHandle == nullptr || !(*dbHandle)->opened()) {
 		::napi_throw_error(env, nullptr, "Database not open");
@@ -73,7 +75,7 @@ napi_value Transaction::Constructor(napi_env env, napi_callback_info info) {
 	NAPI_STATUS_THROWS(rocksdb_js::getProperty(env, argv[1], "disableSnapshot", disableSnapshot));
 
 	napi_ref jsDatabaseRef;
-	NAPI_STATUS_THROWS(::napi_create_reference(env, argv[0], 0, &jsDatabaseRef))
+	NAPI_STATUS_THROWS(::napi_create_reference(env, argv[0], 0, &jsDatabaseRef));
 
 	// create shared_ptr on heap so it persists after function returns
 	std::shared_ptr<TransactionHandle>* txnHandle = new std::shared_ptr<TransactionHandle>(
@@ -89,7 +91,7 @@ napi_value Transaction::Constructor(napi_env env, napi_callback_info info) {
 		(*txnHandle)->dbHandle.get(),
 		(*txnHandle)->dbHandle->descriptor.get(),
 		(*txnHandle)->dbHandle.use_count()
-	)
+	);
 
 	try {
 		NAPI_STATUS_THROWS(::napi_wrap(
@@ -98,7 +100,8 @@ napi_value Transaction::Constructor(napi_env env, napi_callback_info info) {
 			reinterpret_cast<void*>(txnHandle),
 			[](napi_env env, void* data, void* hint) {
 				auto* txnHandle = static_cast<std::shared_ptr<TransactionHandle>*>(data);
-				DEBUG_LOG("Transaction::Constructor NativeTransaction GC'd (txnHandle=%p, ref count=%ld)\n", data, txnHandle->use_count())
+				DEBUG_LOG("Transaction::Constructor NativeTransaction GC'd (txnHandle=%p, ref count=%ld)\n",
+					data, txnHandle->use_count());
 				[[maybe_unused]] auto id = (*txnHandle)->id;
 				if (*txnHandle) {
 					(*txnHandle).reset();
@@ -121,8 +124,8 @@ napi_value Transaction::Constructor(napi_env env, napi_callback_info info) {
  * Aborts the transaction.
  */
 napi_value Transaction::Abort(napi_env env, napi_callback_info info) {
-	NAPI_METHOD()
-	UNWRAP_TRANSACTION_HANDLE("Abort")
+	NAPI_METHOD();
+	UNWRAP_TRANSACTION_HANDLE("Abort");
 
 	TransactionState txnState = (*txnHandle)->state;
 	if (txnState == TransactionState::Aborted) {
@@ -130,15 +133,15 @@ napi_value Transaction::Abort(napi_env env, napi_callback_info info) {
 		return nullptr;
 	}
 	if (txnState == TransactionState::Committing || txnState == TransactionState::Committed) {
-		NAPI_THROW_JS_ERROR("ERR_ALREADY_COMMITTED", "Transaction has already been committed")
+		NAPI_THROW_JS_ERROR("ERR_ALREADY_COMMITTED", "Transaction has already been committed");
 	}
 	(*txnHandle)->state = TransactionState::Aborted;
 
-	ROCKSDB_STATUS_THROWS_ERROR_LIKE((*txnHandle)->txn->Rollback(), "Transaction rollback failed")
-	DEBUG_LOG("Transaction::Abort closing txnHandle=%p txnId=%u\n", (*txnHandle).get(), (*txnHandle)->id)
+	ROCKSDB_STATUS_THROWS_ERROR_LIKE((*txnHandle)->txn->Rollback(), "Transaction rollback failed");
+	DEBUG_LOG("Transaction::Abort closing txnHandle=%p txnId=%u\n", (*txnHandle).get(), (*txnHandle)->id);
 	(*txnHandle)->close();
 
-	NAPI_RETURN_UNDEFINED()
+	NAPI_RETURN_UNDEFINED();
 }
 
 /**
@@ -150,28 +153,28 @@ typedef BaseAsyncState<std::shared_ptr<TransactionHandle>> TransactionCommitStat
  * Commits the transaction.
  */
 napi_value Transaction::Commit(napi_env env, napi_callback_info info) {
-	NAPI_METHOD_ARGV(2)
+	NAPI_METHOD_ARGV(2);
 	napi_value resolve = argv[0];
 	napi_value reject = argv[1];
-	UNWRAP_TRANSACTION_HANDLE("Commit")
+	UNWRAP_TRANSACTION_HANDLE("Commit");
 
 	TransactionCommitState* state = new TransactionCommitState(env, *txnHandle);
-	NAPI_STATUS_THROWS(::napi_create_reference(env, resolve, 1, &state->resolveRef))
-	NAPI_STATUS_THROWS(::napi_create_reference(env, reject, 1, &state->rejectRef))
+	NAPI_STATUS_THROWS(::napi_create_reference(env, resolve, 1, &state->resolveRef));
+	NAPI_STATUS_THROWS(::napi_create_reference(env, reject, 1, &state->rejectRef));
 
 	TransactionState txnState = (*txnHandle)->state;
 	if (txnState == TransactionState::Aborted) {
-		NAPI_THROW_JS_ERROR("ERR_ALREADY_ABORTED", "Transaction has already been aborted")
+		NAPI_THROW_JS_ERROR("ERR_ALREADY_ABORTED", "Transaction has already been aborted");
 	}
 	if (txnState == TransactionState::Committing || txnState == TransactionState::Committed) {
 		// already committed
 		napi_value global;
-		NAPI_STATUS_THROWS(::napi_get_global(env, &global))
-		NAPI_STATUS_THROWS(::napi_call_function(env, global, resolve, 0, nullptr, nullptr))
+		NAPI_STATUS_THROWS(::napi_get_global(env, &global));
+		NAPI_STATUS_THROWS(::napi_call_function(env, global, resolve, 0, nullptr, nullptr));
 		delete state;
 		return nullptr;
 	}
-	DEBUG_LOG("%p Transaction::Commit Setting state to committing\n", (*txnHandle).get(), (*txnHandle)->id)
+	DEBUG_LOG("%p Transaction::Commit Setting state to committing\n", (*txnHandle).get(), (*txnHandle)->id);
 	(*txnHandle)->state = TransactionState::Committing;
 
 	napi_value name;
@@ -180,7 +183,7 @@ napi_value Transaction::Commit(napi_env env, napi_callback_info info) {
 		"transaction.commit",
 		NAPI_AUTO_LENGTH,
 		&name
-	))
+	));
 
 	NAPI_STATUS_THROWS(::napi_create_async_work(
 		env,       // node_env
@@ -190,16 +193,16 @@ napi_value Transaction::Commit(napi_env env, napi_callback_info info) {
 			TransactionCommitState* state = reinterpret_cast<TransactionCommitState*>(data);
 			auto txnHandle = state->handle;
 			if (!txnHandle) {
-				DEBUG_LOG("%p Transaction::Commit ERROR: Called with nullptr txnHandle\n", txnHandle.get())
+				DEBUG_LOG("%p Transaction::Commit ERROR: Called with nullptr txnHandle\n", txnHandle.get());
 				state->status = rocksdb::Status::Aborted("Database closed during transaction commit operation");
 			} else if (txnHandle->isCancelled()) {
-				DEBUG_LOG("%p Transaction::Commit ERROR: Called with txnHandle cancelled\n", txnHandle.get())
+				DEBUG_LOG("%p Transaction::Commit ERROR: Called with txnHandle cancelled\n", txnHandle.get());
 				state->status = rocksdb::Status::Aborted("Database closed during transaction commit operation");
 			} else if (!txnHandle->dbHandle) {
-				DEBUG_LOG("%p Transaction::Commit ERROR: Called with nullptr dbHandle\n", txnHandle.get())
+				DEBUG_LOG("%p Transaction::Commit ERROR: Called with nullptr dbHandle\n", txnHandle.get());
 				state->status = rocksdb::Status::Aborted("Database closed during transaction commit operation");
 			} else if (!txnHandle->dbHandle->opened()) {
-				DEBUG_LOG("%p Transaction::Commit ERROR: Called with dbHandle not opened\n", txnHandle.get())
+				DEBUG_LOG("%p Transaction::Commit ERROR: Called with dbHandle not opened\n", txnHandle.get());
 				state->status = rocksdb::Status::Aborted("Database closed during transaction commit operation");
 			} else {
 				auto descriptor = txnHandle->dbHandle->descriptor;
@@ -213,7 +216,7 @@ napi_value Transaction::Commit(napi_env env, napi_callback_info info) {
 						// write the batch to the store
 						store->writeBatch(*txnHandle->logEntryBatch, committedPosition);
 					} else {
-						DEBUG_LOG("%p Transaction::Commit ERROR: Log store not found for transaction %u\n", txnHandle.get(), txnHandle->id)
+						DEBUG_LOG("%p Transaction::Commit ERROR: Log store not found for transaction %u\n", txnHandle.get(), txnHandle->id);
 						state->status = rocksdb::Status::Aborted("Log store not found for transaction");
 					}
 				}
@@ -225,7 +228,7 @@ napi_value Transaction::Commit(napi_env env, napi_callback_info info) {
 				}
 
 				if (state->status.ok()) {
-					DEBUG_LOG("%p Transaction::Commit Emitted committed event (txnId=%u)\n", txnHandle.get(), txnHandle->id)
+					DEBUG_LOG("%p Transaction::Commit Emitted committed event (txnId=%u)\n", txnHandle.get(), txnHandle->id);
 					txnHandle->state = TransactionState::Committed;
 					descriptor->notify("committed", nullptr);
 				}
@@ -245,18 +248,18 @@ napi_value Transaction::Commit(napi_env env, napi_callback_info info) {
 			if (status != napi_cancelled) {
 				if (state->status.ok()) {
 					if (state->handle) {
-						DEBUG_LOG("%p Transaction::Commit Complete closing (txnId=%u)\n", state->handle.get(), state->handle->id)
+						DEBUG_LOG("%p Transaction::Commit Complete closing (txnId=%u)\n", state->handle.get(), state->handle->id);
 						state->handle->close();
-						DEBUG_LOG("%p Transaction::Commit Complete closed (txnId=%u)\n", state->handle.get(), state->handle->id)
+						DEBUG_LOG("%p Transaction::Commit Complete closed (txnId=%u)\n", state->handle.get(), state->handle->id);
 					} else {
-						DEBUG_LOG("%p Transaction::Commit Complete, but handle is null! (txnId=%u)\n", state->handle.get(), state->handle->id)
+						DEBUG_LOG("%p Transaction::Commit Complete, but handle is null! (txnId=%u)\n", state->handle.get(), state->handle->id);
 					}
 
 					state->callResolve();
 				} else {
 					state->handle->state = TransactionState::Pending;
 					napi_value error;
-					ROCKSDB_CREATE_ERROR_LIKE_VOID(error, state->status, "Transaction commit failed")
+					ROCKSDB_CREATE_ERROR_LIKE_VOID(error, state->status, "Transaction commit failed");
 					state->callReject(error);
 				}
 			}
@@ -270,24 +273,24 @@ napi_value Transaction::Commit(napi_env env, napi_callback_info info) {
 	// register the async work with the transaction handle
 	(*txnHandle)->registerAsyncWork();
 
-	NAPI_STATUS_THROWS(::napi_queue_async_work(env, state->asyncWork))
+	NAPI_STATUS_THROWS(::napi_queue_async_work(env, state->asyncWork));
 
-	NAPI_RETURN_UNDEFINED()
+	NAPI_RETURN_UNDEFINED();
 }
 
 /**
  * Commits the transaction synchronously.
  */
 napi_value Transaction::CommitSync(napi_env env, napi_callback_info info) {
-	NAPI_METHOD()
-	UNWRAP_TRANSACTION_HANDLE("CommitSync")
+	NAPI_METHOD();
+	UNWRAP_TRANSACTION_HANDLE("CommitSync");
 
 	TransactionState txnState = (*txnHandle)->state;
 	if (txnState == TransactionState::Aborted) {
-		NAPI_THROW_JS_ERROR("ERR_ALREADY_ABORTED", "Transaction has already been aborted")
+		NAPI_THROW_JS_ERROR("ERR_ALREADY_ABORTED", "Transaction has already been aborted");
 	}
 	if (txnState == TransactionState::Committing || txnState == TransactionState::Committed) {
-		NAPI_RETURN_UNDEFINED()
+		NAPI_RETURN_UNDEFINED();
 	}
 	(*txnHandle)->state = TransactionState::Committing;
 
@@ -299,7 +302,7 @@ napi_value Transaction::CommitSync(napi_env env, napi_callback_info info) {
 		if (store) {
 			store->writeBatch(*(*txnHandle)->logEntryBatch, committedPosition);
 		} else {
-			DEBUG_LOG("%p Transaction::CommitSync ERROR: Log store not found for transaction %u\n", (*txnHandle).get(), (*txnHandle)->id)
+			DEBUG_LOG("%p Transaction::CommitSync ERROR: Log store not found for transaction %u\n", (*txnHandle).get(), (*txnHandle)->id);
 			NAPI_THROW_JS_ERROR("ERR_LOG_STORE_NOT_FOUND", "Log store not found for transaction");
 		}
 	}
@@ -314,31 +317,31 @@ napi_value Transaction::CommitSync(napi_env env, napi_callback_info info) {
 	}
 
 	if (status.ok()) {
-		DEBUG_LOG("%p Transaction::CommitSync Emitted committed event (txnId=%u)\n", (*txnHandle).get(), (*txnHandle)->id)
+		DEBUG_LOG("%p Transaction::CommitSync Emitted committed event (txnId=%u)\n", (*txnHandle).get(), (*txnHandle)->id);
 		(*txnHandle)->state = TransactionState::Committed;
 		(*txnHandle)->dbHandle->descriptor->notify("committed", nullptr);
 
-		DEBUG_LOG("%p Transaction::CommitSync Closing transaction (txnId=%u)\n", (*txnHandle).get(), (*txnHandle)->id)
+		DEBUG_LOG("%p Transaction::CommitSync Closing transaction (txnId=%u)\n", (*txnHandle).get(), (*txnHandle)->id);
 		(*txnHandle)->close();
 	} else {
 		(*txnHandle)->state = TransactionState::Pending;
 		napi_value error;
-		ROCKSDB_CREATE_ERROR_LIKE_VOID(error, status, "Transaction commit failed")
-		NAPI_STATUS_THROWS(::napi_throw(env, error))
+		ROCKSDB_CREATE_ERROR_LIKE_VOID(error, status, "Transaction commit failed");
+		NAPI_STATUS_THROWS(::napi_throw(env, error));
 	}
 
-	NAPI_RETURN_UNDEFINED()
+	NAPI_RETURN_UNDEFINED();
 }
 
 /**
  * Retrieves a value for the given key.
  */
 napi_value Transaction::Get(napi_env env, napi_callback_info info) {
-	NAPI_METHOD_ARGV(3)
-	NAPI_GET_BUFFER(argv[0], key, "Key is required")
+	NAPI_METHOD_ARGV(3);
+	NAPI_GET_BUFFER(argv[0], key, "Key is required");
 	napi_value resolve = argv[1];
 	napi_value reject = argv[2];
-	UNWRAP_TRANSACTION_HANDLE("Get")
+	UNWRAP_TRANSACTION_HANDLE("Get");
 
 	rocksdb::Slice keySlice(key + keyStart, keyEnd - keyStart);
 	return (*txnHandle)->get(env, keySlice, resolve, reject);
@@ -355,8 +358,8 @@ napi_value Transaction::Get(napi_env env, napi_callback_info info) {
  * ```
  */
 napi_value Transaction::GetCount(napi_env env, napi_callback_info info) {
-	NAPI_METHOD_ARGV(1)
-	UNWRAP_TRANSACTION_HANDLE("GetCount")
+	NAPI_METHOD_ARGV(1);
+	UNWRAP_TRANSACTION_HANDLE("GetCount");
 
 	DBIteratorOptions itOptions;
 	itOptions.initFromNapiObject(env, argv[0]);
@@ -366,7 +369,7 @@ napi_value Transaction::GetCount(napi_env env, napi_callback_info info) {
 	(*txnHandle)->getCount(itOptions, count);
 
 	napi_value result;
-	NAPI_STATUS_THROWS(::napi_create_int64(env, count, &result))
+	NAPI_STATUS_THROWS(::napi_create_int64(env, count, &result));
 	return result;
 }
 
@@ -374,16 +377,16 @@ napi_value Transaction::GetCount(napi_env env, napi_callback_info info) {
  * Retrieves a value for the given key.
  */
 napi_value Transaction::GetSync(napi_env env, napi_callback_info info) {
-	NAPI_METHOD_ARGV(1)
-	NAPI_GET_BUFFER(argv[0], key, "Key is required")
-	UNWRAP_TRANSACTION_HANDLE("GetSync")
+	NAPI_METHOD_ARGV(1);
+	NAPI_GET_BUFFER(argv[0], key, "Key is required");
+	UNWRAP_TRANSACTION_HANDLE("GetSync");
 
 	rocksdb::Slice keySlice(key + keyStart, keyEnd - keyStart);
 	std::string value;
 	rocksdb::Status status = (*txnHandle)->getSync(keySlice, value);
 
 	if (status.IsNotFound()) {
-		NAPI_RETURN_UNDEFINED()
+		NAPI_RETURN_UNDEFINED();
 	}
 
 	if (!status.ok()) {
@@ -398,7 +401,7 @@ napi_value Transaction::GetSync(napi_env env, napi_callback_info info) {
 		value.data(),
 		nullptr,
 		&result
-	))
+	));
 
 	return result;
 }
@@ -407,11 +410,11 @@ napi_value Transaction::GetSync(napi_env env, napi_callback_info info) {
  * Retrieves the timestamp of the transaction in milliseconds.
  */
 napi_value Transaction::GetTimestamp(napi_env env, napi_callback_info info) {
-	NAPI_METHOD()
-	UNWRAP_TRANSACTION_HANDLE("GetTimestamp")
+	NAPI_METHOD();
+	UNWRAP_TRANSACTION_HANDLE("GetTimestamp");
 
 	napi_value result;
-	NAPI_STATUS_THROWS_ERROR(::napi_create_double(env, (*txnHandle)->startTimestamp, &result), "Failed to get timestamp")
+	NAPI_STATUS_THROWS_ERROR(::napi_create_double(env, (*txnHandle)->startTimestamp, &result), "Failed to get timestamp");
 	return result;
 }
 
@@ -419,15 +422,15 @@ napi_value Transaction::GetTimestamp(napi_env env, napi_callback_info info) {
  * Retrieves the ID of the transaction.
  */
 napi_value Transaction::Id(napi_env env, napi_callback_info info) {
-	NAPI_METHOD()
-	UNWRAP_TRANSACTION_HANDLE("Id")
+	NAPI_METHOD();
+	UNWRAP_TRANSACTION_HANDLE("Id");
 
 	napi_value result;
 	NAPI_STATUS_THROWS(::napi_create_uint32(
 		env,
 		(*txnHandle)->id,
 		&result
-	))
+	));
 	return result;
 }
 
@@ -435,46 +438,46 @@ napi_value Transaction::Id(napi_env env, napi_callback_info info) {
  * Puts a value for the given key.
  */
 napi_value Transaction::PutSync(napi_env env, napi_callback_info info) {
-	NAPI_METHOD_ARGV(2)
-	NAPI_GET_BUFFER(argv[0], key, "Key is required")
-	NAPI_GET_BUFFER(argv[1], value, nullptr)
-	UNWRAP_TRANSACTION_HANDLE("Put")
+	NAPI_METHOD_ARGV(2);
+	NAPI_GET_BUFFER(argv[0], key, "Key is required");
+	NAPI_GET_BUFFER(argv[1], value, nullptr);
+	UNWRAP_TRANSACTION_HANDLE("Put");
 
 	rocksdb::Slice keySlice(key + keyStart, keyEnd - keyStart);
 	rocksdb::Slice valueSlice(value + valueStart, valueEnd - valueStart);
 
-	DEBUG_LOG("%p Transaction::PutSync key:", txnHandle->get())
-	DEBUG_LOG_KEY_LN(keySlice)
+	DEBUG_LOG("%p Transaction::PutSync key:", txnHandle->get());
+	DEBUG_LOG_KEY_LN(keySlice);
 
-	DEBUG_LOG("%p Transaction::PutSync value:", txnHandle->get())
-	DEBUG_LOG_KEY_LN(valueSlice)
+	DEBUG_LOG("%p Transaction::PutSync value:", txnHandle->get());
+	DEBUG_LOG_KEY_LN(valueSlice);
 
-	ROCKSDB_STATUS_THROWS_ERROR_LIKE((*txnHandle)->putSync(keySlice, valueSlice), "Transaction put failed")
+	ROCKSDB_STATUS_THROWS_ERROR_LIKE((*txnHandle)->putSync(keySlice, valueSlice), "Transaction put failed");
 
-	NAPI_RETURN_UNDEFINED()
+	NAPI_RETURN_UNDEFINED();
 }
 
 /**
  * Removes a value for the given key.
  */
 napi_value Transaction::RemoveSync(napi_env env, napi_callback_info info) {
-	NAPI_METHOD_ARGV(1)
-	NAPI_GET_BUFFER(argv[0], key, "Key is required")
-	UNWRAP_TRANSACTION_HANDLE("Remove")
+	NAPI_METHOD_ARGV(1);
+	NAPI_GET_BUFFER(argv[0], key, "Key is required");
+	UNWRAP_TRANSACTION_HANDLE("Remove");
 
 	rocksdb::Slice keySlice(key + keyStart, keyEnd - keyStart);
 
-	ROCKSDB_STATUS_THROWS_ERROR_LIKE((*txnHandle)->removeSync(keySlice), "Transaction remove failed")
+	ROCKSDB_STATUS_THROWS_ERROR_LIKE((*txnHandle)->removeSync(keySlice), "Transaction remove failed");
 
-	NAPI_RETURN_UNDEFINED()
+	NAPI_RETURN_UNDEFINED();
 }
 
 /**
  * Sets the timestamp of the transaction.
  */
 napi_value Transaction::SetTimestamp(napi_env env, napi_callback_info info) {
-	NAPI_METHOD_ARGV(1)
-	UNWRAP_TRANSACTION_HANDLE("SetTimestamp")
+	NAPI_METHOD_ARGV(1);
+	UNWRAP_TRANSACTION_HANDLE("SetTimestamp");
 
 	napi_valuetype type;
 	NAPI_STATUS_THROWS(::napi_typeof(env, argv[0], &type));
@@ -496,16 +499,16 @@ napi_value Transaction::SetTimestamp(napi_env env, napi_callback_info info) {
 		return nullptr;
 	}
 
-	NAPI_RETURN_UNDEFINED()
+	NAPI_RETURN_UNDEFINED();
 }
 
 /**
  * Creates a new transaction log instance bound to this transaction.
  */
 napi_value Transaction::UseLog(napi_env env, napi_callback_info info) {
-	NAPI_METHOD_ARGV(1)
-	NAPI_GET_STRING(argv[0], name, "Name is required")
-	UNWRAP_TRANSACTION_HANDLE("UseLog")
+	NAPI_METHOD_ARGV(1);
+	NAPI_GET_STRING(argv[0], name, "Name is required");
+	UNWRAP_TRANSACTION_HANDLE("UseLog");
 
 	// check if transaction is already bound to a different log store
 	auto boundStore = (*txnHandle)->boundLogStore.lock();
@@ -531,21 +534,21 @@ napi_value Transaction::UseLog(napi_env env, napi_callback_info info) {
 	// this needs to create a new TransactionLog instance that is not tracked by
 	// the DBHandle and is bound to this transaction
 	napi_value exports;
-	NAPI_STATUS_THROWS_ERROR(::napi_get_reference_value(env, (*txnHandle)->dbHandle->exportsRef, &exports), "Failed to get 'exports' reference")
+	NAPI_STATUS_THROWS_ERROR(::napi_get_reference_value(env, (*txnHandle)->dbHandle->exportsRef, &exports), "Failed to get 'exports' reference");
 
 	napi_value transactionLogCtor;
-	NAPI_STATUS_THROWS_ERROR(::napi_get_named_property(env, exports, "TransactionLog", &transactionLogCtor), "Failed to get 'TransactionLog' constructor")
+	NAPI_STATUS_THROWS_ERROR(::napi_get_named_property(env, exports, "TransactionLog", &transactionLogCtor), "Failed to get 'TransactionLog' constructor");
 
 	napi_value jsDatabase;
-	NAPI_STATUS_THROWS_ERROR(::napi_get_reference_value(env, (*txnHandle)->jsDatabaseRef, &jsDatabase), "Failed to get 'jsDatabase' reference")
+	NAPI_STATUS_THROWS_ERROR(::napi_get_reference_value(env, (*txnHandle)->jsDatabaseRef, &jsDatabase), "Failed to get 'jsDatabase' reference");
 
 	napi_value args[2];
 	args[0] = jsDatabase;
 
-	NAPI_STATUS_THROWS_ERROR(::napi_create_string_utf8(env, name.c_str(), name.size(), &args[1]), "Invalid log name")
+	NAPI_STATUS_THROWS_ERROR(::napi_create_string_utf8(env, name.c_str(), name.size(), &args[1]), "Invalid log name");
 
 	napi_value instance;
-	NAPI_STATUS_THROWS_ERROR(::napi_new_instance(env, transactionLogCtor, 2, args, &instance), "Failed to create new TransactionLog instance")
+	NAPI_STATUS_THROWS_ERROR(::napi_new_instance(env, transactionLogCtor, 2, args, &instance), "Failed to create new TransactionLog instance");
 
 	return instance;
 }
@@ -573,7 +576,7 @@ void Transaction::Init(napi_env env, napi_value exports) {
 	constexpr size_t len = sizeof("Transaction") - 1;
 
 	napi_ref exportsRef;
-	NAPI_STATUS_THROWS_VOID(::napi_create_reference(env, exports, 1, &exportsRef))
+	NAPI_STATUS_THROWS_VOID(::napi_create_reference(env, exports, 1, &exportsRef));
 
 	napi_value ctor;
 	NAPI_STATUS_THROWS_VOID(::napi_define_class(
@@ -585,9 +588,9 @@ void Transaction::Init(napi_env env, napi_value exports) {
 		sizeof(properties) / sizeof(napi_property_descriptor), // number of properties
 		properties,               // properties array
 		&ctor                     // [out] constructor
-	))
+	));
 
-	NAPI_STATUS_THROWS_VOID(::napi_set_named_property(env, exports, className, ctor))
+	NAPI_STATUS_THROWS_VOID(::napi_set_named_property(env, exports, className, ctor));
 }
 
 } // namespace rocksdb_js

--- a/src/binding/transaction_handle.cpp
+++ b/src/binding/transaction_handle.cpp
@@ -106,18 +106,18 @@ void TransactionHandle::close() {
 	this->txn = nullptr;
 
 	if (this->jsDatabaseRef != nullptr) {
-		DEBUG_LOG("%p TransactionHandle::close Cleaning up reference to database\n", this)
-		NAPI_STATUS_THROWS_ERROR_VOID(::napi_delete_reference(this->env, this->jsDatabaseRef), "Failed to delete reference to database")
-		DEBUG_LOG("%p TransactionHandle::close Reference to database deleted successfully\n", this)
+		DEBUG_LOG("%p TransactionHandle::close Cleaning up reference to database\n", this);
+		NAPI_STATUS_THROWS_ERROR_VOID(::napi_delete_reference(this->env, this->jsDatabaseRef), "Failed to delete reference to database");
+		DEBUG_LOG("%p TransactionHandle::close Reference to database deleted successfully\n", this);
 		this->jsDatabaseRef = nullptr;
 	} else {
-		DEBUG_LOG("%p TransactionHandle::close jsDatabaseRef is already null\n", this)
+		DEBUG_LOG("%p TransactionHandle::close jsDatabaseRef is already null\n", this);
 	}
 
 	// the transaction should already be removed from the registry when
 	// committing/aborting  so we don't need to call transactionRemove here to
 	// avoid race conditions and bad_weak_ptr errors
-	DEBUG_LOG("%p TransactionHandle::close Transaction should already be removed from registry\n", this)
+	DEBUG_LOG("%p TransactionHandle::close Transaction should already be removed from registry\n", this);
 
 	this->dbHandle.reset();
 }
@@ -138,7 +138,7 @@ napi_value TransactionHandle::get(
 	}
 
 	if (this->state != TransactionState::Pending) {
-		DEBUG_LOG("%p TransactionHandle::get Transaction is not in pending state (state=%d)\n", this, this->state)
+		DEBUG_LOG("%p TransactionHandle::get Transaction is not in pending state (state=%d)\n", this, this->state);
 		::napi_throw_error(env, nullptr, "Transaction is not in pending state");
 		return nullptr;
 	}
@@ -176,12 +176,12 @@ napi_value TransactionHandle::get(
 		"transaction.get",
 		NAPI_AUTO_LENGTH,
 		&name
-	))
+	));
 
 	readOptions.read_tier = rocksdb::kReadAllTier;
 	auto state = new AsyncGetState<TransactionHandle*>(env, this, readOptions, key);
-	NAPI_STATUS_THROWS(::napi_create_reference(env, resolve, 1, &state->resolveRef))
-	NAPI_STATUS_THROWS(::napi_create_reference(env, reject, 1, &state->rejectRef))
+	NAPI_STATUS_THROWS(::napi_create_reference(env, resolve, 1, &state->resolveRef));
+	NAPI_STATUS_THROWS(::napi_create_reference(env, reject, 1, &state->rejectRef));
 
 	NAPI_STATUS_THROWS(::napi_create_async_work(
 		env,       // node_env
@@ -220,9 +220,9 @@ napi_value TransactionHandle::get(
 	// register the async work with the transaction handle
 	this->registerAsyncWork();
 
-	NAPI_STATUS_THROWS(::napi_queue_async_work(env, state->asyncWork))
+	NAPI_STATUS_THROWS(::napi_queue_async_work(env, state->asyncWork));
 
-	NAPI_STATUS_THROWS(::napi_create_uint32(env, 1, &returnStatus))
+	NAPI_STATUS_THROWS(::napi_create_uint32(env, 1, &returnStatus));
 	return returnStatus;
 }
 
@@ -261,7 +261,7 @@ rocksdb::Status TransactionHandle::getSync(
 	}
 
 	if (this->state != TransactionState::Pending) {
-		DEBUG_LOG("%p TransactionHandle::getSync Transaction is not in pending state (state=%d)\n", this, this->state)
+		DEBUG_LOG("%p TransactionHandle::getSync Transaction is not in pending state (state=%d)\n", this, this->state);
 		return rocksdb::Status::Aborted("Transaction is not in pending state");
 	}
 
@@ -295,7 +295,7 @@ rocksdb::Status TransactionHandle::putSync(
 	}
 
 	if (this->state != TransactionState::Pending) {
-		DEBUG_LOG("%p TransactionHandle::putSync Transaction is not in pending state (state=%d)\n", this, this->state)
+		DEBUG_LOG("%p TransactionHandle::putSync Transaction is not in pending state (state=%d)\n", this, this->state);
 		return rocksdb::Status::Aborted("Transaction is not in pending state");
 	}
 
@@ -321,7 +321,7 @@ rocksdb::Status TransactionHandle::removeSync(
 	}
 
 	if (this->state != TransactionState::Pending) {
-		DEBUG_LOG("%p TransactionHandle::removeSync Transaction is not in pending state (state=%d)\n", this, this->state)
+		DEBUG_LOG("%p TransactionHandle::removeSync Transaction is not in pending state (state=%d)\n", this, this->state);
 		return rocksdb::Status::Aborted("Transaction is not in pending state");
 	}
 

--- a/src/binding/transaction_log_file.cpp
+++ b/src/binding/transaction_log_file.cpp
@@ -57,7 +57,7 @@ void TransactionLogFile::open(const double latestTimestamp) {
 	char buffer[TRANSACTION_LOG_FILE_HEADER_SIZE];
 	if (this->size == 0) {
 		// file is empty, initialize it
-		DEBUG_LOG("%p TransactionLogFile::open Initializing empty file: %s (timestamp=%f)\n", this, this->path.string().c_str(), latestTimestamp)
+		DEBUG_LOG("%p TransactionLogFile::open Initializing empty file: %s (timestamp=%f)\n", this, this->path.string().c_str(), latestTimestamp);
 		writeUint32BE(buffer, TRANSACTION_LOG_TOKEN);
 		this->writeToFile(buffer, 4);
 		writeUint8(buffer, this->version);
@@ -67,61 +67,61 @@ void TransactionLogFile::open(const double latestTimestamp) {
 		this->writeToFile(buffer, 8);
 		this->size = TRANSACTION_LOG_FILE_HEADER_SIZE;
 	} else if (this->size < TRANSACTION_LOG_FILE_HEADER_SIZE) {
-		DEBUG_LOG("%p TransactionLogFile::open ERROR: File is too small to be a valid transaction log file: %s\n", this, this->path.string().c_str())
+		DEBUG_LOG("%p TransactionLogFile::open ERROR: File is too small to be a valid transaction log file: %s\n", this, this->path.string().c_str());
 		throw std::runtime_error("File is too small to be a valid transaction log file: " + this->path.string());
 	} else {
 		// try to read the token and version from the log file
 		int64_t result = this->readFromFile(buffer, TRANSACTION_LOG_FILE_HEADER_SIZE, 0);
 		if (result < 0) {
-			DEBUG_LOG("%p TransactionLogFile::open ERROR: Failed to read version from file: %s\n", this, this->path.string().c_str())
+			DEBUG_LOG("%p TransactionLogFile::open ERROR: Failed to read version from file: %s\n", this, this->path.string().c_str());
 			throw std::runtime_error("Failed to read version from file: " + this->path.string());
 		}
 
 		// token
 		uint32_t token = readUint32BE(buffer);
 		if (token != TRANSACTION_LOG_TOKEN) {
-			DEBUG_LOG("%p TransactionLogFile::open ERROR: Invalid transaction log file: %s\n", this, this->path.string().c_str())
+			DEBUG_LOG("%p TransactionLogFile::open ERROR: Invalid transaction log file: %s\n", this, this->path.string().c_str());
 			throw std::runtime_error("Invalid transaction log file: " + this->path.string());
 		}
 
 		// version
 		result = this->readFromFile(buffer, 1, 4);
 		if (result < 0) {
-			DEBUG_LOG("%p TransactionLogFile::open ERROR: Failed to read version from file: %s\n", this, this->path.string().c_str())
+			DEBUG_LOG("%p TransactionLogFile::open ERROR: Failed to read version from file: %s\n", this, this->path.string().c_str());
 			throw std::runtime_error("Failed to read version from file: " + this->path.string());
 		}
 		this->version = readUint8(buffer);
 
 		if (this->version != 1) {
-			DEBUG_LOG("%p TransactionLogFile::open ERROR: Unsupported transaction log file version: %s\n", this, this->path.string().c_str())
+			DEBUG_LOG("%p TransactionLogFile::open ERROR: Unsupported transaction log file version: %s\n", this, this->path.string().c_str());
 			throw std::runtime_error("Unsupported transaction log file version: " + std::to_string(this->version));
 		}
 
 		// file timestamp
 		result = this->readFromFile(buffer, 8, 5);
 		if (result < 0) {
-			DEBUG_LOG("%p TransactionLogFile::open ERROR: Failed to read file timestamp from file: %s\n", this, this->path.string().c_str())
+			DEBUG_LOG("%p TransactionLogFile::open ERROR: Failed to read file timestamp from file: %s\n", this, this->path.string().c_str());
 			throw std::runtime_error("Failed to read file timestamp from file: " + this->path.string());
 		}
 		this->timestamp = readDoubleBE(buffer);
 
 		DEBUG_LOG("%p TransactionLogFile::open Opened file %s (size=%zu, version=%u, timestamp=%f)\n",
-			this, this->path.string().c_str(), this->size, this->version, this->timestamp)
+			this, this->path.string().c_str(), this->size, this->version, this->timestamp);
 	}
 
 	DEBUG_LOG("%p TransactionLogFile::open Opened file %s (size=%u)\n",
-		this, this->path.string().c_str(), this->size)
+		this, this->path.string().c_str(), this->size);
 }
 
 void TransactionLogFile::writeEntries(TransactionLogEntryBatch& batch, const uint32_t maxFileSize) {
 	DEBUG_LOG("%p TransactionLogFile::writeEntries Writing batch with %zu entries, current entry index=%zu, bytes written=%zu (timestamp=%f, maxFileSize=%u, currentSize=%u)\n",
-		this, batch.entries.size(), batch.currentEntryIndex, batch.currentEntryBytesWritten, batch.timestamp, maxFileSize, this->size)
+		this, batch.entries.size(), batch.currentEntryIndex, batch.currentEntryBytesWritten, batch.timestamp, maxFileSize, this->size);
 
 	// branch based on file format version
 	if (this->version == 1) {
 		this->writeEntriesV1(batch, maxFileSize);
 	} else {
-		DEBUG_LOG("%p TransactionLogFile::writeEntries Unsupported transaction log file version: %s\n", this, this->path.string().c_str())
+		DEBUG_LOG("%p TransactionLogFile::writeEntries Unsupported transaction log file version: %s\n", this, this->path.string().c_str());
 		throw std::runtime_error("Unsupported transaction log file version: " + std::to_string(this->version));
 	}
 }
@@ -135,11 +135,11 @@ void TransactionLogFile::writeEntriesV1(TransactionLogEntryBatch& batch, const u
 	if (maxFileSize > 0) {
 		if (this->size >= maxFileSize) {
 			DEBUG_LOG("%p TransactionLogFile::writeEntriesV1 File already at max size (%u >= %u), deferring to next file\n",
-				this, this->size, maxFileSize)
+				this, this->size, maxFileSize);
 			return;
 		}
 
-		DEBUG_LOG("%p TransactionLogFile::writeEntriesV1 Calculating how many entries we can fit (size=%u, maxFileSize=%u)\n", this, this->size, maxFileSize)
+		DEBUG_LOG("%p TransactionLogFile::writeEntriesV1 Calculating how many entries we can fit (size=%u, maxFileSize=%u)\n", this, this->size, maxFileSize);
 
 		// calculate how many entries we can fit
 		auto availableSpace = maxFileSize - this->size;
@@ -149,10 +149,10 @@ void TransactionLogFile::writeEntriesV1(TransactionLogEntryBatch& batch, const u
 			// always write the first entry
 			if ((this->size > TRANSACTION_LOG_FILE_HEADER_SIZE || i > batch.currentEntryIndex) && spaceNeeded > availableSpace) {
 				// entry won't fit
-				DEBUG_LOG("%p TransactionLogFile::writeEntriesV1 Entry %u won't fit (need=%u, available=%u)\n", this, i, spaceNeeded, availableSpace)
+				DEBUG_LOG("%p TransactionLogFile::writeEntriesV1 Entry %u won't fit (need=%u, available=%u)\n", this, i, spaceNeeded, availableSpace);
 				break;
 			}
-			DEBUG_LOG("%p TransactionLogFile::writeEntriesV1 Entry %u fits (need=%u, available=%u)\n", this, i, spaceNeeded, availableSpace)
+			DEBUG_LOG("%p TransactionLogFile::writeEntriesV1 Entry %u fits (need=%u, available=%u)\n", this, i, spaceNeeded, availableSpace);
 			++numEntriesToWrite;
 			totalSizeToWrite += entry->size;
 		}
@@ -162,11 +162,11 @@ void TransactionLogFile::writeEntriesV1(TransactionLogEntryBatch& batch, const u
 	}
 
 	if (numEntriesToWrite == 0) {
-		DEBUG_LOG("%p TransactionLogFile::writeEntriesV1 No entries to write\n", this)
+		DEBUG_LOG("%p TransactionLogFile::writeEntriesV1 No entries to write\n", this);
 		return;
 	}
 
-	DEBUG_LOG("%p TransactionLogFile::writeEntriesV1 Writing %u entries to file (%u bytes)\n", this, numEntriesToWrite, totalSizeToWrite)
+	DEBUG_LOG("%p TransactionLogFile::writeEntriesV1 Writing %u entries to file (%u bytes)\n", this, numEntriesToWrite, totalSizeToWrite);
 
 	// allocate buffers for the transaction headers and iovecs
 	auto iovecs = std::make_unique<iovec[]>(numEntriesToWrite);
@@ -195,14 +195,14 @@ void TransactionLogFile::writeEntriesV1(TransactionLogEntryBatch& batch, const u
 
 	int64_t bytesWritten = this->writeBatchToFile(iovecs.get(), static_cast<int>(iovecsIndex));
 	if (bytesWritten < 0) {
-		DEBUG_LOG("%p TransactionLogFile::writeEntriesV1 ERROR: Failed to write transaction log entries to file: %s\n", this, this->path.string().c_str())
+		DEBUG_LOG("%p TransactionLogFile::writeEntriesV1 ERROR: Failed to write transaction log entries to file: %s\n", this, this->path.string().c_str());
 		throw std::runtime_error("Failed to write transaction log entries to file: " + this->path.string());
 	}
 
 	batch.currentEntryBytesWritten += static_cast<uint32_t>(bytesWritten);
 	this->size += static_cast<uint32_t>(bytesWritten);
 	DEBUG_LOG("%p TransactionLogFile::writeEntriesV1 Wrote %lld bytes to log file (size=%u, batch state: entryIndex=%zu, bytesWritten=%zu)\n",
-		this, bytesWritten, this->size, batch.currentEntryIndex, batch.currentEntryBytesWritten)
+		this, bytesWritten, this->size, batch.currentEntryIndex, batch.currentEntryBytesWritten);
 }
 
 /**
@@ -212,14 +212,14 @@ void TransactionLogFile::writeEntriesV1(TransactionLogEntryBatch& batch, const u
  * @return the position of the timestamp, or zero if comes before this logfile, or 0xFFFFFFFF if it comes after this logfile
  */
 uint32_t TransactionLogFile::findPositionByTimestamp(double timestamp, uint32_t mapSize) {
-	DEBUG_LOG("%p TransactionLogFile::findPositionByTimestamp Finding position for timestamp=%f, mapSize=%u\n", this, timestamp, mapSize)
+	DEBUG_LOG("%p TransactionLogFile::findPositionByTimestamp Finding position for timestamp=%f, mapSize=%u\n", this, timestamp, mapSize);
 	std::lock_guard<std::mutex> indexLock(this->indexMutex);
 	auto memoryMap = this->getMemoryMap(mapSize);
 
 	// If memory map is null (e.g., empty file with size 0), return 0xFFFFFFFF
 	// to indicate the timestamp comes after this logfile
 	if (!memoryMap) {
-		DEBUG_LOG("%p TransactionLogFile::findPositionByTimestamp memoryMap is null, returning 0xFFFFFFFF\n", this)
+		DEBUG_LOG("%p TransactionLogFile::findPositionByTimestamp memoryMap is null, returning 0xFFFFFFFF\n", this);
 		return 0xFFFFFFFF;
 	}
 

--- a/src/binding/transaction_log_file.h
+++ b/src/binding/transaction_log_file.h
@@ -223,7 +223,7 @@ struct MemoryMap final {
 		: map(map), mapSize(mapSize), fileSize(mapSize) {}
 
 	~MemoryMap() {
-		DEBUG_LOG("MemoryMap::~MemoryMap map=%p, mapSize=%u\n", this->map, this->mapSize)
+		DEBUG_LOG("MemoryMap::~MemoryMap map=%p, mapSize=%u\n", this->map, this->mapSize);
 #ifdef PLATFORM_WINDOWS
 		if (this->map != nullptr) {
 			::UnmapViewOfFile(this->map);

--- a/src/binding/transaction_log_file_windows.cpp
+++ b/src/binding/transaction_log_file_windows.cpp
@@ -23,13 +23,13 @@ void TransactionLogFile::close() {
 	// Explicitly remove our reference to the memory map.
 	if (this->memoryMap) {
 		DEBUG_LOG("%p TransactionLogFile::close Closing memory map for: %s (ref count=%ld)\n",
-			this, this->path.string().c_str(), this->memoryMap.use_count())
+			this, this->path.string().c_str(), this->memoryMap.use_count());
 		this->memoryMap.reset();
 	}
 
 	if (this->fileHandle != INVALID_HANDLE_VALUE) {
 		DEBUG_LOG("%p TransactionLogFile::close Closing file: %s (handle=%p)\n",
-			this, this->path.string().c_str(), this->fileHandle)
+			this, this->path.string().c_str(), this->fileHandle);
 		::CloseHandle(this->fileHandle);
 		this->fileHandle = INVALID_HANDLE_VALUE;
 	}
@@ -48,12 +48,12 @@ void TransactionLogFile::flush() {
 
 	// Perform the flush without holding the lock (since FlushFileBuffers can be slow)
 	DEBUG_LOG("%p TransactionLogFile::flush Flushing file: %s (handle=%p, size=%u, lastFlushedSize=%u)\n",
-		this, this->path.string().c_str(), handleToFlush, currentSize, this->lastFlushedSize)
+		this, this->path.string().c_str(), handleToFlush, currentSize, this->lastFlushedSize);
 	if (!::FlushFileBuffers(handleToFlush)) {
 		DWORD error = ::GetLastError();
 		std::string errorMessage = getWindowsErrorMessage(error);
 		DEBUG_LOG("%p TransactionLogFile::flush ERROR: FlushFileBuffers failed: %s (error=%lu: %s)\n",
-			this, this->path.string().c_str(), error, errorMessage.c_str())
+			this, this->path.string().c_str(), error, errorMessage.c_str());
 		throw std::runtime_error("Failed to flush file: " + this->path.string());
 	}
 
@@ -64,11 +64,11 @@ void TransactionLogFile::flush() {
 
 void TransactionLogFile::openFile() {
 	if (this->fileHandle != INVALID_HANDLE_VALUE) {
-		DEBUG_LOG("%p TransactionLogFile::openFile File already open: %s\n", this, this->path.string().c_str())
+		DEBUG_LOG("%p TransactionLogFile::openFile File already open: %s\n", this, this->path.string().c_str());
 		return;
 	}
 
-	DEBUG_LOG("%p TransactionLogFile::openFile Opening file: %s\n", this, this->path.string().c_str())
+	DEBUG_LOG("%p TransactionLogFile::openFile Opening file: %s\n", this, this->path.string().c_str());
 
 	// ensure parent directory exists (may have been deleted by purge())
 	auto parentPath = this->path.parent_path();
@@ -78,7 +78,7 @@ void TransactionLogFile::openFile() {
 			rocksdb_js::tryCreateDirectory(parentPath);
 		} catch (const std::filesystem::filesystem_error& e) {
 			DEBUG_LOG("%p TransactionLogFile::openFile Failed to create parent directory: %s (error=%s)\n",
-				this, parentPath.string().c_str(), e.what())
+				this, parentPath.string().c_str(), e.what());
 			throw std::runtime_error("Failed to create parent directory: " + parentPath.string());
 		}
 	}
@@ -101,7 +101,7 @@ void TransactionLogFile::openFile() {
 		DWORD error = ::GetLastError();
 		std::string errorMessage = getWindowsErrorMessage(error);
 		DEBUG_LOG("%p TransactionLogFile::openFile Failed to open sequence file for read/write: %s (error=%lu: %s)\n",
-			this, this->path.string().c_str(), error, errorMessage.c_str())
+			this, this->path.string().c_str(), error, errorMessage.c_str());
 		throw std::runtime_error("Failed to open sequence file for read/write: " + this->path.string());
 	}
 
@@ -162,7 +162,7 @@ void TransactionLogFile::openFile() {
 				);
 				if (result != ERROR_SUCCESS) {
 					DEBUG_LOG("%p TransactionLogFile::openFile Failed to set file permissions: %s (error=%lu)\n",
-						this, this->path.string().c_str(), result)
+						this, this->path.string().c_str(), result);
 				}
 				::LocalFree(newDacl);
 			}
@@ -179,7 +179,7 @@ void TransactionLogFile::openFile() {
 		DWORD error = ::GetLastError();
 		std::string errorMessage = getWindowsErrorMessage(error);
 		DEBUG_LOG("%p TransactionLogFile::openFile Failed to get file size: %s (error=%lu: %s)\n",
-			this, this->path.string().c_str(), error, errorMessage.c_str())
+			this, this->path.string().c_str(), error, errorMessage.c_str());
 		throw std::runtime_error("Failed to get file size: " + this->path.string());
 	}
 	this->size = static_cast<size_t>(fileSize.QuadPart);
@@ -231,7 +231,7 @@ std::shared_ptr<MemoryMap> TransactionLogFile::getMemoryMap(uint32_t fileSize) {
 			DWORD error = ::GetLastError();
 			std::string errorMessage = getWindowsErrorMessage(error);
 			DEBUG_LOG("%p TransactionLogFile::getMemoryMap ERROR: Failed to SetFilePointerEx: %s (error=%lu: %s)\n",
-				this, this->path.string().c_str(), error, errorMessage.c_str())
+				this, this->path.string().c_str(), error, errorMessage.c_str());
 			return nullptr;
 		}
 
@@ -242,7 +242,7 @@ std::shared_ptr<MemoryMap> TransactionLogFile::getMemoryMap(uint32_t fileSize) {
 			DWORD error = ::GetLastError();
 			std::string errorMessage = getWindowsErrorMessage(error);
 			DEBUG_LOG("%p TransactionLogFile::getMemoryMap ERROR: Failed to SetFilePointerEx to new size: %s (error=%lu: %s)\n",
-				this, this->path.string().c_str(), error, errorMessage.c_str())
+				this, this->path.string().c_str(), error, errorMessage.c_str());
 			return nullptr;
 		}
 
@@ -251,7 +251,7 @@ std::shared_ptr<MemoryMap> TransactionLogFile::getMemoryMap(uint32_t fileSize) {
 			DWORD error = ::GetLastError();
 			std::string errorMessage = getWindowsErrorMessage(error);
 			DEBUG_LOG("%p TransactionLogFile::getMemoryMap ERROR: Failed to SetEndOfFile: %s (error=%lu: %s)\n",
-				this, this->path.string().c_str(), error, errorMessage.c_str())
+				this, this->path.string().c_str(), error, errorMessage.c_str());
 			return nullptr;
 		}
 
@@ -260,7 +260,7 @@ std::shared_ptr<MemoryMap> TransactionLogFile::getMemoryMap(uint32_t fileSize) {
 			DWORD error = ::GetLastError();
 			std::string errorMessage = getWindowsErrorMessage(error);
 			DEBUG_LOG("%p TransactionLogFile::getMemoryMap ERROR: Failed to restore position: %s (error=%lu: %s)\n",
-				this, this->path.string().c_str(), error, errorMessage.c_str())
+				this, this->path.string().c_str(), error, errorMessage.c_str());
 			return nullptr;
 		}
 	}
@@ -270,7 +270,7 @@ std::shared_ptr<MemoryMap> TransactionLogFile::getMemoryMap(uint32_t fileSize) {
 		DWORD error = ::GetLastError();
 		std::string errorMessage = getWindowsErrorMessage(error);
 		DEBUG_LOG("%p TransactionLogFile::getMemoryMap ERROR: Failed to CreateFileMapping: %s (error=%lu: %s)\n",
-			this, this->path.string().c_str(), error, errorMessage.c_str())
+			this, this->path.string().c_str(), error, errorMessage.c_str());
 		return nullptr;
 	}
 
@@ -281,7 +281,7 @@ std::shared_ptr<MemoryMap> TransactionLogFile::getMemoryMap(uint32_t fileSize) {
 		DWORD error = ::GetLastError();
 		std::string errorMessage = getWindowsErrorMessage(error);
 		DEBUG_LOG("%p TransactionLogFile::getMemoryMap ERROR: Failed to MapViewOfFile: %s (error=%lu: %s)\n",
-			this, this->path.string().c_str(), error, errorMessage.c_str())
+			this, this->path.string().c_str(), error, errorMessage.c_str());
 		::CloseHandle(mh);
 		return nullptr;
 	}
@@ -314,7 +314,7 @@ bool TransactionLogFile::removeFile() {
 
 	if (this->fileHandle != INVALID_HANDLE_VALUE) {
 		DEBUG_LOG("%p TransactionLogFile::removeFile Closing file: %s (handle=%p)\n",
-			this, this->path.string().c_str(), this->fileHandle)
+			this, this->path.string().c_str(), this->fileHandle);
 		::CloseHandle(this->fileHandle);
 		this->fileHandle = INVALID_HANDLE_VALUE;
 	}
@@ -322,12 +322,12 @@ bool TransactionLogFile::removeFile() {
 	auto removed = std::filesystem::remove(this->path);
 	if (!removed) {
 		DEBUG_LOG("%p TransactionLogFile::removeFile File does not exist: %s\n",
-			this, this->path.string().c_str())
+			this, this->path.string().c_str());
 		return false;
 	}
 
 	DEBUG_LOG("%p TransactionLogFile::removeFile Removed file %s\n",
-		this, this->path.string().c_str())
+		this, this->path.string().c_str());
 	return true;
 }
 
@@ -341,7 +341,7 @@ int64_t TransactionLogFile::writeBatchToFile(const iovec* iovecs, int iovcnt) {
 		DWORD error = ::GetLastError();
 		std::string errorMessage = getWindowsErrorMessage(error);
 		DEBUG_LOG("%p TransactionLogFile::writeBatchToFile SetFilePointer failed (error=%lu: %s)\n",
-			this, error, errorMessage.c_str())
+			this, error, errorMessage.c_str());
 		return -1;
 	}
 
@@ -367,7 +367,7 @@ int64_t TransactionLogFile::writeBatchToFile(const iovec* iovecs, int iovcnt) {
 			DWORD error = ::GetLastError();
 			std::string errorMessage = getWindowsErrorMessage(error);
 			DEBUG_LOG("%p TransactionLogFile::writeBatchToFile WriteFile failed (error=%lu: %s, iovec %d/%d)\n",
-				this, error, errorMessage.c_str(), i, iovcnt)
+				this, error, errorMessage.c_str(), i, iovcnt);
 			// if we've written some data but this write failed, return what we
 			// wrote; otherwise return -1 to indicate error
 			return totalBytesWritten > 0 ? totalBytesWritten : -1;

--- a/src/binding/transaction_log_handle.cpp
+++ b/src/binding/transaction_log_handle.cpp
@@ -9,12 +9,12 @@ TransactionLogHandle::TransactionLogHandle(
 	const std::shared_ptr<DBHandle>& dbHandle,
 	const std::string& logName
 ): dbHandle(dbHandle), logName(logName), transactionId(0) {
-	DEBUG_LOG("%p TransactionLogHandle::TransactionLogHandle Creating TransactionLogHandle \"%s\"\n", this, logName.c_str())
+	DEBUG_LOG("%p TransactionLogHandle::TransactionLogHandle Creating TransactionLogHandle \"%s\"\n", this, logName.c_str());
 	this->store = dbHandle->descriptor->resolveTransactionLogStore(logName);
 }
 
 TransactionLogHandle::~TransactionLogHandle() {
-	DEBUG_LOG("%p TransactionLogHandle::~TransactionLogHandle Closing TransactionLogHandle \"%s\"\n", this, this->logName.c_str())
+	DEBUG_LOG("%p TransactionLogHandle::~TransactionLogHandle Closing TransactionLogHandle \"%s\"\n", this, this->logName.c_str());
 	this->close();
 }
 
@@ -30,14 +30,14 @@ void TransactionLogHandle::addEntry(
 
 	auto txnHandle = dbHandle->descriptor->transactionGet(transactionId);
 	if (!txnHandle) {
-		DEBUG_LOG("%p TransactionLogHandle::addEntry ERROR: Transaction id %u not found\n", this, transactionId)
+		DEBUG_LOG("%p TransactionLogHandle::addEntry ERROR: Transaction id %u not found\n", this, transactionId);
 		throw std::runtime_error("Transaction id " + std::to_string(transactionId) + " not found");
 	}
 
 	auto store = this->store.lock();
 	if (!store) {
 		// store was closed/destroyed, try to get or create a new one
-		DEBUG_LOG("%p TransactionLogHandle::addEntry Store was destroyed, re-resolving \"%s\"\n", this, this->logName.c_str())
+		DEBUG_LOG("%p TransactionLogHandle::addEntry Store was destroyed, re-resolving \"%s\"\n", this, this->logName.c_str());
 		store = dbHandle->descriptor->resolveTransactionLogStore(this->logName);
 		this->store = store; // update weak_ptr to point to new store
 	}
@@ -54,7 +54,7 @@ void TransactionLogHandle::addEntry(
 
 void TransactionLogHandle::close() {
 	// remove this handle from the `DBHandle`
-	DEBUG_LOG("%p TransactionLogHandle::close Closing TransactionLogHandle \"%s\"\n", this, this->logName.c_str())
+	DEBUG_LOG("%p TransactionLogHandle::close Closing TransactionLogHandle \"%s\"\n", this, this->logName.c_str());
 
 	auto dbHandle = this->dbHandle.lock();
 	if (dbHandle) {

--- a/src/binding/transaction_log_store.cpp
+++ b/src/binding/transaction_log_store.cpp
@@ -48,7 +48,7 @@ TransactionLogStore::TransactionLogStore(
 }
 
 TransactionLogStore::~TransactionLogStore() {
-	DEBUG_LOG("%p TransactionLogStore::~TransactionLogStore Closing transaction log store \"%s\"\n", this, this->name.c_str())
+	DEBUG_LOG("%p TransactionLogStore::~TransactionLogStore Closing transaction log store \"%s\"\n", this, this->name.c_str());
 	this->close();
 }
 
@@ -57,15 +57,15 @@ void TransactionLogStore::close() {
 	bool expected = false;
 	if (!this->isClosing.compare_exchange_strong(expected, true)) {
 		// already closing, return early
-		DEBUG_LOG("%p TransactionLogStore::close Already closing, skipping \"%s\"\n", this, this->name.c_str())
+		DEBUG_LOG("%p TransactionLogStore::close Already closing, skipping \"%s\"\n", this, this->name.c_str());
 		return;
 	}
 
 	std::unique_lock<std::mutex> lock(this->writeMutex);
 	std::unique_lock<std::mutex> dataSetsLock(this->dataSetsMutex);
-	DEBUG_LOG("%p TransactionLogStore::close Closing transaction log store \"%s\"\n", this, this->name.c_str())
+	DEBUG_LOG("%p TransactionLogStore::close Closing transaction log store \"%s\"\n", this, this->name.c_str());
 	for (const auto& [sequenceNumber, logFile] : this->sequenceFiles) {
-		DEBUG_LOG("%p TransactionLogStore::close Closing log file \"%s\"\n", this, logFile->path.string().c_str())
+		DEBUG_LOG("%p TransactionLogStore::close Closing log file \"%s\"\n", this, logFile->path.string().c_str());
 		logFile->close();
 	}
 
@@ -86,7 +86,7 @@ std::shared_ptr<TransactionLogFile> TransactionLogStore::getLogFile(const uint32
 
 	if (!logFile) {
 		DEBUG_LOG("%p TransactionLogStore::getLogFile No long file found, creating store \"%s\" (seq=%u)\n",
-			this, this->path.string().c_str(), sequenceNumber)
+			this, this->path.string().c_str(), sequenceNumber);
 
 		// ensure the directory exists before creating the file (should already exist)
 		DEBUG_LOG("%p TransactionLogStore::getLogFile Creating directory: %s\n", this, this->path.string().c_str());
@@ -208,7 +208,7 @@ void TransactionLogStore::purge(std::function<void(const std::filesystem::path&)
 		return;
 	}
 
-	DEBUG_LOG("%p TransactionLogStore::purge Purging transaction log store \"%s\" (# files=%u)\n", this, this->name.c_str(), this->sequenceFiles.size())
+	DEBUG_LOG("%p TransactionLogStore::purge Purging transaction log store \"%s\" (# files=%u)\n", this, this->name.c_str(), this->sequenceFiles.size());
 
 	// collect sequence numbers to remove to avoid modifying map during iteration
 	std::vector<uint32_t> sequenceNumbersToRemove;
@@ -228,21 +228,21 @@ void TransactionLogStore::purge(std::function<void(const std::filesystem::path&)
 				}
 			} catch (const std::filesystem::filesystem_error& e) {
 				// file was deleted or doesn't exist
-				DEBUG_LOG("%p TransactionLogStore::purge File no longer exists: %s\n", this, logFile->path.string().c_str())
+				DEBUG_LOG("%p TransactionLogStore::purge File no longer exists: %s\n", this, logFile->path.string().c_str());
 				continue;
 			} catch (const std::exception& e) {
-				DEBUG_LOG("%p TransactionLogStore::purge Failed to get last write time for file %s: %s\n", this, logFile->path.string().c_str(), e.what())
+				DEBUG_LOG("%p TransactionLogStore::purge Failed to get last write time for file %s: %s\n", this, logFile->path.string().c_str(), e.what());
 				continue;
 			} catch (...) {
 				auto eptr = std::current_exception();
 				std::string errorMsg = getExceptionMessage(eptr);
 				DEBUG_LOG("%p TransactionLogStore::purge Unknown error getting last write time for file %s: %s\n",
-					this, logFile->path.string().c_str(), errorMsg.c_str())
+					this, logFile->path.string().c_str(), errorMsg.c_str());
 				continue;
 			}
 		}
 
-		DEBUG_LOG("%p TransactionLogStore::purge Purging log file: %s\n", this, logFile->path.string().c_str())
+		DEBUG_LOG("%p TransactionLogStore::purge Purging log file: %s\n", this, logFile->path.string().c_str());
 
 		// delete the log file
 		auto removed = logFile->removeFile();
@@ -264,17 +264,17 @@ void TransactionLogStore::purge(std::function<void(const std::filesystem::path&)
 	if (this->sequenceFiles.empty() && !sequenceNumbersToRemove.empty()) {
 		try {
 			if (std::filesystem::exists(this->path)) {
-				DEBUG_LOG("%p TransactionLogStore::purge Removing empty log directory: %s\n", this, this->path.string().c_str())
+				DEBUG_LOG("%p TransactionLogStore::purge Removing empty log directory: %s\n", this, this->path.string().c_str());
 				std::filesystem::remove(this->path);
-				DEBUG_LOG("%p TransactionLogStore::purge Removed empty log directory: %s\n", this, this->path.string().c_str())
+				DEBUG_LOG("%p TransactionLogStore::purge Removed empty log directory: %s\n", this, this->path.string().c_str());
 			}
 		} catch (const std::filesystem::filesystem_error& e) {
-			DEBUG_LOG("%p TransactionLogStore::purge Failed to remove log directory %s: %s\n", this, this->path.string().c_str(), e.what())
+			DEBUG_LOG("%p TransactionLogStore::purge Failed to remove log directory %s: %s\n", this, this->path.string().c_str(), e.what());
 		} catch (...) {
 			auto eptr = std::current_exception();
 			std::string errorMsg = getExceptionMessage(eptr);
 			DEBUG_LOG("%p TransactionLogStore::purge Unknown error removing log directory %s: %s\n",
-				this, this->path.string().c_str(), errorMsg.c_str())
+				this, this->path.string().c_str(), errorMsg.c_str());
 		}
 	}
 }
@@ -299,19 +299,19 @@ void TransactionLogStore::registerLogFile(const std::filesystem::path& path, con
 	}
 
 	DEBUG_LOG("%p TransactionLogStore::registerLogFile Added log file: %s (seq=%u)\n",
-		this, path.string().c_str(), sequenceNumber)
+		this, path.string().c_str(), sequenceNumber);
 }
 
 void TransactionLogStore::writeBatch(TransactionLogEntryBatch& batch, LogPosition& logPosition) {
 	DEBUG_LOG("%p TransactionLogStore::writeBatch Adding batch with %zu entries to store \"%s\" (timestamp=%llu)\n",
-		this, batch.entries.size(), this->name.c_str(), batch.timestamp)
+		this, batch.entries.size(), this->name.c_str(), batch.timestamp);
 
 	std::lock_guard<std::mutex> lock(this->writeMutex);
 
 	logPosition = this->nextLogPosition;
 
 	if (batch.timestamp > this->latestTimestamp) {
-		DEBUG_LOG("%p TransactionLogStore::writeBatch Setting latest timestamp to batch timestamp: %f > %f\n", this, batch.timestamp, this->latestTimestamp)
+		DEBUG_LOG("%p TransactionLogStore::writeBatch Setting latest timestamp to batch timestamp: %f > %f\n", this, batch.timestamp, this->latestTimestamp);
 		this->latestTimestamp = batch.timestamp;
 	}
 
@@ -331,7 +331,7 @@ void TransactionLogStore::writeBatch(TransactionLogEntryBatch& batch, LogPositio
 					}
 					break;
 				} catch (const std::exception& e) {
-					DEBUG_LOG("%p TransactionLogStore::writeBatch Failed to open transaction log file: %s\n", this, e.what())
+					DEBUG_LOG("%p TransactionLogStore::writeBatch Failed to open transaction log file: %s\n", this, e.what());
 					// move to next sequence number and try again
 					logFile = nullptr;
 				}
@@ -341,7 +341,7 @@ void TransactionLogStore::writeBatch(TransactionLogEntryBatch& batch, LogPositio
 			// this prevents infinite loops when file open fails (even with maxIndexSize=0)
 			if (logFile == nullptr || this->maxFileSize > 0) {
 				DEBUG_LOG("%p TransactionLogStore::writeBatch Rotating to next sequence for store \"%s\" (logFile=%p, maxIndexSize=%u)\n",
-					this, this->name.c_str(), static_cast<void*>(logFile.get()), this->maxFileSize)
+					this, this->name.c_str(), static_cast<void*>(logFile.get()), this->maxFileSize);
 				this->currentSequenceNumber = this->nextSequenceNumber++;
 				logFile = nullptr;
 			}
@@ -354,13 +354,13 @@ void TransactionLogStore::writeBatch(TransactionLogEntryBatch& batch, LogPositio
 
 		// ensure we have a valid log file before writing
 		if (!logFile) {
-			DEBUG_LOG("%p TransactionLogStore::writeBatch ERROR: Failed to open transaction log file for store \"%s\"\n", this, this->name.c_str())
+			DEBUG_LOG("%p TransactionLogStore::writeBatch ERROR: Failed to open transaction log file for store \"%s\"\n", this, this->name.c_str());
 			throw std::runtime_error("Failed to open transaction log file for store \"" + this->name + "\"");
 		}
 
 		// if the file is older than the retention threshold, rotate to the next file
 		DEBUG_LOG("%p TransactionLogStore::writeBatch Checking if log file is older than threshold (%f) for store \"%s\"\n",
-			this, this->maxAgeThreshold, this->name.c_str())
+			this, this->maxAgeThreshold, this->name.c_str());
 		if (this->maxAgeThreshold > 0) {
 			try {
 				auto thresholdDuration = std::chrono::duration_cast<std::chrono::milliseconds>(
@@ -370,40 +370,40 @@ void TransactionLogStore::writeBatch(TransactionLogEntryBatch& batch, LogPositio
 				auto now = std::chrono::system_clock::now();
 				auto fileAgeMs = std::chrono::duration_cast<std::chrono::milliseconds>(now - lastWriteTime);
 				DEBUG_LOG("%p TransactionLogStore::writeBatch Max age threshold:        %f\n",
-					this, this->maxAgeThreshold)
+					this, this->maxAgeThreshold);
 				DEBUG_LOG("%p TransactionLogStore::writeBatch Retention duration:       %lld ms\n",
-					this, this->retentionMs.count())
+					this, this->retentionMs.count());
 				DEBUG_LOG("%p TransactionLogStore::writeBatch Threshold duration:       %lld ms\n",
-					this, thresholdDuration.count())
+					this, thresholdDuration.count());
 				DEBUG_LOG("%p TransactionLogStore::writeBatch Log file last write time: %lld ms\n",
-					this, std::chrono::duration_cast<std::chrono::milliseconds>(lastWriteTime.time_since_epoch()).count())
+					this, std::chrono::duration_cast<std::chrono::milliseconds>(lastWriteTime.time_since_epoch()).count());
 				DEBUG_LOG("%p TransactionLogStore::writeBatch Now:                      %lld ms\n",
-					this, std::chrono::duration_cast<std::chrono::milliseconds>(now.time_since_epoch()).count())
+					this, std::chrono::duration_cast<std::chrono::milliseconds>(now.time_since_epoch()).count());
 				DEBUG_LOG("%p TransactionLogStore::writeBatch File age:                 %lld ms\n",
-					this, fileAgeMs.count())
+					this, fileAgeMs.count());
 				if (fileAgeMs >= thresholdDuration) {
 					DEBUG_LOG("%p TransactionLogStore::writeBatch Log file is older than threshold (%lld ms >= %lld ms), rotating to next file for store \"%s\"\n",
-						this, fileAgeMs.count(), thresholdDuration.count(), this->name.c_str())
+						this, fileAgeMs.count(), thresholdDuration.count(), this->name.c_str());
 					this->currentSequenceNumber = this->nextSequenceNumber++;
 					continue;
 				}
 			} catch (const std::filesystem::filesystem_error& e) {
 				// file was deleted or doesn't exist yet
 				DEBUG_LOG("%p TransactionLogStore::writeBatch ERROR: File no longer exists or not yet created: %s - %s\n",
-					this, logFile->path.string().c_str(), e.what())
+					this, logFile->path.string().c_str(), e.what());
 				// rotate to next file to avoid using a problematic file
 				this->currentSequenceNumber = this->nextSequenceNumber++;
 				continue;
 			} catch (const std::exception& e) {
 				DEBUG_LOG("%p TransactionLogStore::writeBatch ERROR: Failed to get last write time for file %s: %s\n",
-					this, logFile->path.string().c_str(), e.what())
+					this, logFile->path.string().c_str(), e.what());
 				this->currentSequenceNumber = this->nextSequenceNumber++;
 				continue;
 			} catch (...) {
 				auto eptr = std::current_exception();
 				std::string errorMsg = getExceptionMessage(eptr);
 				DEBUG_LOG("%p TransactionLogStore::writeBatch ERROR: Unknown error getting last write time for file %s: %s\n",
-					this, logFile->path.string().c_str(), errorMsg.c_str())
+					this, logFile->path.string().c_str(), errorMsg.c_str());
 				this->currentSequenceNumber = this->nextSequenceNumber++;
 				continue;
 			}
@@ -412,25 +412,25 @@ void TransactionLogStore::writeBatch(TransactionLogEntryBatch& batch, LogPositio
 		uint32_t sizeBefore = logFile->size;
 
 		DEBUG_LOG("%p TransactionLogStore::writeBatch Writing to log file for store \"%s\" (seq=%u, size=%u, maxIndexSize=%u)\n",
-			this, this->name.c_str(), logFile->sequenceNumber, logFile->size, this->maxFileSize)
+			this, this->name.c_str(), logFile->sequenceNumber, logFile->size, this->maxFileSize);
 
 		// write as much as possible to this file
 		logFile->writeEntries(batch, this->maxFileSize);
 
 		DEBUG_LOG("%p TransactionLogStore::writeBatch Wrote to log file for store \"%s\" (seq=%u, new size=%u)\n",
-			this, this->name.c_str(), logFile->sequenceNumber, logFile->size)
+			this, this->name.c_str(), logFile->sequenceNumber, logFile->size);
 
 		// if no progress was made, rotate to the next file to avoid infinite loop
 		if (logFile->size == sizeBefore) {
-			DEBUG_LOG("%p TransactionLogStore::writeBatch No progress made (size unchanged), rotating to next file for store \"%s\"\n", this, this->name.c_str())
+			DEBUG_LOG("%p TransactionLogStore::writeBatch No progress made (size unchanged), rotating to next file for store \"%s\"\n", this, this->name.c_str());
 			this->currentSequenceNumber = this->nextSequenceNumber++;
 		} else if (this->maxFileSize > 0 && logFile->size >= this->maxFileSize) {
 			// we've reached or exceeded the max size, rotate to the next file
-			DEBUG_LOG("%p TransactionLogStore::writeBatch Log file reached max size, rotating to next file for store \"%s\"\n", this, this->name.c_str())
+			DEBUG_LOG("%p TransactionLogStore::writeBatch Log file reached max size, rotating to next file for store \"%s\"\n", this, this->name.c_str());
 			this->currentSequenceNumber = this->nextSequenceNumber++;
 		} else if (!batch.isComplete()) {
 			// we've written some entries, but the batch is not complete, rotate to the next file
-			DEBUG_LOG("%p TransactionLogStore::writeBatch Batch is not complete, rotating to next file for store \"%s\"\n", this, this->name.c_str())
+			DEBUG_LOG("%p TransactionLogStore::writeBatch Batch is not complete, rotating to next file for store \"%s\"\n", this, this->name.c_str());
 			this->currentSequenceNumber = this->nextSequenceNumber++;
 		}
 		this->nextLogPosition = { logFile->size, this->currentSequenceNumber };
@@ -438,7 +438,7 @@ void TransactionLogStore::writeBatch(TransactionLogEntryBatch& batch, LogPositio
 	std::lock_guard<std::mutex> dataSetsLock(this->dataSetsMutex);
 	uncommittedTransactionPositions.insert(this->nextLogPosition);
 
-	DEBUG_LOG("%p TransactionLogStore::writeBatch Completed writing all entries\n", this)
+	DEBUG_LOG("%p TransactionLogStore::writeBatch Completed writing all entries\n", this);
 }
 
 void TransactionLogStore::commitFinished(const LogPosition position, rocksdb::SequenceNumber rocksSequenceNumber) {
@@ -499,7 +499,8 @@ void TransactionLogStore::databaseFlushBegin(rocksdb::SequenceNumber rocksSequen
 		try {
 			logFile->flush();
 		} catch (const std::exception& e) {
-			DEBUG_LOG("%p TransactionLogStore::databaseFlushBegin ERROR: Failed to flush log file %u: %s\n", this, logFile->sequenceNumber, e.what())
+			DEBUG_LOG("%p TransactionLogStore::databaseFlushBegin ERROR: Failed to flush log file %u: %s\n",
+				this, logFile->sequenceNumber, e.what());
 			// Continue flushing other files even if one fails
 		}
 	}
@@ -521,7 +522,8 @@ void TransactionLogStore::databaseFlushed(rocksdb::SequenceNumber rocksSequenceN
 			latestSequencePosition = sequencePosition.position;
 		}
 	}
-	DEBUG_LOG("%p TransactionLogStore::databaseFlushed, flushed up to logId: %u position %u\n", this, latestSequencePosition.logSequenceNumber, latestSequencePosition.positionInLogFile);
+	DEBUG_LOG("%p TransactionLogStore::databaseFlushed, flushed up to logId: %u position %u\n",
+		this, latestSequencePosition.logSequenceNumber, latestSequencePosition.positionInLogFile);
 
 	// Only write if the position has changed
 	if (latestSequencePosition.fullPosition == lastWrittenFlushedPosition.fullPosition) {
@@ -582,18 +584,18 @@ std::shared_ptr<TransactionLogStore> TransactionLogStore::load(
 						if (delta.count() > 0) {
 							// file is too old, remove it
 							DEBUG_LOG("%p TransactionLogStore::load File \"%s\" age=%lldms, expired %lldms ago, purging\n",
-								store.get(), filePath.filename().string().c_str(), fileAgeMs.count(), delta.count())
+								store.get(), filePath.filename().string().c_str(), fileAgeMs.count(), delta.count());
 							try {
 								DEBUG_LOG("%p TransactionLogStore::load Removing expired file: %s\n", store.get(), filePath.string().c_str());
 								std::filesystem::remove(filePath);
 							} catch (const std::filesystem::filesystem_error& e) {
 								DEBUG_LOG("%p TransactionLogStore::load Failed to remove expired file %s: %s\n",
-									store.get(), filePath.string().c_str(), e.what())
+									store.get(), filePath.string().c_str(), e.what());
 							}
 							continue;
 						} else {
 							DEBUG_LOG("%p TransactionLogStore::load File \"%s\" age=%lldms, not expired, %lldms left\n",
-								store.get(), filePath.filename().string().c_str(), fileAgeMs.count(), delta.count() * -1)
+								store.get(), filePath.filename().string().c_str(), fileAgeMs.count(), delta.count() * -1);
 						}
 					}
 
@@ -601,20 +603,20 @@ std::shared_ptr<TransactionLogStore> TransactionLogStore::load(
 				}
 			} catch (const std::filesystem::filesystem_error& e) {
 				DEBUG_LOG("%p TransactionLogStore::load Failed to process file (filesystem error): %s\n",
-					store.get(), e.what())
+					store.get(), e.what());
 			} catch (const std::exception& e) {
 				DEBUG_LOG("%p TransactionLogStore::load Failed to load file: %s\n",
-					store.get(), e.what())
+					store.get(), e.what());
 			} catch (...) {
 				auto eptr = std::current_exception();
 				std::string errorMsg = getExceptionMessage(eptr);
 				DEBUG_LOG("%p TransactionLogStore::load Unknown error processing file: %s\n",
-					store.get(), errorMsg.c_str())
+					store.get(), errorMsg.c_str());
 			}
 		}
 	} catch (const std::filesystem::filesystem_error& e) {
 		DEBUG_LOG("%p TransactionLogStore::load Failed to iterate directory: %s\n",
-			store.get(), e.what())
+			store.get(), e.what());
 	}
 	store->uncommittedTransactionPositions.insert(store->nextLogPosition);
 

--- a/src/binding/util.cpp
+++ b/src/binding/util.cpp
@@ -67,7 +67,7 @@ void debugLogNapiValue(napi_env env, napi_value value, uint16_t indent, bool isO
 		case napi_null: fprintf(stderr, "null"); break;
 		case napi_boolean: {
 			bool result;
-			NAPI_STATUS_THROWS_VOID(::napi_get_value_bool(env, value, &result))
+			NAPI_STATUS_THROWS_VOID(::napi_get_value_bool(env, value, &result));
 			if (result) {
 				fprintf(stderr, "true");
 			} else {
@@ -77,28 +77,28 @@ void debugLogNapiValue(napi_env env, napi_value value, uint16_t indent, bool isO
 		}
 		case napi_number: {
 			double result;
-			NAPI_STATUS_THROWS_VOID(::napi_get_value_double(env, value, &result))
+			NAPI_STATUS_THROWS_VOID(::napi_get_value_double(env, value, &result));
 			fprintf(stderr, "%f", result);
 			break;
 		}
 		case napi_string: {
 			char buffer[1024];
 			size_t result;
-			NAPI_STATUS_THROWS_VOID(::napi_get_value_string_utf8(env, value, buffer, sizeof(buffer), &result))
+			NAPI_STATUS_THROWS_VOID(::napi_get_value_string_utf8(env, value, buffer, sizeof(buffer), &result));
 			fprintf(stderr, "\"%s\"", buffer);
 			break;
 		}
 		case napi_function:
 		case napi_symbol: {
 			napi_value toStringFn;
-			NAPI_STATUS_THROWS_VOID(::napi_get_named_property(env, value, "toString", &toStringFn))
+			NAPI_STATUS_THROWS_VOID(::napi_get_named_property(env, value, "toString", &toStringFn));
 
 			napi_value resultValue;
 			NAPI_STATUS_THROWS_VOID(::napi_call_function(env, value, toStringFn, 0, nullptr, &resultValue));
 
 			char buffer[128];
 			size_t result;
-			NAPI_STATUS_THROWS_VOID(::napi_get_value_string_utf8(env, resultValue, buffer, sizeof(buffer), &result))
+			NAPI_STATUS_THROWS_VOID(::napi_get_value_string_utf8(env, resultValue, buffer, sizeof(buffer), &result));
 
 			fprintf(stderr, "%s", buffer);
 			break;
@@ -108,14 +108,14 @@ void debugLogNapiValue(napi_env env, napi_value value, uint16_t indent, bool isO
 			NAPI_STATUS_THROWS_VOID(::napi_is_array(env, value, &isArray));
 			if (isArray) {
 				uint32_t length;
-				NAPI_STATUS_THROWS_VOID(::napi_get_array_length(env, value, &length))
+				NAPI_STATUS_THROWS_VOID(::napi_get_array_length(env, value, &length));
 
 				fprintf(stderr, "[");
 				if (length > 0) {
 					fprintf(stderr, "\n");
 					for (uint32_t i = 0; i < length; i++) {
 						napi_value element;
-						NAPI_STATUS_THROWS_VOID(::napi_get_element(env, value, i, &element))
+						NAPI_STATUS_THROWS_VOID(::napi_get_element(env, value, i, &element));
 						debugLogNapiValue(env, element, indent + 1);
 						if (i < length - 1) {
 							fprintf(stderr, ", // %u\n", i);
@@ -127,23 +127,23 @@ void debugLogNapiValue(napi_env env, napi_value value, uint16_t indent, bool isO
 				fprintf(stderr, "]");
 			} else {
 				napi_value properties;
-				NAPI_STATUS_THROWS_VOID(::napi_get_property_names(env, value, &properties))
+				NAPI_STATUS_THROWS_VOID(::napi_get_property_names(env, value, &properties));
 				uint32_t length;
-				NAPI_STATUS_THROWS_VOID(::napi_get_array_length(env, properties, &length))
+				NAPI_STATUS_THROWS_VOID(::napi_get_array_length(env, properties, &length));
 
 				fprintf(stderr, "{");
 				if (length > 0) {
 					fprintf(stderr, "\n");
 					for (uint32_t i = 0; i < length; i++) {
 						napi_value propertyName;
-						NAPI_STATUS_THROWS_VOID(::napi_get_element(env, properties, i, &propertyName))
+						NAPI_STATUS_THROWS_VOID(::napi_get_element(env, properties, i, &propertyName));
 
 						char nameBuffer[1024];
 						size_t nameLength;
-						NAPI_STATUS_THROWS_VOID(::napi_get_value_string_utf8(env, propertyName, nameBuffer, sizeof(nameBuffer), &nameLength))
+						NAPI_STATUS_THROWS_VOID(::napi_get_value_string_utf8(env, propertyName, nameBuffer, sizeof(nameBuffer), &nameLength));
 
 						napi_value propertyValue;
-						NAPI_STATUS_THROWS_VOID(::napi_get_property(env, value, propertyName, &propertyValue))
+						NAPI_STATUS_THROWS_VOID(::napi_get_property(env, value, propertyName, &propertyValue));
 
 						for (uint16_t i = 0; i < indent; i++) {
 							fprintf(stderr, "  ");
@@ -168,7 +168,7 @@ void debugLogNapiValue(napi_env env, napi_value value, uint16_t indent, bool isO
 		case napi_bigint: {
 			int64_t result;
 			bool lossless;
-			NAPI_STATUS_THROWS_VOID(::napi_get_value_bigint_int64(env, value, &result, &lossless))
+			NAPI_STATUS_THROWS_VOID(::napi_get_value_bigint_int64(env, value, &result, &lossless));
 			if (lossless) {
 				fprintf(stderr, "%" PRId64, result);
 			} else {
@@ -306,7 +306,7 @@ static const char* errorCodeStrings[] = {
  * Creates a new JavaScript error object from a RocksDB status.
  */
 void createRocksDBError(napi_env env, rocksdb::Status status, const char* msg, napi_value& error) {
-	ROCKSDB_STATUS_FORMAT_ERROR(status, msg)
+	ROCKSDB_STATUS_FORMAT_ERROR(status, msg);
 
 	napi_value global;
 	napi_value objectCtor;
@@ -316,11 +316,11 @@ void createRocksDBError(napi_env env, rocksdb::Status status, const char* msg, n
 	napi_value errorCode;
 	napi_value errorMsg;
 
-	NAPI_STATUS_THROWS_VOID(::napi_get_global(env, &global))
-	NAPI_STATUS_THROWS_VOID(::napi_get_named_property(env, global, "Object", &objectCtor))
-	NAPI_STATUS_THROWS_VOID(::napi_get_named_property(env, objectCtor, "create", &objectCreateFn))
-	NAPI_STATUS_THROWS_VOID(::napi_get_named_property(env, global, "Error", &errorCtor))
-	NAPI_STATUS_THROWS_VOID(::napi_get_named_property(env, errorCtor, "prototype", &errorProto))
+	NAPI_STATUS_THROWS_VOID(::napi_get_global(env, &global));
+	NAPI_STATUS_THROWS_VOID(::napi_get_named_property(env, global, "Object", &objectCtor));
+	NAPI_STATUS_THROWS_VOID(::napi_get_named_property(env, objectCtor, "create", &objectCreateFn));
+	NAPI_STATUS_THROWS_VOID(::napi_get_named_property(env, global, "Error", &errorCtor));
+	NAPI_STATUS_THROWS_VOID(::napi_get_named_property(env, errorCtor, "prototype", &errorProto));
 
 	const char* codeStr;
 	switch (status.code()) {
@@ -341,14 +341,14 @@ void createRocksDBError(napi_env env, rocksdb::Status status, const char* msg, n
 		case rocksdb::Status::Code::kColumnFamilyDropped: codeStr = errorCodeStrings[15]; break;
 		default: codeStr = errorCodeStrings[0]; break;
 	}
-	NAPI_STATUS_THROWS_VOID(::napi_create_string_utf8(env, codeStr, NAPI_AUTO_LENGTH, &errorCode))
+	NAPI_STATUS_THROWS_VOID(::napi_create_string_utf8(env, codeStr, NAPI_AUTO_LENGTH, &errorCode));
 
-	NAPI_STATUS_THROWS_VOID(::napi_create_string_utf8(env, errorStr.c_str(), errorStr.size(), &errorMsg))
+	NAPI_STATUS_THROWS_VOID(::napi_create_string_utf8(env, errorStr.c_str(), errorStr.size(), &errorMsg));
 
 	napi_value createArgs[1] = { errorProto };
-	NAPI_STATUS_THROWS_VOID(::napi_call_function(env, objectCtor, objectCreateFn, 1, createArgs, &error))
-	NAPI_STATUS_THROWS_VOID(::napi_set_named_property(env, error, "code", errorCode))
-	NAPI_STATUS_THROWS_VOID(::napi_set_named_property(env, error, "message", errorMsg))
+	NAPI_STATUS_THROWS_VOID(::napi_call_function(env, objectCtor, objectCreateFn, 1, createArgs, &error));
+	NAPI_STATUS_THROWS_VOID(::napi_set_named_property(env, error, "code", errorCode));
+	NAPI_STATUS_THROWS_VOID(::napi_set_named_property(env, error, "message", errorMsg));
 }
 
 /**
@@ -363,19 +363,19 @@ void createJSError(napi_env env, const char* code, const char* message, napi_val
 	napi_value errorCode;
 	napi_value errorMsg;
 
-	NAPI_STATUS_THROWS_VOID(::napi_get_global(env, &global))
-	NAPI_STATUS_THROWS_VOID(::napi_get_named_property(env, global, "Object", &objectCtor))
-	NAPI_STATUS_THROWS_VOID(::napi_get_named_property(env, objectCtor, "create", &objectCreateFn))
-	NAPI_STATUS_THROWS_VOID(::napi_get_named_property(env, global, "Error", &errorCtor))
-	NAPI_STATUS_THROWS_VOID(::napi_get_named_property(env, errorCtor, "prototype", &errorProto))
+	NAPI_STATUS_THROWS_VOID(::napi_get_global(env, &global));
+	NAPI_STATUS_THROWS_VOID(::napi_get_named_property(env, global, "Object", &objectCtor));
+	NAPI_STATUS_THROWS_VOID(::napi_get_named_property(env, objectCtor, "create", &objectCreateFn));
+	NAPI_STATUS_THROWS_VOID(::napi_get_named_property(env, global, "Error", &errorCtor));
+	NAPI_STATUS_THROWS_VOID(::napi_get_named_property(env, errorCtor, "prototype", &errorProto));
 
-	NAPI_STATUS_THROWS_VOID(::napi_create_string_utf8(env, code, NAPI_AUTO_LENGTH, &errorCode))
-	NAPI_STATUS_THROWS_VOID(::napi_create_string_utf8(env, message, NAPI_AUTO_LENGTH, &errorMsg))
+	NAPI_STATUS_THROWS_VOID(::napi_create_string_utf8(env, code, NAPI_AUTO_LENGTH, &errorCode));
+	NAPI_STATUS_THROWS_VOID(::napi_create_string_utf8(env, message, NAPI_AUTO_LENGTH, &errorMsg));
 
 	napi_value createArgs[1] = { errorProto };
-	NAPI_STATUS_THROWS_VOID(::napi_call_function(env, objectCtor, objectCreateFn, 1, createArgs, &error))
-	NAPI_STATUS_THROWS_VOID(::napi_set_named_property(env, error, "code", errorCode))
-	NAPI_STATUS_THROWS_VOID(::napi_set_named_property(env, error, "message", errorMsg))
+	NAPI_STATUS_THROWS_VOID(::napi_call_function(env, objectCtor, objectCreateFn, 1, createArgs, &error));
+	NAPI_STATUS_THROWS_VOID(::napi_set_named_property(env, error, "code", errorCode));
+	NAPI_STATUS_THROWS_VOID(::napi_set_named_property(env, error, "message", errorMsg));
 }
 
 /**
@@ -424,9 +424,9 @@ const char* getNapiBufferFromArg(
 		end = length;
 	}
 
-	RANGE_CHECK(start > end, "Buffer start greater than end (start=" << start << ", end=" << end << ")", nullptr)
-	RANGE_CHECK(start > length, "Buffer start greater than length (start=" << start << ", length=" << length << ")", nullptr)
-	RANGE_CHECK(end > length, "Buffer end greater than length (end=" << end << ", length=" << length << ")", nullptr)
+	RANGE_CHECK(start > end, "Buffer start greater than end (start=" << start << ", end=" << end << ")", nullptr);
+	RANGE_CHECK(start > length, "Buffer start greater than length (start=" << start << ", length=" << length << ")", nullptr);
+	RANGE_CHECK(end > length, "Buffer end greater than length (end=" << end << ", length=" << length << ")", nullptr);
 
 	if (data == nullptr) {
 		// data is null because the buffer is empty


### PR DESCRIPTION
This PR uses the same technique that Node.js uses to trick the compiler into requiring semicolons after calling a preprocessor macro. During this, found and removed some unused macros.

Fixes https://github.com/HarperFast/rocksdb-js/issues/243.