### PR TITLE
Export `IteratorOptions` type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,11 +2,13 @@ import { version } from './load-binding.js';
 
 export { RocksDatabase, type RocksDatabaseOptions } from './database.js';
 export { DBIterator } from './dbi-iterator.js';
+export type { IteratorOptions } from './dbi.js';
 export type { Key } from './encoding.js';
 export { constants, shutdown, type TransactionEntry, TransactionLog } from './load-binding.js';
 export * from './parse-transaction-log.js';
 export { type Context, Store } from './store.js';
 export { Transaction } from './transaction.js';
+
 import './transaction-log-reader.js';
 
 export const versions: { rocksdb: string; 'rocksdb-js': string } = {


### PR DESCRIPTION
Noticed that the `IteratorOptions` type should be exported.