### PR TITLE
Add `db.name` prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,18 @@ There's also a static `open()` method for convenience that performs the same thi
 const db = RocksDatabase.open('path/to/db');
 ```
 
+### `db.name: string`
+
+Returns the database column family's name.
+
+```typescript
+const db = new RocksDatabase('path/to/db');
+console.log(db.name); // 'default'
+
+const db2 = new RocksDatabase('path/to/db', { name: 'users' });
+console.log(db.name); // 'users'
+```
+
 ## Data Operations
 
 ### `db.clear(options?): Promise<number>`

--- a/src/database.ts
+++ b/src/database.ts
@@ -41,6 +41,11 @@ export interface RocksDatabaseOptions extends StoreOptions {
  * ```
  */
 export class RocksDatabase extends DBI<DBITransactional> {
+	/**
+	 * The name of the database.
+	 */
+	#name: string;
+
 	constructor(pathOrStore: string | Store, options?: RocksDatabaseOptions) {
 		if (typeof pathOrStore === 'string') {
 			super(new Store(pathOrStore, options));
@@ -49,6 +54,7 @@ export class RocksDatabase extends DBI<DBITransactional> {
 		} else {
 			throw new TypeError('Invalid database path or store');
 		}
+		this.#name = options?.name ?? 'default';
 	}
 
 	/**
@@ -289,6 +295,13 @@ export class RocksDatabase extends DBI<DBITransactional> {
 	 */
 	listLogs(): string[] {
 		return this.store.listLogs();
+	}
+
+	/**
+	 * The name of the database.
+	 */
+	get name(): string {
+		return this.#name;
 	}
 
 	/**

--- a/test/column-families.test.ts
+++ b/test/column-families.test.ts
@@ -8,6 +8,8 @@ describe('Column Families', () => {
 			await db2.put('foo', 'bar2');
 			expect(db.get('foo')).toBe('bar');
 			expect(db2.get('foo')).toBe('bar2');
+			expect(db.name).toBe('default');
+			expect(db2.name).toBe('foo');
 		}));
 
 	it('should reuse same instance for same column family', () =>
@@ -15,5 +17,7 @@ describe('Column Families', () => {
 			await db.put('foo', 'bar');
 			expect(db.get('foo')).toBe('bar');
 			expect(db2.get('foo')).toBe('bar');
+			expect(db.name).toBe('foo');
+			expect(db2.name).toBe('foo');
 		}));
 });


### PR DESCRIPTION
There's no way to know what a `db` instance's column family is and being able to get the name is (very) useful for debugging.