### PR TITLE
Actually use a x64 machine to build the x64 binding

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -55,7 +55,7 @@ jobs:
           - runner: macos-latest
             name: darwin-arm64
             target: arm64
-          - runner: macos-latest
+          - runner: macos-15-intel
             name: darwin-x64
             target: x64
           - runner: ubuntu-24.04-arm


### PR DESCRIPTION
The publish script is using `macos-latest` which is an arm64 machine when we really need an x64 machine.