### PR TITLE
Suppress error if `ldd` is not found

### DIFF
--- a/src/load-binding.ts
+++ b/src/load-binding.ts
@@ -180,6 +180,7 @@ function locateBinding(): string {
 		try {
 			isMusl = readFileSync('/usr/bin/ldd', 'utf8').includes('musl');
 		} catch {
+			// `/usr/bin/ldd` likely doesn't exist
 			if (typeof process.report?.getReport === 'function') {
 				process.report.excludeEnv = true;
 				const report = process.report.getReport() as unknown as {
@@ -191,7 +192,11 @@ function locateBinding(): string {
 						obj.includes('libc.musl-') || obj.includes('ld-musl-')
 					);
 			}
-			isMusl = isMusl || execSync('ldd --version', { encoding: 'utf8' }).includes('musl');
+			try {
+				isMusl = isMusl || execSync('ldd --version', { encoding: 'utf8', stdio: 'pipe' }).includes('musl');
+			} catch {
+				// ldd may not exist on some systems such as Docker Hardened Images
+			}
 		}
 		runtime = isMusl ? '-musl' : '-glibc';
 	}


### PR DESCRIPTION
Docker Hardened Images do not have `ldd` which causes `execSync('ldd')` to throw.