### PR TITLE
Copy start key into iterator to avoid crash when GC frees the start key

### DIFF
--- a/src/binding/db_iterator_handle.cpp
+++ b/src/binding/db_iterator_handle.cpp
@@ -64,7 +64,8 @@ void DBIteratorHandle::close() {
 
 void DBIteratorHandle::init(DBIteratorOptions& options) {
 	if (options.startKeyStr != nullptr) {
-		this->startKey = rocksdb::Slice(options.startKeyStr + options.startKeyStart, options.startKeyEnd - options.startKeyStart);
+		this->startKeyStr = std::string(options.startKeyStr + options.startKeyStart, options.startKeyEnd - options.startKeyStart);
+		this->startKey = rocksdb::Slice(this->startKeyStr);
 		options.readOptions.iterate_lower_bound = &this->startKey;
 
 		DEBUG_LOG("%p DBIteratorHandle::init Start key:", this);


### PR DESCRIPTION
I noticed benchmarks have been flakey lately. I suspect it's because values are being GC'd while still referenced. I found this instance in the iterator where the C++ code was referencing the V8 owned strings which could be the source of instability.