### PR TITLE
Add timeout to benchmark teardown

### DIFF
--- a/benchmark/setup.ts
+++ b/benchmark/setup.ts
@@ -402,7 +402,16 @@ export function workerBenchmark(type: string, options: any): void {
 					`rocksdb-benchmark-${randomBytes(8).toString('hex')}`
 				);
 
-				await activeBenchmark;
+				let teardownTimeoutId: NodeJS.Timeout;
+				await Promise.race([
+					activeBenchmark,
+					new Promise<void>((_, reject) => {
+						teardownTimeoutId = setTimeout(
+							() => reject(new Error('Benchmark teardown timed out')),
+							30_000
+						);
+					}),
+				]).finally(() => clearTimeout(teardownTimeoutId!));
 				activeBenchmark = promise;
 
 				// launch all workers and wait for them to initialize


### PR DESCRIPTION
I noticed when I ran benchmarks locally, the benchmarks hung. Figured we should add a timeout just to be sure.