### PR TITLE
Add transaction log retention override to `purgeLogs()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -729,6 +729,7 @@ const names = db.listLogs();
 Deletes transaction log files older than the `transactionLogRetention` (defaults to 3 days).
 
 - `options: object`
+  - `before?: number` Remove all transaction log files older than the specified timestamp.
   - `destroy?: boolean` When `true`, deletes transaction log stores including all log sequence files
     on disk.
   - `name?: string` The name of a store to limit the purging to.

--- a/src/binding/db_descriptor.cpp
+++ b/src/binding/db_descriptor.cpp
@@ -1554,6 +1554,9 @@ napi_value DBDescriptor::listTransactionLogStores(napi_env env) {
  * Purges transaction logs.
  */
 napi_value DBDescriptor::purgeTransactionLogs(napi_env env, napi_value options) {
+	uint64_t before = 0;
+	NAPI_STATUS_THROWS(rocksdb_js::getProperty(env, options, "before", before));
+
 	bool destroy = false;
 	NAPI_STATUS_THROWS(rocksdb_js::getProperty(env, options, "destroy", destroy));
 
@@ -1575,7 +1578,7 @@ napi_value DBDescriptor::purgeTransactionLogs(napi_env env, napi_value options) 
 				auto path = filePath.string();
 				NAPI_STATUS_THROWS_VOID(::napi_create_string_utf8(env, path.c_str(), path.length(), &logFileValue));
 				NAPI_STATUS_THROWS_VOID(::napi_set_element(env, removed, i++, logFileValue));
-			}, destroy);
+			}, destroy, before);
 
 			if (destroy) {
 				storesToRemove.push_back(store);

--- a/src/binding/transaction_log_store.h
+++ b/src/binding/transaction_log_store.h
@@ -254,11 +254,14 @@ struct TransactionLogStore final {
 	LogPosition getLastFlushedPosition();
 
 	/**
-	 * Purges transaction logs.
+	 * Purges transaction logs. By default, it deletes transaction log files older than the
+	 * retention period (3 days). If `before` is provided, it deletes transaction log files older
+	 * than the specified timestamp. If `all` is true, it deletes all transaction log files.
 	 */
 	void purge(
 		std::function<void(const std::filesystem::path&)> visitor = nullptr,
-		const bool all = false
+		const bool all = false,
+		const uint64_t before = 0
 	);
 
 	/**

--- a/src/load-binding.ts
+++ b/src/load-binding.ts
@@ -91,7 +91,7 @@ type RejectCallback = (err: Error) => void;
 
 export type UserSharedBufferCallback = () => void;
 
-export type PurgeLogsOptions = { destroy?: boolean; name?: string };
+export type PurgeLogsOptions = { before?: number; destroy?: boolean; name?: string };
 
 export type NativeDatabase = {
 	new (): NativeDatabase;


### PR DESCRIPTION
Added a `before` option to let you delete transaction log files older than a certain timestamp, but newer than the retention period.

Fixes #229 