### PR TITLE
Use older Ubuntu to build glibc versions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 24
-          registry-url: "https://registry.npmjs.org"
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Generate GitHub token
         id: github-token
@@ -116,7 +116,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 24
-          registry-url: "https://registry.npmjs.org"
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Generate GitHub token
         id: github-token
@@ -170,7 +170,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 24
-          registry-url: "https://registry.npmjs.org"
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Generate GitHub token
         id: github-token


### PR DESCRIPTION
The RocksDB prebuild for linux glibc runs on Ubuntu 22.04, but the `rocksdb-js` publish workflow builds the binaries on Ubuntu 24.04 which would use the latest glibc! Updated the publish workflow to use the older Ubuntu 22.04.