### PR TITLE
Fix log memory leak fix

### DIFF
--- a/src/binding/transaction_log.cpp
+++ b/src/binding/transaction_log.cpp
@@ -253,7 +253,7 @@ napi_value TransactionLog::GetLastFlushed(napi_env env, napi_callback_info info)
 napi_value TransactionLog::GetPath(napi_env env, napi_callback_info info) {
 	NAPI_METHOD();
 	UNWRAP_TRANSACTION_LOG_HANDLE("GetPath");
-	auto store = (*txnLogHandle)->store;
+	auto store = (*txnLogHandle)->store.lock();
 	if (store) {
 		napi_value result;
 		NAPI_STATUS_THROWS(::napi_create_string_utf8(env, store->path.string().c_str(), store->path.string().size(), &result));

--- a/src/binding/transaction_log_handle.cpp
+++ b/src/binding/transaction_log_handle.cpp
@@ -34,7 +34,7 @@ void TransactionLogHandle::addEntry(
 		throw std::runtime_error("Transaction id " + std::to_string(transactionId) + " not found");
 	}
 
-	auto store = this->store;
+	auto store = this->store.lock();
 	if (!store) {
 		// store was closed/destroyed, try to get or create a new one
 		DEBUG_LOG("%p TransactionLogHandle::addEntry Store was destroyed, re-resolving \"%s\"\n", this, this->logName.c_str());
@@ -63,31 +63,31 @@ void TransactionLogHandle::close() {
 }
 
 uint64_t TransactionLogHandle::getLogFileSize(uint32_t sequenceNumber) {
-	auto store = this->store;
+	auto store = this->store.lock();
 	if (store) return store->getLogFileSize(sequenceNumber);
 	return 0;
 }
 
 std::weak_ptr<MemoryMap> TransactionLogHandle::getMemoryMap(uint32_t sequenceNumber) {
-	auto store = this->store;
+	auto store = this->store.lock();
 	if (store) return store->getMemoryMap(sequenceNumber);
 	return std::weak_ptr<MemoryMap>(); // nullptr
 }
 
 LogPosition TransactionLogHandle::findPosition(double timestamp) {
-	auto store = this->store;
+	auto store = this->store.lock();
 	if (store) return store->findPositionByTimestamp(timestamp);
 	return { 0, 0 };
 }
 
 LogPosition TransactionLogHandle::getLastFlushed() {
-	auto store = this->store;
+	auto store = this->store.lock();
 	if (store) return store->getLastFlushedPosition();
 	return { 0, 0 };
 }
 
 std::weak_ptr<LogPosition> TransactionLogHandle::getLastCommittedPosition() {
-	auto store = this->store;
+	auto store = this->store.lock();
 	if (store) return store->getLastCommittedPosition();
 	return std::weak_ptr<LogPosition>(); // nullptr
 }

--- a/src/binding/transaction_log_handle.h
+++ b/src/binding/transaction_log_handle.h
@@ -17,7 +17,7 @@ struct TransactionLogHandle final : Closable {
 	/**
 	 * The transaction log store.
 	 */
-	std::shared_ptr<TransactionLogStore> store;
+	std::weak_ptr<TransactionLogStore> store;
 
 	/**
 	 * The name of the transaction log store.


### PR DESCRIPTION
Instead of creating a shared_ptr to the `TransactionLogStore` that is "longer lived", we can persist the store before committing and then we don't have to lock the weak_ptr again. This allows us to continue to use the weak_ptr as an "is alive" mechanism.

As apart of testing this, I also properly clean up the sequence files when the transaction log store is closing. I did not fix the unlock/relock when calling purge, but we should do that.