### PR TITLE
Switch the Windows C runtime linking to /MT (static)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1197,6 +1197,11 @@ either `glibc` (default) or `musl`.
 ROCKSDB_LIBC=musl pnpm rebuild
 ```
 
+### Windows C runtime versions
+
+By default on Windows, `rocksdb-js` is compiled with the `/MT` flag. This will statically link the
+C runtime making the binary self-contained and portable.
+
 ### Building RocksDB from Source
 
 To build RocksDB from source, simply set the `ROCKSDB_PATH` environment variable to the path of the

--- a/binding.gyp
+++ b/binding.gyp
@@ -81,7 +81,7 @@
 					# 'defines': ['DEBUG'],
 					'msvs_settings': {
 						'VCCLCompilerTool': {
-							'RuntimeLibrary': 2,
+							'RuntimeLibrary': 0,
 							'ExceptionHandling': 1,
 							'AdditionalOptions!': [],
 							'AdditionalOptions': ['/Zc:__cplusplus', '/std:c++20']
@@ -102,8 +102,8 @@
 					'ldflags': ['--coverage'],
 					'msvs_settings': {
 						'VCCLCompilerTool': {
-							# 'RuntimeLibrary': 3,
-							'RuntimeLibrary': 2,
+							# 'RuntimeLibrary': 1,
+							'RuntimeLibrary': 0,
 							'ExceptionHandling': 1,
 							'AdditionalOptions!': [],
 							# 'AdditionalOptions': ['/Zc:__cplusplus', '/std:c++20']

--- a/scripts/init-rocksdb/download-rocksdb.ts
+++ b/scripts/init-rocksdb/download-rocksdb.ts
@@ -20,8 +20,9 @@ export async function downloadRocksDB(
 	const { arch } = process;
 	let platform = platformMap[process.platform] || process.platform;
 
-	const filename = `rocksdb-${version}-${platform}-${arch}${runtime || ''}`;
-	let [asset] = prebuild.assets.filter((asset) => asset.name.startsWith(filename));
+	const filename = `rocksdb-${version}-${platform}-${arch}${runtime || ''}.`;
+	const assets = prebuild.assets.filter((asset) => asset.name.startsWith(filename));
+	let asset = assets[0];
 
 	if (!asset) {
 		// try the old filename


### PR DESCRIPTION
Switch the linked C runtime to static to provide a better, more stable distributable.