### PR TITLE
Add RocksDB to cache hash

### DIFF
--- a/.github/actions/setup-deps/action.yml
+++ b/.github/actions/setup-deps/action.yml
@@ -13,7 +13,7 @@ runs:
       uses: actions/cache@v4
       with:
         path: deps/rocksdb
-        key: ${{ runner.os }}-rocksdb-${{ hashFiles('package.json') }}
+        key: ${{ runner.os }}-rocksdb-${{ hashFiles('package.json', 'pnpm-lock.yaml', 'deps/rocksdb/**') }}
         restore-keys: |
           ${{ runner.os }}-rocksdb-
 


### PR DESCRIPTION
RocksDB 10.10.1 prebuild was re-released to use /MT instead of /MD after some branches were already created. The existing brances would use the old cache hash which didn't take into account that the RocksDB release actually changed. The solution is to add the `deps/rocksdb` directory to the cache hash files list.