### PR TITLE
Use a mmap overlay to avoid SIGBUS, increment log file sequence numbe…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ build
 deps
 dist
 node_modules
+.clangd
 .claude
 .DS_Store
 .env

--- a/src/binding/transaction.cpp
+++ b/src/binding/transaction.cpp
@@ -1,5 +1,3 @@
-#include <sstream>
-#include <thread>
 #include "database.h"
 #include "db_descriptor.h"
 #include "db_handle.h"

--- a/src/binding/transaction_log_file.cpp
+++ b/src/binding/transaction_log_file.cpp
@@ -198,6 +198,7 @@ void TransactionLogFile::writeEntriesV1(TransactionLogEntryBatch& batch, const u
 
 	batch.currentEntryBytesWritten += static_cast<uint32_t>(bytesWritten);
 	this->size += static_cast<uint32_t>(bytesWritten);
+	this->updateMemoryMapOverlay();
 	DEBUG_LOG("%p TransactionLogFile::writeEntriesV1 Wrote %lld bytes to log file (size=%u, batch state: entryIndex=%zu, bytesWritten=%zu)\n",
 		this, bytesWritten, this->size.load(std::memory_order_relaxed), batch.currentEntryIndex, batch.currentEntryBytesWritten);
 }

--- a/src/binding/transaction_log_file.h
+++ b/src/binding/transaction_log_file.h
@@ -98,6 +98,16 @@ struct TransactionLogFile final {
 	 */
 	std::shared_ptr<MemoryMap> memoryMap = nullptr;
 
+#ifdef PLATFORM_POSIX
+	/**
+	 * The file size at which the last MAP_FIXED overlay was applied over the
+	 * anonymous base mapping. Used to avoid redundant mmap calls; only
+	 * re-overlay when the file has grown past the current overlay's page
+	 * boundary.
+	 */
+	std::atomic<uint32_t> lastOverlaySize = 0;
+#endif
+
 	/**
 	 * The mutex used to protect the file (open/close, read/write, etc).
 	 */
@@ -166,6 +176,14 @@ struct TransactionLogFile final {
 	 * Return a memory map of the file and mark it as in use
 	 */
 	std::shared_ptr<MemoryMap> getMemoryMap(uint32_t fileSize);
+
+	/**
+	 * On POSIX, extends the MAP_FIXED file overlay to cover any new pages
+	 * written since the last overlay. Called after writes that grow the file
+	 * so that cached JS buffers see the new data without re-acquiring.
+	 * No-op on Windows where the file is pre-extended to maxFileSize.
+	 */
+	void updateMemoryMapOverlay();
 
 	/**
 	 * Finds the position in this log file with the oldest transaction that is equal to, or newer than, the provided timestamp.

--- a/src/binding/transaction_log_file_posix.cpp
+++ b/src/binding/transaction_log_file_posix.cpp
@@ -116,6 +116,8 @@ std::shared_ptr<MemoryMap> TransactionLogFile::getMemoryMap(uint32_t fileSize) {
 		return nullptr;
 	}
 
+	std::lock_guard<std::mutex> lock(this->fileMutex);
+
 	if (this->memoryMap) {
 		if (this->memoryMap->mapSize >= fileSize) {
 			this->updateMemoryMapOverlay();

--- a/src/binding/transaction_log_file_posix.cpp
+++ b/src/binding/transaction_log_file_posix.cpp
@@ -21,6 +21,7 @@ void TransactionLogFile::close() {
 		DEBUG_LOG("%p TransactionLogFile::close Closing memory map for: %s (ref count=%ld)\n",
 			this, this->path.string().c_str(), this->memoryMap.use_count());
 		this->memoryMap.reset();
+		this->lastOverlaySize.store(0, std::memory_order_relaxed);
 	}
 
 	if (this->fd >= 0) {
@@ -115,22 +116,63 @@ std::shared_ptr<MemoryMap> TransactionLogFile::getMemoryMap(uint32_t fileSize) {
 		return nullptr;
 	}
 
-	if (!this->memoryMap) {
-		void* map = ::mmap(NULL, fileSize, PROT_READ, MAP_SHARED, this->fd, 0);
-		DEBUG_LOG("%p TransactionLogFile::getMemoryMap new memory map: %p\n", this, map);
-		if (map == MAP_FAILED) {
-			DEBUG_LOG("%p TransactionLogFile::getMemoryMap ERROR: mmap failed: %s", this, ::strerror(errno));
+	if (this->memoryMap) {
+		if (this->memoryMap->mapSize >= fileSize) {
+			this->updateMemoryMapOverlay();
+			this->memoryMap->fileSize = fileSize;
+			return this->memoryMap;
+		}
+		DEBUG_LOG("%p TransactionLogFile::getMemoryMap Existing memory map too small (mapSize=%u, fileSize=%u), remapping\n",
+			this, this->memoryMap->mapSize, fileSize);
+	}
+
+	// On POSIX, mmap(fd, maxFileSize) over a small file causes SIGBUS on
+	// pages entirely beyond the file. We first create an anonymous
+	// zero-filled mapping for the full region, then overlay the actual file
+	// content at the start via MAP_FIXED. Pages beyond the file remain
+	// anonymous and safely read as zero.
+	void* anonMap = ::mmap(NULL, fileSize, PROT_READ, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+	DEBUG_LOG("%p TransactionLogFile::getMemoryMap new anonymous map: %p (size=%u)\n", this, anonMap, fileSize);
+	if (anonMap == MAP_FAILED) {
+		DEBUG_LOG("%p TransactionLogFile::getMemoryMap ERROR: mmap (anonymous) failed: %s\n", this, ::strerror(errno));
+		return nullptr;
+	}
+
+	uint32_t actualSize = std::min(this->size.load(std::memory_order_relaxed), fileSize);
+	if (actualSize > 0 && this->fd >= 0) {
+		void* fileMap = ::mmap(anonMap, actualSize, PROT_READ, MAP_SHARED | MAP_FIXED, this->fd, 0);
+		if (fileMap == MAP_FAILED) {
+			DEBUG_LOG("%p TransactionLogFile::getMemoryMap ERROR: mmap (file overlay) failed: %s\n", this, ::strerror(errno));
+			::munmap(anonMap, fileSize);
 			return nullptr;
 		}
-		// If successful, return a MemoryMap object for tracking references.
-		// Note, that we do not need to do any cleanup from this class's
-		// destructor. Removing files that are memory mapped is perfectly fine,
-		// and the memory map can be safely used indefinitely (the file descriptor
-		// doesn't need to be kept open either).
-		this->memoryMap = std::make_shared<MemoryMap>(map, fileSize);
 	}
-	this->memoryMap->fileSize = fileSize;
+	this->lastOverlaySize.store(actualSize, std::memory_order_relaxed);
+
+	// The MemoryMap destructor calls munmap on the full region, which
+	// correctly frees both anonymous and file-backed pages. Removing files
+	// that are memory mapped is perfectly fine on POSIX, and the memory map
+	// can be safely used indefinitely.
+	this->memoryMap = std::make_shared<MemoryMap>(anonMap, fileSize);
 	return this->memoryMap;
+}
+
+void TransactionLogFile::updateMemoryMapOverlay() {
+	if (!this->memoryMap || !this->memoryMap->map || this->fd < 0) return;
+
+	uint32_t actualSize = std::min(this->size.load(std::memory_order_relaxed), this->memoryMap->mapSize);
+	if (actualSize == 0) return;
+
+	uint32_t lastOverlay = this->lastOverlaySize.load(std::memory_order_relaxed);
+	uint32_t overlayPageEnd = lastOverlay > 0 ? ((lastOverlay + 4095u) & ~4095u) : 0;
+	if (actualSize <= overlayPageEnd) return;
+
+	DEBUG_LOG("%p TransactionLogFile::updateMemoryMapOverlay Extending overlay %u -> %u\n",
+		this, lastOverlay, actualSize);
+	void* result = ::mmap(this->memoryMap->map, actualSize, PROT_READ, MAP_SHARED | MAP_FIXED, this->fd, 0);
+	if (result != MAP_FAILED) {
+		this->lastOverlaySize.store(actualSize, std::memory_order_relaxed);
+	}
 }
 
 int64_t TransactionLogFile::readFromFile(void* buffer, uint32_t size, int64_t offset) {
@@ -147,6 +189,7 @@ bool TransactionLogFile::removeFile() {
 		DEBUG_LOG("%p TransactionLogFile::removeFile Releasing memory map before removing file: %s\n",
 			this, this->path.string().c_str());
 		this->memoryMap.reset();
+		this->lastOverlaySize.store(0, std::memory_order_relaxed);
 	}
 
 	if (this->fd >= 0) {

--- a/src/binding/transaction_log_file_windows.cpp
+++ b/src/binding/transaction_log_file_windows.cpp
@@ -429,6 +429,10 @@ std::string getWindowsErrorMessage(DWORD errorCode) {
 	return message;
 }
 
+void TransactionLogFile::updateMemoryMapOverlay() {
+	// No-op: Windows pre-extends the file to maxFileSize before mapping.
+}
+
 } // namespace rocksdb_js
 
 #endif

--- a/src/binding/transaction_log_file_windows.cpp
+++ b/src/binding/transaction_log_file_windows.cpp
@@ -206,6 +206,8 @@ std::shared_ptr<MemoryMap> TransactionLogFile::getMemoryMap(uint32_t fileSize) {
 		return nullptr;
 	}
 
+	std::lock_guard<std::mutex> lock(this->fileMutex);
+
 	if (this->memoryMap) {
 		if (this->memoryMap->mapSize >= fileSize) {
 			// existing memory map will work

--- a/src/binding/transaction_log_store.cpp
+++ b/src/binding/transaction_log_store.cpp
@@ -321,7 +321,8 @@ void TransactionLogStore::registerLogFile(const std::filesystem::path& path, con
 	}
 
 	// update next sequence number to be one higher than the highest existing
-	if (sequenceNumber >= this->nextSequenceNumber) {
+	// if (sequenceNumber >= this->nextSequenceNumber) {
+	if (sequenceNumber > this->nextSequenceNumber) {
 		this->nextSequenceNumber = sequenceNumber + 1;
 	}
 

--- a/src/binding/transaction_log_store.cpp
+++ b/src/binding/transaction_log_store.cpp
@@ -270,6 +270,18 @@ void TransactionLogStore::doPurge(std::function<void(const std::filesystem::path
 
 	// remove sequence files from the map
 	for (uint32_t sequenceNumber : sequenceNumbersToRemove) {
+		if (sequenceNumber == this->currentSequenceNumber) {
+			// Advance to maintain monotonicity of (sequenceNumber, position)
+			// pairs. Existing shared_ptrs to the old memory map remain valid
+			// until released. Post-increment is safe because registerLogFile
+			// guarantees nextSequenceNumber > currentSequenceNumber.
+			this->currentSequenceNumber = this->nextSequenceNumber++;
+			this->nextLogPosition = { 0, this->currentSequenceNumber };
+			DEBUG_LOG("%p TransactionLogStore::purge Current sequence purged, advanced to %u\n",
+				this, this->currentSequenceNumber);
+
+			// TODO: remove the txn.state file if there are no uncommitted transactions left to flush
+		}
 		this->sequenceFiles.erase(sequenceNumber);
 	}
 
@@ -308,7 +320,7 @@ void TransactionLogStore::registerLogFile(const std::filesystem::path& path, con
 	}
 
 	// update next sequence number to be one higher than the highest existing
-	if (sequenceNumber > this->nextSequenceNumber) {
+	if (sequenceNumber >= this->nextSequenceNumber) {
 		this->nextSequenceNumber = sequenceNumber + 1;
 	}
 

--- a/src/binding/transaction_log_store.cpp
+++ b/src/binding/transaction_log_store.cpp
@@ -270,18 +270,18 @@ void TransactionLogStore::doPurge(std::function<void(const std::filesystem::path
 
 	// remove sequence files from the map
 	for (uint32_t sequenceNumber : sequenceNumbersToRemove) {
-		if (sequenceNumber == this->currentSequenceNumber) {
-			// Advance to maintain monotonicity of (sequenceNumber, position)
-			// pairs. Existing shared_ptrs to the old memory map remain valid
-			// until released. Post-increment is safe because registerLogFile
-			// guarantees nextSequenceNumber > currentSequenceNumber.
-			this->currentSequenceNumber = this->nextSequenceNumber++;
-			this->nextLogPosition = { 0, this->currentSequenceNumber };
-			DEBUG_LOG("%p TransactionLogStore::purge Current sequence purged, advanced to %u\n",
-				this, this->currentSequenceNumber);
+		// if (sequenceNumber == this->currentSequenceNumber) {
+		// 	// Advance to maintain monotonicity of (sequenceNumber, position)
+		// 	// pairs. Existing shared_ptrs to the old memory map remain valid
+		// 	// until released. Post-increment is safe because registerLogFile
+		// 	// guarantees nextSequenceNumber > currentSequenceNumber.
+		// 	this->currentSequenceNumber = this->nextSequenceNumber++;
+		// 	this->nextLogPosition = { 0, this->currentSequenceNumber };
+		// 	DEBUG_LOG("%p TransactionLogStore::purge Current sequence purged, advanced to %u\n",
+		// 		this, this->currentSequenceNumber);
 
-			// TODO: remove the txn.state file if there are no uncommitted transactions left to flush
-		}
+		// 	// TODO: remove the txn.state file if there are no uncommitted transactions left to flush
+		// }
 		this->sequenceFiles.erase(sequenceNumber);
 	}
 
@@ -311,7 +311,8 @@ void TransactionLogStore::registerLogFile(const std::filesystem::path& path, con
 	auto logFile = std::make_shared<TransactionLogFile>(path, sequenceNumber);
 	this->sequenceFiles[sequenceNumber] = logFile;
 
-	if (sequenceNumber >= this->currentSequenceNumber) {
+	// if (sequenceNumber >= this->currentSequenceNumber) {
+	if (sequenceNumber > this->currentSequenceNumber) {
 		if (!logFile->isOpen()) {
 			logFile->open(this->latestTimestamp);
 		}

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -5,7 +5,9 @@ import { defineConfig, type UserConfig } from 'tsdown';
 const { version } = JSON.parse(readFileSync('./package.json', 'utf8'));
 
 const config: UserConfig = defineConfig({
-	external: ['msgpackr', 'ordered-binary'],
+	deps: {
+		neverBundle: ['msgpackr', 'ordered-binary'],
+	},
 	entry: './src/index.ts',
 	format: ['es', 'cjs'],
 	minify: Boolean(process.env.MINIFY),


### PR DESCRIPTION
Use a mmap overlay to avoid SIGBUS, increment log file sequence number if current log file is purged.

This PR supersedes https://github.com/HarperFast/rocksdb-js/pull/481.