### PR TITLE
Fix dead lock when purging transaction logs

### DIFF
--- a/src/binding/db_descriptor.cpp
+++ b/src/binding/db_descriptor.cpp
@@ -48,8 +48,16 @@ public:
 			DEBUG_LOG("%p TransactionLogEventListener::OnFlushBegin flushedSequence=%llu\n",
 				desc.get(), (unsigned long long)flushedSequence);
 
-			std::lock_guard<std::mutex> lock(desc->transactionLogMutex);
-			for (auto& [name, store] : desc->transactionLogStores) {
+			// Collect stores while holding the lock, then call methods without
+			// holding transactionLogMutex to avoid deadlock with purgeTransactionLogs.
+			std::vector<std::shared_ptr<TransactionLogStore>> stores;
+			{
+				std::lock_guard<std::mutex> lock(desc->transactionLogMutex);
+				for (auto& [name, store] : desc->transactionLogStores) {
+					stores.push_back(store);
+				}
+			}
+			for (auto& store : stores) {
 				store->databaseFlushBegin(flushedSequence);
 			}
 		} else {
@@ -90,8 +98,17 @@ public:
 				// The last CF flush has completed for the job, now signal that the database flush is done
 				DEBUG_LOG("%p TransactionLogEventListener::OnFlushCompleted job completed name=%s job id=%d flushedSequence=%llu\n",
 					desc.get(), flush_info.cf_name.c_str(), flush_info.job_id, (unsigned long long)it->second.flushedSequence);
-				std::lock_guard<std::mutex> lock(desc->transactionLogMutex);
-				for (auto& [name, store] : desc->transactionLogStores) {
+
+				// Collect stores while holding the lock, then call methods without
+				// holding transactionLogMutex to avoid deadlock with purgeTransactionLogs.
+				std::vector<std::shared_ptr<TransactionLogStore>> stores;
+				{
+					std::lock_guard<std::mutex> lock(desc->transactionLogMutex);
+					for (auto& [name, store] : desc->transactionLogStores) {
+						stores.push_back(store);
+					}
+				}
+				for (auto& store : stores) {
 					store->databaseFlushed(it->second.flushedSequence);
 				}
 				this->jobTrackers.erase(it); // cleanup
@@ -178,13 +195,24 @@ void DBDescriptor::close() {
 		}
 	}
 
+	// Close transaction log stores WITHOUT holding transactionLogMutex while calling
+	// store->close(), as that acquires writeMutex. If a worker thread is in writeBatch()
+	// holding writeMutex and triggers a RocksDB flush, the flush callback will try to
+	// acquire transactionLogMutex, causing a deadlock.
 	if (!this->transactionLogStores.empty()) {
-		std::lock_guard<std::mutex> logLock(this->transactionLogMutex);
-		DEBUG_LOG("%p DBDescriptor::~DBDescriptor Closing transaction log stores (size=%zu)\n", this, this->transactionLogStores.size());
-		for (auto& [name, transactionLogStore] : this->transactionLogStores) {
-			transactionLogStore->close();
+		std::vector<std::shared_ptr<TransactionLogStore>> storesToClose;
+		{
+			std::lock_guard<std::mutex> logLock(this->transactionLogMutex);
+			DEBUG_LOG("%p DBDescriptor::close Collecting transaction log stores to close (size=%zu)\n", this, this->transactionLogStores.size());
+			for (auto& [name, transactionLogStore] : this->transactionLogStores) {
+				storesToClose.push_back(transactionLogStore);
+			}
+			this->transactionLogStores.clear();
 		}
-		this->transactionLogStores.clear();
+		// Close stores without holding transactionLogMutex
+		for (auto& store : storesToClose) {
+			store->close();
+		}
 	}
 
 	this->transactions.clear();
@@ -1723,6 +1751,15 @@ napi_value DBDescriptor::listTransactionLogStores(napi_env env) {
 
 /**
  * Purges transaction logs.
+ *
+ * IMPORTANT: This method must NOT hold transactionLogMutex while calling
+ * store->purge() or store->tryClose(), as those operations acquire writeMutex.
+ * RocksDB flush event listeners (OnFlushBegin/OnFlushCompleted) acquire
+ * transactionLogMutex, and if a thread holding writeMutex triggers a flush,
+ * we get a deadlock:
+ *   - purgeTransactionLogs: holds transactionLogMutex, waiting for writeMutex
+ *   - worker thread: holds writeMutex, RocksDB flush waiting for callback
+ *   - flush callback: waiting for transactionLogMutex
  */
 napi_value DBDescriptor::purgeTransactionLogs(napi_env env, napi_value options) {
 	uint64_t before = 0;
@@ -1738,35 +1775,52 @@ napi_value DBDescriptor::purgeTransactionLogs(napi_env env, napi_value options) 
 	NAPI_STATUS_THROWS(::napi_create_array(env, &removed));
 
 	size_t i = 0;
+	std::vector<std::shared_ptr<TransactionLogStore>> storesToPurge;
 	std::vector<std::shared_ptr<TransactionLogStore>> storesToRemove;
-	std::lock_guard<std::mutex> lock(this->transactionLogMutex);
 
-	for (auto& entry : this->transactionLogStores) {
-		auto store = entry.second;
-		if (name.empty() || store->name == name) {
-			store->purge([&](const std::filesystem::path& filePath) -> void {
-				napi_value logFileValue;
-				auto path = filePath.string();
-				NAPI_STATUS_THROWS_VOID(::napi_create_string_utf8(env, path.c_str(), path.length(), &logFileValue));
-				NAPI_STATUS_THROWS_VOID(::napi_set_element(env, removed, i++, logFileValue));
-			}, destroy, before);
-
-			if (destroy) {
-				// tryClose() atomically checks for active transactions and marks
-				// the store as closing under writeMutex. If there are active
-				// transactions it returns false and the store is left open.
-				if (store->tryClose()) {
-					storesToRemove.push_back(store);
-				}
+	// Phase 1: Collect stores to process while holding the lock.
+	{
+		std::lock_guard<std::mutex> lock(this->transactionLogMutex);
+		for (auto& entry : this->transactionLogStores) {
+			auto store = entry.second;
+			if (name.empty() || store->name == name) {
+				storesToPurge.push_back(store);
 			}
 		}
 	}
 
-	for (auto& store : storesToRemove) {
-		// tryClose() already closed the store; just remove it from the registry
-		// and delete the directory from disk.
-		this->transactionLogStores.erase(store->name);
+	// Phase 2: Process stores WITHOUT holding transactionLogMutex.
+	// This prevents deadlock with flush event listeners that also need
+	// transactionLogMutex while a thread may be holding writeMutex.
+	for (auto& store : storesToPurge) {
+		store->purge([&](const std::filesystem::path& filePath) -> void {
+			napi_value logFileValue;
+			auto path = filePath.string();
+			NAPI_STATUS_THROWS_VOID(::napi_create_string_utf8(env, path.c_str(), path.length(), &logFileValue));
+			NAPI_STATUS_THROWS_VOID(::napi_set_element(env, removed, i++, logFileValue));
+		}, destroy, before);
 
+		if (destroy) {
+			// tryClose() atomically checks for active transactions and marks
+			// the store as closing under writeMutex. If there are active
+			// transactions it returns false and the store is left open.
+			if (store->tryClose()) {
+				storesToRemove.push_back(store);
+			}
+		}
+	}
+
+	// Phase 3: Remove closed stores from the registry while holding the lock.
+	if (!storesToRemove.empty()) {
+		std::lock_guard<std::mutex> lock(this->transactionLogMutex);
+		for (auto& store : storesToRemove) {
+			// tryClose() already closed the store; just remove it from the registry.
+			this->transactionLogStores.erase(store->name);
+		}
+	}
+
+	// Phase 4: Delete directories outside the lock (I/O operations).
+	for (auto& store : storesToRemove) {
 		try {
 			std::filesystem::remove_all(store->path);
 		} catch (const std::filesystem::filesystem_error& e) {
@@ -1792,8 +1846,15 @@ std::shared_ptr<TransactionLogStore> DBDescriptor::resolveTransactionLogStore(co
 
 	auto it = this->transactionLogStores.find(name);
 	if (it != this->transactionLogStores.end()) {
-		DEBUG_LOG("%p DBDescriptor::resolveTransactionLogStore Found transaction log store \"%s\"\n", this, name.c_str());
-		return it->second;
+		// Check if the store is closing - if so, we need to create a new one.
+		// This can happen when purgeTransactionLogs has called tryClose() (which sets
+		// isClosing=true) but hasn't yet removed the store from the map. We can't
+		// return a closing store because operations on it will fail.
+		if (!it->second->isClosing.load(std::memory_order_relaxed)) {
+			DEBUG_LOG("%p DBDescriptor::resolveTransactionLogStore Found transaction log store \"%s\"\n", this, name.c_str());
+			return it->second;
+		}
+		DEBUG_LOG("%p DBDescriptor::resolveTransactionLogStore Found closing transaction log store \"%s\", creating new one\n", this, name.c_str());
 	}
 
 	auto logDirectory = std::filesystem::path(this->transactionLogsPath) / name;
@@ -1811,7 +1872,8 @@ std::shared_ptr<TransactionLogStore> DBDescriptor::resolveTransactionLogStore(co
 		this->transactionLogRetentionMs,
 		this->transactionLogMaxAgeThreshold
 	);
-	this->transactionLogStores.emplace(txnLogStore->name, txnLogStore);
+	// Use insert_or_assign to replace any closing store with the same name
+	this->transactionLogStores.insert_or_assign(txnLogStore->name, txnLogStore);
 	return txnLogStore;
 }
 

--- a/src/binding/db_descriptor.cpp
+++ b/src/binding/db_descriptor.cpp
@@ -1776,7 +1776,6 @@ napi_value DBDescriptor::purgeTransactionLogs(napi_env env, napi_value options) 
 
 	size_t i = 0;
 	std::vector<std::shared_ptr<TransactionLogStore>> storesToPurge;
-	std::vector<std::shared_ptr<TransactionLogStore>> storesToRemove;
 
 	// Phase 1: Collect stores to process while holding the lock.
 	{
@@ -1804,18 +1803,20 @@ napi_value DBDescriptor::purgeTransactionLogs(napi_env env, napi_value options) 
 			// tryClose() atomically checks for active transactions and marks
 			// the store as closing under writeMutex. If there are active
 			// transactions it returns false and the store is left open.
-			if (store->tryClose()) {
-				storesToRemove.push_back(store);
-			}
+			store->tryClose();
 		}
 	}
 
 	// Phase 3: Remove closed stores from the registry while holding the lock.
 	// Track which stores were actually removed so we only delete their directories.
 	std::vector<std::shared_ptr<TransactionLogStore>> storesActuallyRemoved;
-	if (!storesToRemove.empty()) {
+	if (destroy) {
 		std::lock_guard<std::mutex> lock(this->transactionLogMutex);
-		for (auto& store : storesToRemove) {
+		for (auto& store : storesToPurge) {
+			// Skip stores that weren't successfully closed by tryClose().
+			if (!store->isClosing.load(std::memory_order_relaxed)) {
+				continue;
+			}
 			// Only erase if the store in the map is the same as the one we closed.
 			// A new store with the same name may have been created between Phase 1
 			// and Phase 3 by a concurrent resolveTransactionLogStore() call.

--- a/src/binding/db_descriptor.cpp
+++ b/src/binding/db_descriptor.cpp
@@ -1811,16 +1811,26 @@ napi_value DBDescriptor::purgeTransactionLogs(napi_env env, napi_value options) 
 	}
 
 	// Phase 3: Remove closed stores from the registry while holding the lock.
+	// Track which stores were actually removed so we only delete their directories.
+	std::vector<std::shared_ptr<TransactionLogStore>> storesActuallyRemoved;
 	if (!storesToRemove.empty()) {
 		std::lock_guard<std::mutex> lock(this->transactionLogMutex);
 		for (auto& store : storesToRemove) {
-			// tryClose() already closed the store; just remove it from the registry.
-			this->transactionLogStores.erase(store->name);
+			// Only erase if the store in the map is the same as the one we closed.
+			// A new store with the same name may have been created between Phase 1
+			// and Phase 3 by a concurrent resolveTransactionLogStore() call.
+			auto it = this->transactionLogStores.find(store->name);
+			if (it != this->transactionLogStores.end() && it->second.get() == store.get()) {
+				this->transactionLogStores.erase(it);
+				storesActuallyRemoved.push_back(store);
+			}
 		}
 	}
 
 	// Phase 4: Delete directories outside the lock (I/O operations).
-	for (auto& store : storesToRemove) {
+	// Only delete directories for stores that were actually removed from the map.
+	// If a new store was created with the same name, we must not delete its directory.
+	for (auto& store : storesActuallyRemoved) {
 		try {
 			std::filesystem::remove_all(store->path);
 		} catch (const std::filesystem::filesystem_error& e) {

--- a/test/workers/transaction-log-worker.mts
+++ b/test/workers/transaction-log-worker.mts
@@ -5,11 +5,19 @@ const db = RocksDatabase.open(workerData.path);
 
 parentPort?.on('message', async (event) => {
 	if (event.addManyEntries) {
+		// The main thread may call purgeLogs({ destroy: true }) which can close
+		// a transaction log store while we're trying to use it. This is expected
+		// behavior in concurrent scenarios - we just catch the error and continue.
 		for (let i = 0; i < event.count; i++) {
-			const log = db.useLog('foo');
-			await db.transaction(async (txn) => {
-				log.addEntry(Buffer.from('world'), txn.id);
-			});
+			try {
+				const log = db.useLog('foo');
+				await db.transaction(async (txn) => {
+					log.addEntry(Buffer.from('world'), txn.id);
+				});
+			} catch {
+				// Errors like "Transaction log store is closed" are expected when
+				// the main thread is destroying stores. Just continue to next iteration.
+			}
 		}
 		parentPort?.postMessage({ done: true });
 	} else if (event.close) {


### PR DESCRIPTION
Fixes two related issues. One of them was a deadlock that caused the transaction log worker test to sometimes timeout.

**Issue 1: `DBDescriptor::close()` deadlock**

When closing a descriptor, it would hold `transactionLogMutex` while calling `store->close()` which acquires `writeMutex`. This deadlock occurred when the main thread was closing the descriptor while another thread holds `writeMutex` and RocksDB flush callback is blocked waiting for `transactionLogMutex` to free.

To fix it, update RocksDB flush listeners to hold the `transactionLogMutex` only while we collect the stores to close, release the lock, then signal the database is flushed.

Also, when closing the DB descriptor, hold the `transactionLogMutex` only while we collect the stores to close, then release the lock, then close the stores.

**Issue 2: `resolveTransactionLogStore()` returns stores that are closing/closed**

`purgeTransactionLogs()` calls `tryClose()`, `isClosing` is set to true, but the store is still in the stores map. `resolveTransactionLogStore()` sees the store still in the map and doesn't care if it's closing/closed, so it happily returns it.

The fix is to simply check if the store is closing, and if so, return a new store.

Disclaimer, Claude burned a lot of tokens to find and fix the deadlock.