### PR TITLE
Export `RocksDBStats` type

### DIFF
--- a/README.md
+++ b/README.md
@@ -662,18 +662,20 @@ const db = RocksDatabase.open('/path/to/db', {
 console.log(db.getStats());
 ```
 
-### `db.getStat(statName: string): number`
+### `db.getStat(statName: string): RocksDBStat`
 
-Retrieves a single statistic value.
+Retrieves a single statistic value. Return value is either a `number` or `StatsHistogramData`
+object.
 
 ```typescript
 console.log(db.getStat('rocksdb.block.cache.miss'));
 ```
 
-### `db.getStats(all?: boolean): Object<string, number | StatsHistogramData>`
+### `db.getStats(all?: boolean): RocksDBStats`
 
 Returns an object containing a curated list of column family-level properties, internal tickers
-stats, and internal histogram stats.
+stats, and internal histogram stats. Return value is an object with the stat name as the key and
+a `RocksDBStat` as the value.
 
 By default, it only returns the most meaningful internal stats. When `all = true`, it returns the
 same column family-level properties, but includes all internal tickers and histogram stats.
@@ -722,6 +724,14 @@ The `stats.StatsLevel` contains constants used to set which types of skip and re
 - `StatsLevel.ExceptDetailedTimers` Skip time waiting for mutex locks and compression.
 - `StatsLevel.ExceptTimeForMutex` Skip time waiting for mutex locks.
 - `StatsLevel.All` Collects all stats.
+
+### `type RocksDBStat = number | StatsHistogramData`
+
+A `RocksDBStat` is either a `number` or `StatsHistogramData` object.
+
+### `type RocksDBStats = Record<string, RocksDBStat>`
+
+A `RocksDBStats` is an object with the stat name as the key and a `RocksDBStat` as the value.
 
 ### `type StatsHistogramData`
 

--- a/src/binding/db_handle.cpp
+++ b/src/binding/db_handle.cpp
@@ -141,6 +141,9 @@ napi_value DBHandle::getStats(napi_env env, bool all) {
 	// sst
 	SET_INTERNAL_STAT(result, "rocksdb.total-sst-files-size");
 	SET_INTERNAL_STAT(result, "rocksdb.live-sst-files-size");
+
+	// data size
+	SET_INTERNAL_STAT(result, "rocksdb.estimate-live-data-size");
 	SET_INTERNAL_STAT(result, "rocksdb.estimate-num-keys");
 
 	// block cache

--- a/src/database.ts
+++ b/src/database.ts
@@ -35,6 +35,9 @@ export interface RocksDatabaseOptions extends StoreOptions {
 	name?: string;
 }
 
+export type RocksDBStat = number | StatsHistogramData;
+export type RocksDBStats = Record<string, RocksDBStat>;
+
 /**
  * The main class for interacting with a RocksDB database.
  *
@@ -228,7 +231,7 @@ export class RocksDatabase extends DBI<DBITransactional> {
 	 * @param statName - The name of the statistic to retrieve.
 	 * @returns The statistic value.
 	 */
-	getStat(statName: string): number | StatsHistogramData {
+	getStat(statName: string): RocksDBStat {
 		return this.store.db.getStat(statName);
 	}
 
@@ -241,7 +244,7 @@ export class RocksDatabase extends DBI<DBITransactional> {
 	 * const stats = db.getStats();
 	 * ```
 	 */
-	getStats(all = false): Record<string, number | StatsHistogramData> {
+	getStats(all = false): RocksDBStats {
 		return this.store.db.getStats(all);
 	}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,11 @@
 import { version } from './load-binding.js';
 
-export { RocksDatabase, type RocksDatabaseOptions } from './database.js';
+export {
+	RocksDatabase,
+	type RocksDatabaseOptions,
+	type RocksDBStat,
+	type RocksDBStats,
+} from './database.js';
 export { DBIterator } from './dbi-iterator.js';
 export { DBI, type IteratorOptions } from './dbi.js';
 export type { Key } from './encoding.js';

--- a/test/stats.test.ts
+++ b/test/stats.test.ts
@@ -42,7 +42,7 @@ describe('Statistics', () => {
 
 			stats = db.getStats();
 			expect(stats).toBeDefined();
-			expect(Object.keys(stats).length).toBeLessThan(25);
+			expect(Object.keys(stats).length).toBeLessThanOrEqual(25);
 
 			// internal stats
 			expect(stats['rocksdb.number.keys.written']).toBeUndefined();


### PR DESCRIPTION
This is helpful when calling `getStats()` from TypeScript.