### PR TITLE
Set database name on encoder

### DIFF
--- a/src/database.ts
+++ b/src/database.ts
@@ -446,8 +446,12 @@ export class RocksDatabase extends DBI<DBITransactional> {
 					const bytesWritten = store.writeKey(value, store.encodeBuffer, 0);
 					return store.encodeBuffer.subarray(0, bytesWritten);
 				},
+				copyBuffers: true,
 			};
-			store.encoder.copyBuffers = true;
+		}
+
+		if (store.encoder) {
+			store.encoder.name = this.#name;
 		}
 
 		if (store.decoder && store.decoder.needsStableBuffer !== true) {

--- a/src/encoding.ts
+++ b/src/encoding.ts
@@ -16,6 +16,7 @@ export interface Encoder {
 	encode?: (value: any, mode?: number) => Buffer; // | string;
 	Encoder?: EncoderFunction;
 	freezeData?: boolean;
+	name?: string;
 	needsStableBuffer?: boolean;
 	randomAccessStructure?: boolean;
 	readKey?: (buffer: Buffer, start: number, end: number, inSequence?: boolean) => any;


### PR DESCRIPTION
I noticed [Harper setting the database name on the encoder](https://github.com/HarperFast/harper/commit/02abd63f9eee89403f35c6e0ae2afcd0e02faebc#diff-2a3520ef673512c350042faa431f24956f148f2e19889470bd00a79b5da339c5R116) and figured we might as well do it in rocksdb-js.