### PR TITLE
Remove column family on drop, expose columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,18 @@ const db = RocksDatabase.open('foo');
 db.close();
 ```
 
+### `db.columns: string[]`
+
+Returns the list of column families in the RocksDB database.
+
+```typescript
+const db = RocksDatabase.open('path/to/db');
+console.log(db.columns); // ['default']
+
+const db2 = new RocksDatabase('path/to/db', { name: 'users' });
+console.log(db.columns); // ['default', 'users']
+```
+
 ### `db.config(options)`
 
 Sets global database settings.
@@ -290,11 +302,13 @@ await promise;
 console.log(db.getOldestSnapshotTimestamp()); // returns `0`, no snapshots
 ```
 
-### `db.getDBProperty(propertyName: string): string`
+### `db.getDBProperty(propertyName: string): string | undefined`
 
 Gets a RocksDB database property as a string.
 
 - `propertyName: string` The name of the property to retrieve (e.g., ) `'rocksdb.levelstats'`.
+
+Returns `undefined` if the property is not found.
 
 ```typescript
 const db = RocksDatabase.open('/path/to/database');
@@ -302,11 +316,13 @@ const levelStats = db.getDBProperty('rocksdb.levelstats');
 const stats = db.getDBProperty('rocksdb.stats');
 ```
 
-### `db.getDBIntProperty(propertyName: string): number`
+### `db.getDBIntProperty(propertyName: string): number | undefined`
 
 Gets a RocksDB database property as an integer.
 
 - `propertyName: string` The name of the property to retrieve (e.g., ) `'rocksdb.num-blob-files'`.
+
+Returns `undefined` if the property is not found.
 
 ```typescript
 const db = RocksDatabase.open('/path/to/database');

--- a/src/binding/database.cpp
+++ b/src/binding/database.cpp
@@ -1,4 +1,5 @@
 #include <node_api.h>
+#include <algorithm>
 #include <sstream>
 #include "database.h"
 #include "db_handle.h"
@@ -189,6 +190,38 @@ napi_value Database::Close(napi_env env, napi_callback_info info) {
 }
 
 /**
+ * Returns the list of column families in the RocksDB database.
+ *
+ * @example
+ * ```typescript
+ * const db = new NativeDatabase();
+ * console.log(db.columns);
+ * ```
+ */
+napi_value Database::Columns(napi_env env, napi_callback_info info) {
+	NAPI_METHOD();
+	UNWRAP_DB_HANDLE_AND_OPEN();
+
+	const auto& columns = (*dbHandle)->descriptor->columns;
+	std::vector<std::string> columnNames;
+	columnNames.reserve(columns.size());
+	for (const auto& [name, _column] : columns) {
+		columnNames.push_back(name);
+	}
+	std::sort(columnNames.begin(), columnNames.end());
+
+	napi_value result;
+	size_t i = 0;
+	NAPI_STATUS_THROWS(::napi_create_array(env, &result));
+	for (const auto& name : columnNames) {
+		napi_value columnValue;
+		NAPI_STATUS_THROWS(::napi_create_string_utf8(env, name.c_str(), name.size(), &columnValue));
+		NAPI_STATUS_THROWS(::napi_set_element(env, result, i++, columnValue));
+	}
+	return result;
+}
+
+/**
  * Destroys the RocksDB database.
  *
  * @example
@@ -252,6 +285,8 @@ napi_value Database::Drop(napi_env env, napi_callback_info info) {
 		return nullptr;
 	}
 
+	(*dbHandle)->descriptor->tryUnregisterColumnFamily((*dbHandle)->getColumnFamilyName());
+
 	NAPI_STATUS_THROWS_ERROR(::napi_call_function(
 		env, global, resolve, 0, nullptr, nullptr
 	), "Failed to call resolve function");
@@ -279,6 +314,9 @@ napi_value Database::DropSync(napi_env env, napi_callback_info info) {
 
 	DEBUG_LOG("%p Database::DropSync dropping database: %s\n", dbHandle->get(), (*dbHandle)->path.c_str());
 	ROCKSDB_STATUS_THROWS_ERROR_LIKE((*dbHandle)->descriptor->db->DropColumnFamily((*dbHandle)->getColumnFamilyHandle()), "Drop failed");
+
+	(*dbHandle)->descriptor->tryUnregisterColumnFamily((*dbHandle)->getColumnFamilyName());
+
 	DEBUG_LOG("%p Database::DropSync dropped database\n", dbHandle->get());
 	NAPI_RETURN_UNDEFINED();
 }
@@ -612,7 +650,6 @@ napi_value Database::GetDBProperty(napi_env env, napi_callback_info info) {
 	);
 
 	if (!success) {
-		::napi_throw_error(env, nullptr, "Failed to get database property");
 		NAPI_RETURN_UNDEFINED();
 	}
 
@@ -649,8 +686,6 @@ napi_value Database::GetDBIntProperty(napi_env env, napi_callback_info info) {
 	);
 
 	if (!success) {
-		std::string errorMsg = "Failed to get database integer property \"" + propertyName + "\"";
-		::napi_throw_error(env, nullptr, errorMsg.c_str());
 		NAPI_RETURN_UNDEFINED();
 	}
 
@@ -1238,6 +1273,7 @@ void Database::Init(napi_env env, napi_value exports) {
 		{ "clear", nullptr, Clear, nullptr, nullptr, nullptr, napi_default, nullptr },
 		{ "clearSync", nullptr, ClearSync, nullptr, nullptr, nullptr, napi_default, nullptr },
 		{ "close", nullptr, Close, nullptr, nullptr, nullptr, napi_default, nullptr },
+		{ "columns", nullptr, nullptr, Columns, nullptr, nullptr, napi_default, nullptr },
 		{ "destroy", nullptr, Destroy, nullptr, nullptr, nullptr, napi_default, nullptr },
 		{ "drop", nullptr, Drop, nullptr, nullptr, nullptr, napi_default, nullptr },
 		{ "dropSync", nullptr, DropSync, nullptr, nullptr, nullptr, napi_default, nullptr },

--- a/src/binding/database.h
+++ b/src/binding/database.h
@@ -43,6 +43,7 @@ struct Database final {
 	static napi_value Clear(napi_env env, napi_callback_info info);
 	static napi_value ClearSync(napi_env env, napi_callback_info info);
 	static napi_value Close(napi_env env, napi_callback_info info);
+	static napi_value Columns(napi_env env, napi_callback_info info);
 	static napi_value Destroy(napi_env env, napi_callback_info info);
 	static napi_value Drop(napi_env env, napi_callback_info info);
 	static napi_value DropSync(napi_env env, napi_callback_info info);

--- a/src/binding/db_descriptor.cpp
+++ b/src/binding/db_descriptor.cpp
@@ -818,6 +818,42 @@ uint32_t DBDescriptor::transactionGetNextId() {
 }
 
 /**
+ * Attempts to unregister a column family from the descriptor. This will only
+ * remove the column family from the columns map if there is at most one
+ * DBHandle still referencing it (the one performing the drop).
+ */
+bool DBDescriptor::tryUnregisterColumnFamily(const std::string& columnName) {
+	auto it = this->columns.find(columnName);
+	if (it == this->columns.end()) {
+		DEBUG_LOG("%p DBDescriptor::tryUnregisterColumnFamily column \"%s\" not found\n",
+			this, columnName.c_str());
+		return false;
+	}
+
+	// Check the reference count on the ColumnFamilyDescriptor shared_ptr.
+	// References are held by:
+	// - 1: the columns map entry
+	// - 1: each DBHandle that has this column family open
+	// So if use_count <= 2, only the map and the calling DBHandle hold references.
+	long refCount = it->second.use_count();
+
+	DEBUG_LOG("%p DBDescriptor::tryUnregisterColumnFamily column \"%s\" has %ld references\n",
+		this, columnName.c_str(), refCount);
+
+	// Only unregister if there's at most 2 references (map + the DBHandle doing the drop)
+	if (refCount <= 2) {
+		this->columns.erase(it);
+		DEBUG_LOG("%p DBDescriptor::tryUnregisterColumnFamily unregistered column \"%s\"\n",
+			this, columnName.c_str());
+		return true;
+	}
+
+	DEBUG_LOG("%p DBDescriptor::tryUnregisterColumnFamily column \"%s\" still has %ld other references, not unregistering\n",
+		this, columnName.c_str(), refCount - 2);
+	return false;
+}
+
+/**
  * Called when a lock callback completes (async or sync) to clean up the lock
  * handle and fire the next callback in the queue.
  */

--- a/src/binding/db_descriptor.h
+++ b/src/binding/db_descriptor.h
@@ -223,6 +223,17 @@ public:
 	uint32_t transactionGetNextId();
 
 	/**
+	 * Attempts to unregister a column family from the descriptor. This will
+	 * only remove the column family from the columns map if there is at most
+	 * one DBHandle still referencing it (the one performing the drop).
+	 *
+	 * @param columnName The name of the column family to unregister.
+	 * @returns true if the column family was unregistered, false if other
+	 *          DBHandles are still referencing it.
+	 */
+	bool tryUnregisterColumnFamily(const std::string& columnName);
+
+	/**
 	 * Creates a new user shared buffer or returns an existing one.
 	 *
 	 * @param env The environment of the current callback.

--- a/src/binding/db_handle.h
+++ b/src/binding/db_handle.h
@@ -84,7 +84,7 @@ struct DBHandle final : Closable, AsyncWorkHandle, public std::enable_shared_fro
 	~DBHandle();
 
 	rocksdb::Status clear();
-	void close();
+	void close() override;
 	napi_value get(
 		napi_env env,
 		rocksdb::Slice& key,

--- a/src/database.ts
+++ b/src/database.ts
@@ -118,6 +118,13 @@ export class RocksDatabase extends DBI<DBITransactional> {
 	}
 
 	/**
+	 * Returns the list of column families in the RocksDB database.
+	 */
+	get columns(): string[] {
+		return this.store.db.columns;
+	}
+
+	/**
 	 * Set global database settings.
 	 *
 	 * @param options - The options for the database.
@@ -184,7 +191,7 @@ export class RocksDatabase extends DBI<DBITransactional> {
 	 * const numKeys = db.getDBIntProperty('rocksdb.estimate-num-keys');
 	 * ```
 	 */
-	getDBIntProperty(propertyName: string): number {
+	getDBIntProperty(propertyName: string): number | undefined {
 		return this.store.db.getDBIntProperty(propertyName);
 	}
 
@@ -201,7 +208,7 @@ export class RocksDatabase extends DBI<DBITransactional> {
 	 * const stats = db.getDBProperty('rocksdb.stats');
 	 * ```
 	 */
-	getDBProperty(propertyName: string): string {
+	getDBProperty(propertyName: string): string | undefined {
 		return this.store.db.getDBProperty(propertyName);
 	}
 

--- a/src/load-binding.ts
+++ b/src/load-binding.ts
@@ -129,6 +129,7 @@ export type NativeDatabase = {
 	clear(resolve: ResolveCallback<void>, reject: RejectCallback): void;
 	clearSync(): void;
 	close(): void;
+	columns: string[];
 	destroy(): void;
 	drop(resolve: ResolveCallback<void>, reject: RejectCallback): void;
 	dropSync(): void;
@@ -143,8 +144,8 @@ export type NativeDatabase = {
 		txnId?: number
 	): number;
 	getCount(options?: RangeOptions, txnId?: number): number;
-	getDBIntProperty(propertyName: string): number;
-	getDBProperty(propertyName: string): string;
+	getDBIntProperty(propertyName: string): number | undefined;
+	getDBProperty(propertyName: string): string | undefined;
 	getMonotonicTimestamp(): number;
 	getOldestSnapshotTimestamp(): number;
 	getStat(statName: string): number | StatsHistogramData;

--- a/test/column-families.test.ts
+++ b/test/column-families.test.ts
@@ -10,6 +10,8 @@ describe('Column Families', () => {
 			expect(db2.get('foo')).toBe('bar2');
 			expect(db.name).toBe('default');
 			expect(db2.name).toBe('foo');
+			expect(db.columns).toEqual(['default', 'foo']);
+			expect(db2.columns).toEqual(['default', 'foo']);
 		}));
 
 	it('should reuse same instance for same column family', () =>
@@ -19,5 +21,16 @@ describe('Column Families', () => {
 			expect(db2.get('foo')).toBe('bar');
 			expect(db.name).toBe('foo');
 			expect(db2.name).toBe('foo');
+			expect(db.columns).toEqual(['default', 'foo']);
+			expect(db2.columns).toEqual(['default', 'foo']);
+		}));
+
+	it('should get column families', () =>
+		dbRunner({ skipOpen: true, dbOptions: [{}, { name: 'foo' }] }, async ({ db }, { db: db2 }) => {
+			db.open();
+			expect(db.columns).toEqual(['default']);
+			db2.open();
+			expect(db.columns).toEqual(['default', 'foo']);
+			expect(db2.columns).toEqual(['default', 'foo']);
 		}));
 });

--- a/test/db-properties.test.ts
+++ b/test/db-properties.test.ts
@@ -13,7 +13,7 @@ describe('Database Properties', () => {
 			const levelStats = db.getDBProperty('rocksdb.levelstats');
 			expect(levelStats).toBeDefined();
 			expect(typeof levelStats).toBe('string');
-			expect(levelStats.length).toBeGreaterThan(0);
+			expect(levelStats!.length).toBeGreaterThan(0);
 		}));
 
 	it('should get stats property from database', () =>
@@ -26,7 +26,7 @@ describe('Database Properties', () => {
 			const stats = db.getDBProperty('rocksdb.stats');
 			expect(stats).toBeDefined();
 			expect(typeof stats).toBe('string');
-			expect(stats.length).toBeGreaterThan(0);
+			expect(stats!.length).toBeGreaterThan(0);
 		}));
 
 	it('should get integer property from database', () =>
@@ -50,7 +50,7 @@ describe('Database Properties', () => {
 			await db.flush();
 
 			// Get number of files at level 0, for some reason this is a string property
-			const numFiles = +db.getDBProperty('rocksdb.num-files-at-level0');
+			const numFiles = +db.getDBProperty('rocksdb.num-files-at-level0')!;
 			expect(numFiles).toBeDefined();
 			expect(typeof numFiles).toBe('number');
 			expect(numFiles).toBeGreaterThan(0);
@@ -126,15 +126,21 @@ describe('Database Properties', () => {
 			expect(memTableSize).toBeGreaterThan(0);
 		}));
 
+	it('should return undefined for unknown string property', () =>
+		dbRunner(async ({ db }) => {
+			expect(db.getDBProperty('invalid.property.name.that.does.not.exist')).toBeUndefined();
+		}));
+
+	it('should return undefined for unknown integer property', () =>
+		dbRunner(async ({ db }) => {
+			expect(db.getDBIntProperty('invalid.property.name.that.does.not.exist')).toBeUndefined();
+		}));
+
 	it('should throw error for invalid string property', () =>
 		dbRunner(async ({ db }) => {
 			expect(() => {
 				db.getDBProperty(undefined as any);
 			}).toThrow('Property name is required');
-
-			expect(() => {
-				db.getDBProperty('invalid.property.name.that.does.not.exist');
-			}).toThrow('Failed to get database property');
 		}));
 
 	it('should throw error for invalid integer property', () =>
@@ -142,10 +148,6 @@ describe('Database Properties', () => {
 			expect(() => {
 				db.getDBIntProperty(undefined as any);
 			}).toThrow('Property name is required');
-
-			expect(() => {
-				db.getDBIntProperty('invalid.property.name.that.does.not.exist');
-			}).toThrow('Failed to get database integer property');
 		}));
 
 	it('should throw error when database is not open', () =>

--- a/test/drop.test.ts
+++ b/test/drop.test.ts
@@ -13,6 +13,7 @@ describe('Drop', () => {
 			db.putSync('key', 'value');
 			expect(db.getSync('key')).toBe('value');
 			db.dropSync();
+			expect(db.columns).toEqual(['default']);
 			db.close();
 			db.open();
 			expect(db.getSync('key')).toBeUndefined();
@@ -23,6 +24,7 @@ describe('Drop', () => {
 			db.putSync('key', 'value');
 			expect(db.getSync('key')).toBe('value');
 			await db.drop();
+			expect(db.columns).toEqual(['default']);
 			db.close();
 			db.open();
 			expect(db.getSync('key')).toBeUndefined();
@@ -32,7 +34,9 @@ describe('Drop', () => {
 		dbRunner({ dbOptions: [{ name: 'test' }] }, ({ db }) => {
 			db.putSync('key', 'value');
 			expect(db.getSync('key')).toBe('value');
+			expect(db.columns).toEqual(['default', 'test']);
 			db.dropSync();
+			expect(db.columns).toEqual(['default']);
 			db.close();
 			db.open();
 			expect(db.getSync('key')).toBeUndefined();
@@ -42,7 +46,9 @@ describe('Drop', () => {
 		dbRunner({ dbOptions: [{ name: 'test' }] }, async ({ db }) => {
 			db.putSync('key', 'value');
 			expect(db.getSync('key')).toBe('value');
+			expect(db.columns).toEqual(['default', 'test']);
 			await db.drop();
+			expect(db.columns).toEqual(['default']);
 			db.close();
 			db.open();
 			expect(db.getSync('key')).toBeUndefined();
@@ -56,7 +62,11 @@ describe('Drop', () => {
 				db2.putSync('key2', 'value2');
 				expect(db1.getSync('key')).toBe('value');
 				expect(db2.getSync('key2')).toBe('value2');
+				expect(db1.columns).toEqual(['default', 'test']);
+				expect(db2.columns).toEqual(['default', 'test']);
 				await db1.drop();
+				expect(db1.columns).toEqual(['default', 'test']);
+				expect(db2.columns).toEqual(['default', 'test']);
 				expect(db1.getSync('key')).toBe('value');
 				expect(db2.getSync('key2')).toBe('value2');
 
@@ -65,12 +75,21 @@ describe('Drop', () => {
 				db1.open();
 				expect(db1.getSync('key')).toBe('value');
 				expect(db2.getSync('key2')).toBe('value2');
+				expect(db1.columns).toEqual(['default', 'test']);
+				expect(db2.columns).toEqual(['default', 'test']);
 
 				// close db1 and reopen it, then do the same to db2, keeping column family alive
 				db1.close();
+				expect(db2.columns).toEqual(['default', 'test']);
 				db1.open();
+				expect(db1.columns).toEqual(['default', 'test']);
+				expect(db2.columns).toEqual(['default', 'test']);
 				db2.close();
+				expect(db1.columns).toEqual(['default', 'test']);
 				db2.open();
+				expect(db1.columns).toEqual(['default', 'test']);
+				expect(db2.columns).toEqual(['default', 'test']);
+
 				expect(db1.getSync('key')).toBe('value');
 				expect(db2.getSync('key2')).toBe('value2');
 
@@ -78,7 +97,10 @@ describe('Drop', () => {
 				db1.close();
 				db2.close();
 				db1.open();
+				expect(db1.columns).toEqual(['default', 'test']);
 				db2.open();
+				expect(db1.columns).toEqual(['default', 'test']);
+				expect(db2.columns).toEqual(['default', 'test']);
 				expect(db1.getSync('key')).toBeUndefined();
 				expect(db2.getSync('key2')).toBeUndefined();
 			}


### PR DESCRIPTION
When calling `db.drop()`, it wasn't remove the column from the `DBDescriptor::columns`. The column should only be removed from `columns` once all `DBHandles` to the `DBDescriptor` have been closed.

Added a `db.columns` getter to expose the columns to JS.

Added missing `override` to `DBHandle::close()`.

Have `db.getDBProperty()` and `db.getDBIntProperty()` to return `undefined` if property not found instead of throwing.