### PR TITLE
Fix `TransactionOptions` type and enable `retryOnBusy` to `saveStructures`

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,7 +399,7 @@ Synchronous version of `remove()`.
 
 ## Transactions
 
-### `db.transaction<T>(callback: TransactionCallback<T>, options?: DBTransactionOptions): Promise<T>`
+### `db.transaction<T>(callback: TransactionCallback<T>, options?: TransactionOptions): Promise<T>`
 
 Executes all database operations within the specified callback within a single transaction. If the
 callback completes without error, the database operations are automatically committed. However, if

--- a/src/database.ts
+++ b/src/database.ts
@@ -5,7 +5,7 @@ import {
 	type StatsHistogramData,
 	type PurgeLogsOptions,
 	type RocksDatabaseConfig,
-	type TransactionOptions,
+	type NativeTransactionOptions,
 } from './load-binding.js';
 import {
 	type ArrayBufferWithNotify,
@@ -33,6 +33,22 @@ export interface RocksDatabaseOptions extends StoreOptions {
 	 * @default 'default'
 	 */
 	name?: string;
+}
+
+export interface TransactionOptions extends NativeTransactionOptions {
+	/**
+	 * The maximum number of times to retry the transaction.
+	 *
+	 * @default 3
+	 */
+	maxRetries?: number;
+
+	/**
+	 * Whether to retry the transaction if it fails with `IsBusy`.
+	 *
+	 * @default `true` when the transaction is bound to a transaction log, otherwise `false`
+	 */
+	retryOnBusy?: boolean;
 }
 
 export type RocksDBStat = number | StatsHistogramData;
@@ -408,23 +424,26 @@ export class RocksDatabase extends DBI<DBITransactional> {
 					structures: any,
 					isCompatible: boolean | ((existingStructures: any) => boolean)
 				) => {
-					return this.transactionSync((txn: Transaction) => {
-						// note: we need to get a fresh copy of the shared structures,
-						// so we don't want to use the transaction's getBinarySync()
-						const existingStructuresBuffer = this.getBinarySync(sharedStructuresKey);
-						const existingStructures =
-							existingStructuresBuffer && store.decoder?.decode
-								? store.decoder.decode(existingStructuresBuffer as BufferWithDataView)
-								: undefined;
-						if (typeof isCompatible == 'function') {
-							if (!isCompatible(existingStructures)) {
+					return this.transactionSync(
+						(txn: Transaction, _attempt: number) => {
+							// note: we need to get a fresh copy of the shared structures,
+							// so we don't want to use the transaction's getBinarySync()
+							const existingStructuresBuffer = this.getBinarySync(sharedStructuresKey);
+							const existingStructures =
+								existingStructuresBuffer && store.decoder?.decode
+									? store.decoder.decode(existingStructuresBuffer as BufferWithDataView)
+									: undefined;
+							if (typeof isCompatible == 'function') {
+								if (!isCompatible(existingStructures)) {
+									return false;
+								}
+							} else if (existingStructures && existingStructures.length !== isCompatible) {
 								return false;
 							}
-						} else if (existingStructures && existingStructures.length !== isCompatible) {
-							return false;
-						}
-						txn.putSync(sharedStructuresKey, structures);
-					});
+							txn.putSync(sharedStructuresKey, structures);
+						},
+						{ retryOnBusy: true }
+					);
 				};
 			}
 			store.encoder = new EncoderClass({ ...opts, ...store.encoder });

--- a/src/load-binding.ts
+++ b/src/load-binding.ts
@@ -7,32 +7,18 @@ import { createRequire } from 'node:module';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-export type TransactionOptions = {
+export type NativeTransactionOptions = {
 	/**
 	 * Whether to disable snapshots.
 	 *
 	 * @default false
 	 */
 	disableSnapshot?: boolean;
-
-	/**
-	 * The maximum number of times to retry the transaction.
-	 *
-	 * @default 3
-	 */
-	maxRetries?: number;
-
-	/**
-	 * Whether to retry the transaction if it fails with `IsBusy`.
-	 *
-	 * @default `true` when the transaction is bound to a transaction log, otherwise `false`
-	 */
-	retryOnBusy?: boolean;
 };
 
 export type NativeTransaction = {
 	id: number;
-	new (context: NativeDatabase, options?: TransactionOptions): NativeTransaction;
+	new (context: NativeDatabase, options?: NativeTransactionOptions): NativeTransaction;
 	abort(): void;
 	commit(resolve: () => void, reject: (err: Error) => void): void;
 	commitSync(): void;

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -1,5 +1,5 @@
 import { DBI } from './dbi';
-import { NativeTransaction, type TransactionOptions } from './load-binding.js';
+import { NativeTransaction, type NativeTransactionOptions } from './load-binding.js';
 import { Store } from './store.js';
 
 export class TransactionAlreadyAbortedError extends Error {
@@ -42,7 +42,7 @@ export class Transaction extends DBI {
 	 * @param store - The base store interface for this transaction.
 	 * @param options - The options for the transaction.
 	 */
-	constructor(store: Store, options?: TransactionOptions) {
+	constructor(store: Store, options?: NativeTransactionOptions) {
 		if (store.readOnly) {
 			super(store);
 			this.#txn = { id: 0 } as NativeTransaction;


### PR DESCRIPTION
Found a few inconsistencies with the `TransactionOptions` type.

Also, with https://github.com/HarperFast/rocksdb-js/pull/531 being closed, I thought it was a good idea to add the `retryOnBusy` flag to the `saveStructures` callback.