### PR TITLE
Compaction support

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -53,6 +53,13 @@ jobs:
       matrix:
         node: [20, 22, 24]
         os: [ubuntu-latest, windows-latest, macos-latest]
+        include:
+          - node: 20
+            pnpm-version: '10'
+          - node: 22
+            pnpm-version: latest
+          - node: 24
+            pnpm-version: latest
 
     steps:
       - name: Checkout repository
@@ -61,7 +68,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: latest
+          version: ${{ matrix.pnpm-version }}
 
       - name: Use Node.js ${{ matrix.node }}
         uses: actions/setup-node@v6
@@ -100,6 +107,12 @@ jobs:
         with:
           version: latest
 
+      - name: Use Node.js 24
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: 'pnpm'
+
       - name: Install Bun
         uses: oven-sh/setup-bun@v2
         with:
@@ -135,6 +148,12 @@ jobs:
         uses: pnpm/action-setup@v4
         with:
           version: latest
+
+      - name: Use Node.js 24
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: 'pnpm'
 
       - name: Install Deno
         uses: denoland/setup-deno@v2

--- a/README.md
+++ b/README.md
@@ -193,6 +193,27 @@ const entriesRemoved = db.clearSync();
 console.log(entriesRemoved); // 10
 ```
 
+### `db.compactRange(options?): Promise<void>`
+
+Compacts a range of keys in the database. In RocksDB, deleted keys are not immediately removed from
+the database. Instead, they are marked as deleted and a tombstone is written. This function
+triggers a manual compaction which removes the tombstones and reclaims space.
+
+- `start?: Key` The start key of the range to compact.
+- `end?: Key` The end key of the range to compact.
+
+```typescript
+await db.compactRange();
+```
+
+### `db.compactRangeSync(options?): void`
+
+Synchronous version of `compactRange()`.
+
+```typescript
+db.compactRangeSync();
+```
+
 ### `db.destroy(): void`
 
 Completely removes a database based on the `db` instance's path including all data, column families,
@@ -222,6 +243,23 @@ Synchronous version of `db.drop()`.
 const db = RocksDatabase.open('path/to/db');
 db.dropSync();
 db.close();
+```
+
+### `db.flush(): Promise<void>`
+
+Flushes all in-memory data to disk asynchronously.
+
+```typescript
+await db.flush();
+```
+
+### `db.flushSync(): void`
+
+Flushes all in-memory data to disk synchronously. Note that this can be an expensive operation, so
+it is recommended to use `flush()` if you want to keep the event loop free.
+
+```typescript
+db.flushSync();
 ```
 
 ### `db.get(key: Key, options?: GetOptions): MaybePromise<any>`
@@ -875,23 +913,6 @@ await Promise.all([
 Note: If the `callback` throws an error, Node.js suppress the error. Node.js 18.3.0 introduced a
 `--force-node-api-uncaught-exceptions-policy` flag which will cause errors to emit the
 `'uncaughtException'` event. Future Node.js releases will enable this flag by default.
-
-### `db.flush(): Promise<void>`
-
-Flushes all in-memory data to disk asynchronously.
-
-```typescript
-await db.flush();
-```
-
-### `db.flushSync(): void`
-
-Flushes all in-memory data to disk synchronously. Note that this can be an expensive operation, so
-it is recommended to use `flush()` if you want to keep the event loop free.
-
-```typescript
-db.flushSync();
-```
 
 ## Transaction Log
 

--- a/README.md
+++ b/README.md
@@ -193,25 +193,30 @@ const entriesRemoved = db.clearSync();
 console.log(entriesRemoved); // 10
 ```
 
-### `db.compactRange(options?): Promise<void>`
+### `db.compact(options?): Promise<void>`
 
 Compacts a range of keys in the database. In RocksDB, deleted keys are not immediately removed from
 the database. Instead, they are marked as deleted and a tombstone is written. This function
 triggers a manual compaction which removes the tombstones and reclaims space.
 
-- `start?: Key` The start key of the range to compact.
-- `end?: Key` The end key of the range to compact.
+- `options: object`
+  - `start?: Key` The start key of the range to compact.
+  - `end?: Key` The end key of the range to compact.
 
 ```typescript
-await db.compactRange();
+await db.compact();
+
+await db.compact({ start: 'a', end: 'z' });
 ```
 
-### `db.compactRangeSync(options?): void`
+### `db.compactSync(options?): void`
 
-Synchronous version of `compactRange()`.
+Synchronous version of `compact()`.
 
 ```typescript
-db.compactRangeSync();
+db.compactSync();
+
+db.compactSync({ start: 'a', end: 'z' });
 ```
 
 ### `db.destroy(): void`

--- a/README.md
+++ b/README.md
@@ -1283,6 +1283,7 @@ Available commands:
 
 - `clear` Clear all data in the current column family
 - `columns` List column families
+- `compact` Compact the current column family
 - `count` Count the number of keys in the current column family
 - `drop <column>` Permanently drop a column family
 - `exit` Exit the REPL

--- a/README.md
+++ b/README.md
@@ -105,10 +105,12 @@ Sets global database settings.
   - `blockCacheSize: number` The amount of memory in bytes to use to cache uncompressed blocks.
     Defaults to 32MB. Set to `0` (zero) disables block cache for future opened databases. Existing
     block cache for any opened databases is resized immediately. Negative values throw an error.
+  - `compactOnClose: boolean` When `true`, compacts the database on close. Defaults to `false`.
 
 ```typescript
 RocksDatabase.config({
 	blockCacheSize: 100 * 1024 * 1024, // 100MB
+	compactOnClose: true,
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -1155,6 +1155,8 @@ The default `Store` contains the following methods which can be overridden:
 
 - `constructor(path, options?)`
 - `close()`
+- `compact(options?)`
+- `compactSync(options?)`
 - `decodeKey(key)`
 - `decodeValue(value)`
 - `encodeKey(key)`

--- a/README.md
+++ b/README.md
@@ -199,7 +199,8 @@ console.log(entriesRemoved); // 10
 
 Compacts a range of keys in the database. In RocksDB, deleted keys are not immediately removed from
 the database. Instead, they are marked as deleted and a tombstone is written. This function
-triggers a manual compaction which removes the tombstones and reclaims space.
+triggers a manual compaction which removes the tombstones and reclaims space. Only one compaction
+per database path can be performed at a time.
 
 - `options: object`
   - `start?: Key` The start key of the range to compact.

--- a/bin/rocksdb-js.mjs
+++ b/bin/rocksdb-js.mjs
@@ -12,6 +12,7 @@ import { inspect, parseArgs, styleText } from 'node:util';
 const COMMANDS = {
 	clear: clearCommand,
 	columns: columnsCommand,
+	compact: compactCommand,
 	count: countCommand,
 	drop: dropCommand,
 	exit: () => process.exit(0),
@@ -187,6 +188,21 @@ function columnsCommand() {
 	console.log();
 }
 
+async function compactCommand() {
+	const sizeBefore = currentDB.getDBIntProperty('rocksdb.estimate-live-data-size') ?? 0;
+	const { time } = await run(() => currentDB.compact());
+	const sizeAfter = currentDB.getDBIntProperty('rocksdb.estimate-live-data-size') ?? 0;
+	const ratio =
+		sizeBefore > 0
+			? `reduced by ${(((sizeBefore - sizeAfter) / sizeBefore) * 100).toFixed(2)}%`
+			: sizeAfter > 0
+				? `increased by ${sizeAfter.toLocaleString()} bytes`
+				: 'no change';
+	console.log(`Compacted, ${ratio} ${note(`(${time}ms)`)}`);
+	console.log(`${hl(sizeBefore.toLocaleString())} -> ${hl(sizeAfter.toLocaleString())} bytes\n`);
+	console.log();
+}
+
 async function countCommand() {
 	const { result: count, time } = await run(() => currentDB.getKeysCount());
 	console.log(`Count: ${hl(count)} ${note(`(${time}ms)`)}\n`);
@@ -257,6 +273,7 @@ async function propCommand(args) {
 function helpCommand() {
 	console.log(`${hl('clear')}                      Clear all data in the current column family`);
 	console.log(`${hl('columns')}                    List column families`);
+	console.log(`${hl('compact')}                    Compact the current column family`);
 	console.log(
 		`${hl('count')}                      Count the number of keys in the current column family`
 	);

--- a/src/binding/database.cpp
+++ b/src/binding/database.cpp
@@ -222,6 +222,177 @@ napi_value Database::Columns(napi_env env, napi_callback_info info) {
 }
 
 /**
+ * Compacts the entire key range of the database asynchronously.
+ * This triggers manual compaction which removes tombstones and reclaims space.
+ *
+ * @example
+ * ```typescript
+ * const db = new NativeDatabase();
+ * await db.compact();
+ * ```
+ */
+napi_value Database::Compact(napi_env env, napi_callback_info info) {
+	NAPI_METHOD_ARGV(4);
+	UNWRAP_DB_HANDLE_AND_OPEN();
+
+	if ((*dbHandle)->descriptor->readOnly) {
+		NAPI_RETURN_UNDEFINED();
+	}
+
+	napi_value resolve = argv[0];
+	napi_value reject = argv[1];
+
+	auto state = new AsyncCompactState(env, *dbHandle);
+
+	// Check for optional start key (argv[2])
+	napi_valuetype startType;
+	NAPI_STATUS_THROWS(::napi_typeof(env, argv[2], &startType));
+	if (startType != napi_undefined && startType != napi_null) {
+		rocksdb::Slice startSlice;
+		if (!rocksdb_js::getSliceFromArg(env, argv[2], startSlice, (*dbHandle)->defaultKeyBufferPtr, "Start key must be a buffer")) {
+			delete state;
+			return nullptr;
+		}
+		state->startKey = std::string(startSlice.data(), startSlice.size());
+		state->hasStart = true;
+	}
+
+	// Check for optional end key (argv[3])
+	napi_valuetype endType;
+	NAPI_STATUS_THROWS(::napi_typeof(env, argv[3], &endType));
+	if (endType != napi_undefined && endType != napi_null) {
+		rocksdb::Slice endSlice;
+		if (!rocksdb_js::getSliceFromArg(env, argv[3], endSlice, (*dbHandle)->defaultKeyBufferPtr, "End key must be a buffer")) {
+			delete state;
+			return nullptr;
+		}
+		state->endKey = std::string(endSlice.data(), endSlice.size());
+		state->hasEnd = true;
+	}
+
+	napi_value name;
+	NAPI_STATUS_THROWS(::napi_create_string_utf8(
+		env,
+		"database.compact",
+		NAPI_AUTO_LENGTH,
+		&name
+	));
+
+	NAPI_STATUS_THROWS(::napi_create_reference(env, resolve, 1, &state->resolveRef));
+	NAPI_STATUS_THROWS(::napi_create_reference(env, reject, 1, &state->rejectRef));
+
+	NAPI_STATUS_THROWS(::napi_create_async_work(
+		env,       // node_env
+		nullptr,   // async_resource
+		name,      // async_resource_name
+		[](napi_env doNotUse, void* data) { // execute
+			auto state = reinterpret_cast<AsyncCompactState*>(data);
+			// check if database is still open before proceeding
+			if (!state->handle || !state->handle->opened() || state->handle->isCancelled()) {
+				state->status = rocksdb::Status::Aborted("Database closed during compact operation");
+			} else {
+				rocksdb::Slice* startPtr = state->hasStart ? new rocksdb::Slice(state->startKey) : nullptr;
+				rocksdb::Slice* endPtr = state->hasEnd ? new rocksdb::Slice(state->endKey) : nullptr;
+				state->status = state->handle->descriptor->db->CompactRange(
+					rocksdb::CompactRangeOptions(),
+					state->handle->columnDescriptor->column.get(),
+					startPtr,
+					endPtr
+				);
+				delete startPtr;
+				delete endPtr;
+			}
+			// signal that execute handler is complete
+			state->signalExecuteCompleted();
+		},
+		[](napi_env env, napi_status status, void* data) { // complete
+			auto state = reinterpret_cast<AsyncCompactState*>(data);
+
+			state->deleteAsyncWork();
+
+			if (status != napi_cancelled) {
+				if (state->status.ok()) {
+					napi_value undefined;
+					NAPI_STATUS_THROWS_VOID(::napi_get_undefined(env, &undefined));
+					state->callResolve(undefined);
+				} else {
+					ROCKSDB_STATUS_CREATE_NAPI_ERROR_VOID(state->status, "Compact failed");
+					state->callReject(error);
+				}
+			}
+
+			delete state;
+		},
+		state,
+		&state->asyncWork
+	));
+
+	(*dbHandle)->registerAsyncWork();
+
+	NAPI_STATUS_THROWS(::napi_queue_async_work(env, state->asyncWork));
+
+	NAPI_RETURN_UNDEFINED();
+}
+
+/**
+ * Compacts the entire key range of the database synchronously.
+ * This triggers manual compaction which removes tombstones and reclaims space.
+ *
+ * @example
+ * ```typescript
+ * const db = new NativeDatabase();
+ * db.compactSync();
+ * ```
+ * @example
+ * ```typescript
+ * const db = new NativeDatabase();
+ * db.compactSync('a', 'z');
+ * ```
+ */
+napi_value Database::CompactSync(napi_env env, napi_callback_info info) {
+	NAPI_METHOD_ARGV(2);
+	UNWRAP_DB_HANDLE_AND_OPEN();
+
+	if ((*dbHandle)->descriptor->readOnly) {
+		NAPI_RETURN_UNDEFINED();
+	}
+
+	rocksdb::Slice startSlice;
+	rocksdb::Slice* startPtr = nullptr;
+	napi_valuetype startType;
+	NAPI_STATUS_THROWS(::napi_typeof(env, argv[0], &startType));
+	if (startType != napi_undefined && startType != napi_null) {
+		if (!rocksdb_js::getSliceFromArg(env, argv[0], startSlice, (*dbHandle)->defaultKeyBufferPtr, "Start key must be a buffer")) {
+			return nullptr;
+		}
+		startPtr = &startSlice;
+	}
+
+	rocksdb::Slice endSlice;
+	rocksdb::Slice* endPtr = nullptr;
+	napi_valuetype endType;
+	NAPI_STATUS_THROWS(::napi_typeof(env, argv[1], &endType));
+	if (endType != napi_undefined && endType != napi_null) {
+		if (!rocksdb_js::getSliceFromArg(env, argv[1], endSlice, (*dbHandle)->defaultKeyBufferPtr, "End key must be a buffer")) {
+			return nullptr;
+		}
+		endPtr = &endSlice;
+	}
+
+	ROCKSDB_STATUS_THROWS_ERROR_LIKE(
+		(*dbHandle)->descriptor->db->CompactRange(
+			rocksdb::CompactRangeOptions(),
+			(*dbHandle)->columnDescriptor->column.get(),
+			startPtr,
+			endPtr
+		),
+		"Compact failed"
+	);
+
+	NAPI_RETURN_UNDEFINED();
+}
+
+/**
  * Destroys the RocksDB database.
  *
  * @example
@@ -1274,6 +1445,8 @@ void Database::Init(napi_env env, napi_value exports) {
 		{ "clearSync", nullptr, ClearSync, nullptr, nullptr, nullptr, napi_default, nullptr },
 		{ "close", nullptr, Close, nullptr, nullptr, nullptr, napi_default, nullptr },
 		{ "columns", nullptr, nullptr, Columns, nullptr, nullptr, napi_default, nullptr },
+		{ "compact", nullptr, Compact, nullptr, nullptr, nullptr, napi_default, nullptr },
+		{ "compactSync", nullptr, CompactSync, nullptr, nullptr, nullptr, napi_default, nullptr },
 		{ "destroy", nullptr, Destroy, nullptr, nullptr, nullptr, napi_default, nullptr },
 		{ "drop", nullptr, Drop, nullptr, nullptr, nullptr, napi_default, nullptr },
 		{ "dropSync", nullptr, DropSync, nullptr, nullptr, nullptr, napi_default, nullptr },

--- a/src/binding/database.cpp
+++ b/src/binding/database.cpp
@@ -248,12 +248,8 @@ napi_value Database::Compact(napi_env env, napi_callback_info info) {
 	napi_valuetype startType;
 	NAPI_STATUS_THROWS(::napi_typeof(env, argv[2], &startType));
 	if (startType != napi_undefined && startType != napi_null) {
-		rocksdb::Slice startSlice;
-		if (!rocksdb_js::getSliceFromArg(env, argv[2], startSlice, (*dbHandle)->defaultKeyBufferPtr, "Start key must be a buffer")) {
-			delete state;
-			return nullptr;
-		}
-		state->startKey = std::string(startSlice.data(), startSlice.size());
+		NAPI_GET_BUFFER(argv[2], startKey, "Start key must be a buffer");
+		state->startKey = std::string(startKey, startKeyLength);
 		state->hasStart = true;
 	}
 
@@ -261,12 +257,8 @@ napi_value Database::Compact(napi_env env, napi_callback_info info) {
 	napi_valuetype endType;
 	NAPI_STATUS_THROWS(::napi_typeof(env, argv[3], &endType));
 	if (endType != napi_undefined && endType != napi_null) {
-		rocksdb::Slice endSlice;
-		if (!rocksdb_js::getSliceFromArg(env, argv[3], endSlice, (*dbHandle)->defaultKeyBufferPtr, "End key must be a buffer")) {
-			delete state;
-			return nullptr;
-		}
-		state->endKey = std::string(endSlice.data(), endSlice.size());
+		NAPI_GET_BUFFER(argv[3], endKey, "End key must be a buffer");
+		state->endKey = std::string(endKey, endKeyLength);
 		state->hasEnd = true;
 	}
 
@@ -361,9 +353,8 @@ napi_value Database::CompactSync(napi_env env, napi_callback_info info) {
 	napi_valuetype startType;
 	NAPI_STATUS_THROWS(::napi_typeof(env, argv[0], &startType));
 	if (startType != napi_undefined && startType != napi_null) {
-		if (!rocksdb_js::getSliceFromArg(env, argv[0], startSlice, (*dbHandle)->defaultKeyBufferPtr, "Start key must be a buffer")) {
-			return nullptr;
-		}
+		NAPI_GET_BUFFER(argv[0], startKey, "Start key must be a buffer");
+		startSlice = rocksdb::Slice(startKey, startKeyLength);
 		startPtr = &startSlice;
 	}
 
@@ -372,9 +363,8 @@ napi_value Database::CompactSync(napi_env env, napi_callback_info info) {
 	napi_valuetype endType;
 	NAPI_STATUS_THROWS(::napi_typeof(env, argv[1], &endType));
 	if (endType != napi_undefined && endType != napi_null) {
-		if (!rocksdb_js::getSliceFromArg(env, argv[1], endSlice, (*dbHandle)->defaultKeyBufferPtr, "End key must be a buffer")) {
-			return nullptr;
-		}
+		NAPI_GET_BUFFER(argv[1], endKey, "End key must be a buffer");
+		endSlice = rocksdb::Slice(endKey, endKeyLength);
 		endPtr = &endSlice;
 	}
 

--- a/src/binding/database.cpp
+++ b/src/binding/database.cpp
@@ -291,16 +291,15 @@ napi_value Database::Compact(napi_env env, napi_callback_info info) {
 			if (!state->handle || !state->handle->opened() || state->handle->isCancelled()) {
 				state->status = rocksdb::Status::Aborted("Database closed during compact operation");
 			} else {
-				rocksdb::Slice* startPtr = state->hasStart ? new rocksdb::Slice(state->startKey) : nullptr;
-				rocksdb::Slice* endPtr = state->hasEnd ? new rocksdb::Slice(state->endKey) : nullptr;
-				state->status = state->handle->descriptor->db->CompactRange(
-					rocksdb::CompactRangeOptions(),
+				rocksdb::Slice startSlice(state->startKey);
+				rocksdb::Slice endSlice(state->endKey);
+				rocksdb::Slice* startPtr = state->hasStart ? &startSlice : nullptr;
+				rocksdb::Slice* endPtr = state->hasEnd ? &endSlice : nullptr;
+				state->status = state->handle->descriptor->compactRange(
 					state->handle->columnDescriptor->column.get(),
 					startPtr,
 					endPtr
 				);
-				delete startPtr;
-				delete endPtr;
 			}
 			// signal that execute handler is complete
 			state->signalExecuteCompleted();
@@ -380,8 +379,7 @@ napi_value Database::CompactSync(napi_env env, napi_callback_info info) {
 	}
 
 	ROCKSDB_STATUS_THROWS_ERROR_LIKE(
-		(*dbHandle)->descriptor->db->CompactRange(
-			rocksdb::CompactRangeOptions(),
+		(*dbHandle)->descriptor->compactRange(
 			(*dbHandle)->columnDescriptor->column.get(),
 			startPtr,
 			endPtr

--- a/src/binding/database.h
+++ b/src/binding/database.h
@@ -47,6 +47,8 @@ struct Database final {
 	static napi_value Destroy(napi_env env, napi_callback_info info);
 	static napi_value Drop(napi_env env, napi_callback_info info);
 	static napi_value DropSync(napi_env env, napi_callback_info info);
+	static napi_value Compact(napi_env env, napi_callback_info info);
+	static napi_value CompactSync(napi_env env, napi_callback_info info);
 	static napi_value Flush(napi_env env, napi_callback_info info);
 	static napi_value FlushSync(napi_env env, napi_callback_info info);
 	static napi_value Get(napi_env env, napi_callback_info info);
@@ -93,6 +95,20 @@ struct AsyncClearState final : BaseAsyncState<std::shared_ptr<DBHandle>> {
 		failureMsg(failureMsg)
 	{}
 };
+
+/**
+ * State for the `CompactRange` async work.
+ */
+struct AsyncCompactState final : BaseAsyncState<std::shared_ptr<DBHandle>> {
+	std::string startKey;
+	std::string endKey;
+	bool hasStart = false;
+	bool hasEnd = false;
+
+	AsyncCompactState(napi_env env, std::shared_ptr<DBHandle> handle)
+		: BaseAsyncState<std::shared_ptr<DBHandle>>(env, handle) {}
+};
+
 
 /**
  * State for the `Flush` async work.

--- a/src/binding/db_descriptor.cpp
+++ b/src/binding/db_descriptor.cpp
@@ -153,6 +153,21 @@ void DBDescriptor::close() {
 	// We want to ensure that all in-memory data is written to disk
 	this->flush();
 
+	// Trigger manual compaction on all column families to reclaim space from
+	// tombstones before closing
+	if (!this->readOnly) {
+		for (const auto& [name, columnDesc] : this->columns) {
+			if (columnDesc && columnDesc->column) {
+				this->db->CompactRange(
+					rocksdb::CompactRangeOptions(),
+					columnDesc->column.get(),
+					nullptr,
+					nullptr
+				);
+			}
+		}
+	}
+
 	// Wait for any outstanding (background threads) operations to complete.
 	// Note that this is not setting the RocksDB `close_db` flag since active
 	// references to the databases may still exist. Also, contrary to the

--- a/src/binding/db_descriptor.cpp
+++ b/src/binding/db_descriptor.cpp
@@ -158,12 +158,7 @@ void DBDescriptor::close() {
 	if (!this->readOnly && DBSettings::getInstance().getCompactOnClose()) {
 		for (const auto& [name, columnDesc] : this->columns) {
 			if (columnDesc && columnDesc->column) {
-				this->db->CompactRange(
-					rocksdb::CompactRangeOptions(),
-					columnDesc->column.get(),
-					nullptr,
-					nullptr
-				);
+				this->compactRange(columnDesc->column.get(), nullptr, nullptr);
 			}
 		}
 	}
@@ -1785,6 +1780,21 @@ rocksdb::Status DBDescriptor::flush() {
 	return this->db->Flush(
 		flushOptions,
 		columnHandles
+	);
+}
+
+rocksdb::Status DBDescriptor::compactRange(
+	rocksdb::ColumnFamilyHandle* column,
+	const rocksdb::Slice* start,
+	const rocksdb::Slice* end
+) {
+	std::lock_guard<std::mutex> lock(this->compactMutex);
+	DEBUG_LOG("%p DBDescriptor::compactRange Compacting range\n", this);
+	return this->db->CompactRange(
+		rocksdb::CompactRangeOptions(),
+		column,
+		start,
+		end
 	);
 }
 

--- a/src/binding/db_descriptor.cpp
+++ b/src/binding/db_descriptor.cpp
@@ -155,7 +155,7 @@ void DBDescriptor::close() {
 
 	// Trigger manual compaction on all column families to reclaim space from
 	// tombstones before closing
-	if (!this->readOnly) {
+	if (!this->readOnly && DBSettings::getInstance().getCompactOnClose()) {
 		for (const auto& [name, columnDesc] : this->columns) {
 			if (columnDesc && columnDesc->column) {
 				this->db->CompactRange(

--- a/src/binding/db_descriptor.h
+++ b/src/binding/db_descriptor.h
@@ -30,13 +30,18 @@ struct UserSharedBufferData;
 struct UserSharedBufferFinalizeData;
 
 /**
- * Custom deleter for RocksDB that calls WaitForCompact with close_db=true
- * before destroying the database instance.
+ * Custom deleter for RocksDB that triggers compaction and waits for it to
+ * complete before destroying the database instance.
  */
 struct DBDeleter {
 	void operator()(rocksdb::DB* db) const {
 		if (db) {
 			DEBUG_LOG("DBDeleter::operator() Compacting and closing database\n");
+			// Trigger manual compaction on the default column family to reclaim
+			// space from tombstones before closing. Using nullptr for column family
+			// handle compacts the default column family.
+			db->CompactRange(rocksdb::CompactRangeOptions(), nullptr, nullptr);
+			// Wait for compaction to complete and close the database
 			rocksdb::WaitForCompactOptions options;
 			options.close_db = true;
 			db->WaitForCompact(options);

--- a/src/binding/db_descriptor.h
+++ b/src/binding/db_descriptor.h
@@ -30,18 +30,15 @@ struct UserSharedBufferData;
 struct UserSharedBufferFinalizeData;
 
 /**
- * Custom deleter for RocksDB that triggers compaction and waits for it to
- * complete before destroying the database instance.
+ * Custom deleter for RocksDB that waits for any background compaction to
+ * complete before destroying the database instance. Compaction is triggered
+ * by DBDescriptor::close() before this deleter runs.
  */
 struct DBDeleter {
 	void operator()(rocksdb::DB* db) const {
 		if (db) {
-			DEBUG_LOG("DBDeleter::operator() Compacting and closing database\n");
-			// Trigger manual compaction on the default column family to reclaim
-			// space from tombstones before closing. Using nullptr for column family
-			// handle compacts the default column family.
-			db->CompactRange(rocksdb::CompactRangeOptions(), nullptr, nullptr);
-			// Wait for compaction to complete and close the database
+			DEBUG_LOG("DBDeleter::operator() Waiting for compaction and closing database\n");
+			// Wait for any background compaction to complete and close the database
 			rocksdb::WaitForCompactOptions options;
 			options.close_db = true;
 			db->WaitForCompact(options);

--- a/src/binding/db_descriptor.h
+++ b/src/binding/db_descriptor.h
@@ -128,6 +128,11 @@ struct DBDescriptor final : public std::enable_shared_from_this<DBDescriptor> {
 	std::atomic<bool> closing{false};
 
 	/**
+	 * Mutex to prevent concurrent compaction operations.
+	 */
+	std::mutex compactMutex;
+
+	/**
 	 * Map of listener callbacks by key.
 	 */
 	std::unordered_map<std::string, std::vector<std::shared_ptr<ListenerCallback>>> listenerCallbacks;
@@ -263,6 +268,21 @@ public:
 	napi_value purgeTransactionLogs(napi_env env, napi_value options);
 	std::shared_ptr<TransactionLogStore> resolveTransactionLogStore(const std::string& name);
 	rocksdb::Status flush();
+
+	/**
+	 * Compacts a range of keys in the specified column family. This method is
+	 * thread-safe and uses a mutex to prevent concurrent compaction operations.
+	 *
+	 * @param column The column family to compact.
+	 * @param start The start key of the range (nullptr for beginning).
+	 * @param end The end key of the range (nullptr for end).
+	 * @returns The status of the compaction operation.
+	 */
+	rocksdb::Status compactRange(
+		rocksdb::ColumnFamilyHandle* column,
+		const rocksdb::Slice* start,
+		const rocksdb::Slice* end
+	);
 };
 
 /**

--- a/src/binding/db_handle.cpp
+++ b/src/binding/db_handle.cpp
@@ -29,8 +29,7 @@ rocksdb::Status DBHandle::clear() {
 	}
 
 	// compact the database to reclaim space
-	rocksdb::Status status = this->descriptor->db->CompactRange(
-		rocksdb::CompactRangeOptions(),
+	rocksdb::Status status = this->descriptor->compactRange(
 		this->columnDescriptor->column.get(),
 		nullptr,
 		nullptr

--- a/src/binding/db_settings.cpp
+++ b/src/binding/db_settings.cpp
@@ -70,6 +70,8 @@ napi_value DBSettings::Config(napi_env env, napi_callback_info info) {
 		}
 	}
 
+	NAPI_STATUS_THROWS(rocksdb_js::getProperty(env, params, "compactOnClose", settings.compactOnClose, false));
+
 	NAPI_RETURN_UNDEFINED();
 }
 

--- a/src/binding/db_settings.h
+++ b/src/binding/db_settings.h
@@ -20,6 +20,8 @@ private:
 	size_t blockCacheSize;
 	std::shared_ptr<rocksdb::Cache> blockCache;
 
+	bool compactOnClose;
+
 public:
 	static DBSettings& getInstance() {
 		if (!instance) {
@@ -33,6 +35,10 @@ public:
 	}
 
 	std::shared_ptr<rocksdb::Cache> getBlockCache();
+
+	inline bool getCompactOnClose() const {
+		return compactOnClose;
+	}
 
 	static napi_value Config(napi_env env, napi_callback_info info);
 

--- a/src/binding/macros.h
+++ b/src/binding/macros.h
@@ -50,14 +50,6 @@
 		} \
 	} while (0)
 
-#define NAPI_STATUS_RETURN(call) \
-	do { \
-		napi_status status = (call); \
-		if (status != napi_ok) { \
-			return status; \
-		} \
-	} while (0)
-
 #define NAPI_STATUS_THROWS_RVAL(call, rval) \
 	do { \
 		napi_status status = (call); \

--- a/src/binding/util.cpp
+++ b/src/binding/util.cpp
@@ -473,27 +473,23 @@ const char* getNapiBufferFromArg(
 bool getSliceFromArg(napi_env env, napi_value arg, rocksdb::Slice& result, char* defaultBuffer, const char* errorMsg) {
 	int32_t length;
 	char* data;
-
-	// check if the argument is a buffer first...
-	// Deno will return successfully a buffer as a int32 with a value of 0
-	bool isBuffer;
-	NAPI_STATUS_THROWS_RVAL(::napi_is_buffer(env, arg, &isBuffer), false);
-
-	if (isBuffer) {
-		size_t bufferLength;
-		NAPI_STATUS_THROWS_RVAL(::napi_get_buffer_info(env, arg, reinterpret_cast<void**>(&data), &bufferLength), false);
-		length = static_cast<int32_t>(bufferLength);
+	// NOTE: Deno will return `napi_ok` if `arg` is a Buffer
+	napi_status argStatus = ::napi_get_value_int32(env, arg, &length);
+	if (argStatus == napi_ok) {
+		// utilize the default shared buffer, if we have a number as a length
+		data = defaultBuffer;
 	} else {
-		napi_status argStatus = ::napi_get_value_int32(env, arg, &length);
-		if (argStatus == napi_ok) {
-			// utilize the default shared buffer, if we have a number as a length
-			data = defaultBuffer;
-		} else {
+		// otherwise, see if we can accept a buffer
+		bool isBuffer;
+		NAPI_STATUS_THROWS_RVAL(::napi_is_buffer(env, arg, &isBuffer), false);
+		if (!isBuffer) {
 			::napi_throw_error(env, nullptr, errorMsg);
 			return false;
 		}
+		size_t bufferLength;
+		NAPI_STATUS_THROWS_RVAL(::napi_get_buffer_info(env, arg, reinterpret_cast<void**>(&data), &bufferLength), false);
+		length = static_cast<int32_t>(bufferLength);
 	}
-
 	result = rocksdb::Slice(data, length);
 	return true;
 }

--- a/src/binding/util.cpp
+++ b/src/binding/util.cpp
@@ -473,22 +473,27 @@ const char* getNapiBufferFromArg(
 bool getSliceFromArg(napi_env env, napi_value arg, rocksdb::Slice& result, char* defaultBuffer, const char* errorMsg) {
 	int32_t length;
 	char* data;
-	napi_status argStatus = ::napi_get_value_int32(env, arg, &length);
-	if (argStatus == napi_ok) {
-		// utilize the default shared buffer, if we have a number as a length
-		data = defaultBuffer;
-	} else {
-		// otherwise, see if we can accept a buffer
-		bool isBuffer;
-		NAPI_STATUS_THROWS_RVAL(::napi_is_buffer(env, arg, &isBuffer), false);
-		if (!isBuffer) {
-			::napi_throw_error(env, nullptr, errorMsg);
-			return false;
-		}
+
+	// check if the argument is a buffer first...
+	// Deno will return successfully a buffer as a int32 with a value of 0
+	bool isBuffer;
+	NAPI_STATUS_THROWS_RVAL(::napi_is_buffer(env, arg, &isBuffer), false);
+
+	if (isBuffer) {
 		size_t bufferLength;
 		NAPI_STATUS_THROWS_RVAL(::napi_get_buffer_info(env, arg, reinterpret_cast<void**>(&data), &bufferLength), false);
 		length = static_cast<int32_t>(bufferLength);
+	} else {
+		napi_status argStatus = ::napi_get_value_int32(env, arg, &length);
+		if (argStatus == napi_ok) {
+			// utilize the default shared buffer, if we have a number as a length
+			data = defaultBuffer;
+		} else {
+			::napi_throw_error(env, nullptr, errorMsg);
+			return false;
+		}
 	}
+
 	result = rocksdb::Slice(data, length);
 	return true;
 }

--- a/src/database.ts
+++ b/src/database.ts
@@ -26,6 +26,11 @@ import * as orderedBinary from 'ordered-binary';
 
 export type TransactionCallback<T> = (txn: Transaction, attempt: number) => T | PromiseLike<T>;
 
+export type CompactOptions = {
+	start?: Key;
+	end?: Key;
+};
+
 export interface RocksDatabaseOptions extends StoreOptions {
 	/**
 	 * The column family name.
@@ -131,6 +136,60 @@ export class RocksDatabase extends DBI<DBITransactional> {
 	 */
 	close(): void {
 		this.store.close();
+	}
+
+	/**
+	 * Compacts the entire key range of the database asynchronously.
+	 * This triggers manual compaction which removes tombstones and reclaims space.
+	 *
+	 * @example
+	 * ```typescript
+	 * const db = RocksDatabase.open('/path/to/database');
+	 * await db.compactRange();
+	 * ```
+	 */
+	compact(options?: CompactOptions): Promise<void> {
+		let startBuffer: Buffer | undefined;
+		let endBuffer: Buffer | undefined;
+
+		if (options?.start !== undefined) {
+			const start = this.store.encodeKey(options.start);
+			startBuffer = Buffer.from(start.subarray(start.start, start.end));
+		}
+		if (options?.end !== undefined) {
+			const end = this.store.encodeKey(options.end);
+			endBuffer = Buffer.from(end.subarray(end.start, end.end));
+		}
+
+		return new Promise((resolve, reject) =>
+			this.store.db.compact(resolve, reject, startBuffer, endBuffer)
+		);
+	}
+
+	/**
+	 * Compacts the entire key range of the database synchronously.
+	 * This triggers manual compaction which removes tombstones and reclaims space.
+	 *
+	 * @example
+	 * ```typescript
+	 * const db = RocksDatabase.open('/path/to/database');
+	 * db.compactRangeSync();
+	 * ```
+	 */
+	compactSync(options?: CompactOptions): void {
+		let startBuffer: Buffer | undefined;
+		let endBuffer: Buffer | undefined;
+
+		if (options?.start !== undefined) {
+			const start = this.store.encodeKey(options.start);
+			startBuffer = Buffer.from(start.subarray(start.start, start.end));
+		}
+		if (options?.end !== undefined) {
+			const end = this.store.encodeKey(options.end);
+			endBuffer = Buffer.from(end.subarray(end.start, end.end));
+		}
+
+		this.store.db.compactSync(startBuffer, endBuffer);
 	}
 
 	/**

--- a/src/database.ts
+++ b/src/database.ts
@@ -145,7 +145,7 @@ export class RocksDatabase extends DBI<DBITransactional> {
 	 * @example
 	 * ```typescript
 	 * const db = RocksDatabase.open('/path/to/database');
-	 * await db.compactRange();
+	 * await db.compact();
 	 * ```
 	 */
 	compact(options?: CompactOptions): Promise<void> {
@@ -173,7 +173,7 @@ export class RocksDatabase extends DBI<DBITransactional> {
 	 * @example
 	 * ```typescript
 	 * const db = RocksDatabase.open('/path/to/database');
-	 * db.compactRangeSync();
+	 * db.compactSync();
 	 * ```
 	 */
 	compactSync(options?: CompactOptions): void {

--- a/src/database.ts
+++ b/src/database.ts
@@ -9,6 +9,7 @@ import {
 } from './load-binding.js';
 import {
 	type ArrayBufferWithNotify,
+	CompactOptions,
 	ITERATOR_STATE_BUFFER,
 	KEY_BUFFER,
 	Store,
@@ -26,11 +27,6 @@ import { Encoder as MsgpackEncoder } from 'msgpackr';
 import * as orderedBinary from 'ordered-binary';
 
 export type TransactionCallback<T> = (txn: Transaction, attempt: number) => T | PromiseLike<T>;
-
-export type CompactOptions = {
-	start?: Key;
-	end?: Key;
-};
 
 export interface RocksDatabaseOptions extends StoreOptions {
 	/**
@@ -150,21 +146,7 @@ export class RocksDatabase extends DBI<DBITransactional> {
 	 * ```
 	 */
 	compact(options?: CompactOptions): Promise<void> {
-		let startBuffer: Buffer | undefined;
-		let endBuffer: Buffer | undefined;
-
-		if (options?.start !== undefined) {
-			const start = this.store.encodeKey(options.start);
-			startBuffer = Buffer.from(start.subarray(start.start, start.end));
-		}
-		if (options?.end !== undefined) {
-			const end = this.store.encodeKey(options.end);
-			endBuffer = Buffer.from(end.subarray(end.start, end.end));
-		}
-
-		return new Promise((resolve, reject) =>
-			this.store.db.compact(resolve, reject, startBuffer, endBuffer)
-		);
+		return this.store.compact(options);
 	}
 
 	/**
@@ -178,19 +160,7 @@ export class RocksDatabase extends DBI<DBITransactional> {
 	 * ```
 	 */
 	compactSync(options?: CompactOptions): void {
-		let startBuffer: Buffer | undefined;
-		let endBuffer: Buffer | undefined;
-
-		if (options?.start !== undefined) {
-			const start = this.store.encodeKey(options.start);
-			startBuffer = Buffer.from(start.subarray(start.start, start.end));
-		}
-		if (options?.end !== undefined) {
-			const end = this.store.encodeKey(options.end);
-			endBuffer = Buffer.from(end.subarray(end.start, end.end));
-		}
-
-		this.store.db.compactSync(startBuffer, endBuffer);
+		return this.store.compactSync(options);
 	}
 
 	/**

--- a/src/load-binding.ts
+++ b/src/load-binding.ts
@@ -115,6 +115,8 @@ export type NativeDatabase = {
 	clear(resolve: ResolveCallback<void>, reject: RejectCallback): void;
 	clearSync(): void;
 	close(): void;
+	compact(resolve: ResolveCallback<void>, reject: RejectCallback, start?: Key, end?: Key): void;
+	compactSync(start?: Key, end?: Key): void;
 	columns: string[];
 	destroy(): void;
 	drop(resolve: ResolveCallback<void>, reject: RejectCallback): void;

--- a/src/load-binding.ts
+++ b/src/load-binding.ts
@@ -199,7 +199,10 @@ export type NativeDatabase = {
 	withLock(key: BufferWithDataView, callback: () => void | Promise<void>): Promise<void>;
 };
 
-export type RocksDatabaseConfig = { blockCacheSize?: number };
+export type RocksDatabaseConfig = {
+	blockCacheSize?: number;
+	compactOnClose?: boolean;
+};
 
 const nativeExtRE = /\.node$/;
 const req = createRequire(import.meta.url);

--- a/src/store.ts
+++ b/src/store.ts
@@ -65,6 +65,11 @@ export type StorePutOptions = PutOptions & DBITransactional;
 export type StoreRangeOptions = RangeOptions & DBITransactional;
 export type StoreRemoveOptions = DBITransactional | unknown;
 
+export type CompactOptions = {
+	start?: Key;
+	end?: Key;
+};
+
 /**
  * Options for the `Store` class.
  */
@@ -334,6 +339,60 @@ export class Store {
 	 */
 	close(): void {
 		this.db.close();
+	}
+
+	/**
+	 * Compacts the entire key range of the database asynchronously.
+	 * This triggers manual compaction which removes tombstones and reclaims space.
+	 *
+	 * @example
+	 * ```typescript
+	 * const db = RocksDatabase.open('/path/to/database');
+	 * await db.compact();
+	 * ```
+	 */
+	compact(options?: CompactOptions): Promise<void> {
+		let startBuffer: Buffer | undefined;
+		let endBuffer: Buffer | undefined;
+
+		if (options?.start !== undefined) {
+			const start = this.encodeKey(options.start);
+			startBuffer = Buffer.from(start.subarray(start.start, start.end));
+		}
+		if (options?.end !== undefined) {
+			const end = this.encodeKey(options.end);
+			endBuffer = Buffer.from(end.subarray(end.start, end.end));
+		}
+
+		return new Promise((resolve, reject) =>
+			this.db.compact(resolve, reject, startBuffer, endBuffer)
+		);
+	}
+
+	/**
+	 * Compacts the entire key range of the database synchronously.
+	 * This triggers manual compaction which removes tombstones and reclaims space.
+	 *
+	 * @example
+	 * ```typescript
+	 * const db = RocksDatabase.open('/path/to/database');
+	 * db.compactSync();
+	 * ```
+	 */
+	compactSync(options?: CompactOptions): void {
+		let startBuffer: Buffer | undefined;
+		let endBuffer: Buffer | undefined;
+
+		if (options?.start !== undefined) {
+			const start = this.encodeKey(options.start);
+			startBuffer = Buffer.from(start.subarray(start.start, start.end));
+		}
+		if (options?.end !== undefined) {
+			const end = this.encodeKey(options.end);
+			endBuffer = Buffer.from(end.subarray(end.start, end.end));
+		}
+
+		this.db.compactSync(startBuffer, endBuffer);
 	}
 
 	/**

--- a/test/compaction.test.ts
+++ b/test/compaction.test.ts
@@ -1,0 +1,109 @@
+import { dbRunner } from './lib/util.js';
+import { describe, expect, it } from 'vitest';
+
+describe('Compaction', () => {
+	it('should compact on close', () =>
+		dbRunner(async ({ db }) => {
+			const sizeStart = db.getDBIntProperty('rocksdb.estimate-live-data-size') ?? 0;
+			for (let i = 0; i < 1000; ++i) {
+				await db.put(`foo-${i}`, `bar-${i}`);
+			}
+			await db.flush();
+			const sizeWithData = db.getDBIntProperty('rocksdb.estimate-live-data-size') ?? 0;
+			expect(sizeWithData).toBeGreaterThan(sizeStart);
+
+			for (let i = 0; i < 1000; ++i) {
+				await db.remove(`foo-${i}`);
+			}
+			await db.flush();
+			const sizeAfterRemove = db.getDBIntProperty('rocksdb.estimate-live-data-size') ?? 0;
+			db.close();
+
+			db.open();
+			const sizeAfter = db.getDBIntProperty('rocksdb.estimate-live-data-size') ?? 0;
+			expect(sizeAfter).toBeLessThan(sizeAfterRemove);
+		}));
+
+	it('should compact with compact()', () =>
+		dbRunner(async ({ db }) => {
+			const sizeStart = db.getDBIntProperty('rocksdb.estimate-live-data-size') ?? 0;
+			for (let i = 0; i < 1000; ++i) {
+				await db.put(`foo-${i}`, `bar-${i}`);
+			}
+			await db.flush();
+			const sizeWithData = db.getDBIntProperty('rocksdb.estimate-live-data-size') ?? 0;
+			expect(sizeWithData).toBeGreaterThan(sizeStart);
+
+			for (let i = 0; i < 1000; ++i) {
+				await db.remove(`foo-${i}`);
+			}
+			await db.flush();
+			const sizeAfterRemove = db.getDBIntProperty('rocksdb.estimate-live-data-size') ?? 0;
+
+			await db.compact();
+			const sizeAfterCompact = db.getDBIntProperty('rocksdb.estimate-live-data-size') ?? 0;
+			expect(sizeAfterCompact).toBeLessThan(sizeAfterRemove);
+		}));
+
+	it('should compact with compactSync()', () =>
+		dbRunner(async ({ db }) => {
+			const sizeStart = db.getDBIntProperty('rocksdb.estimate-live-data-size') ?? 0;
+			for (let i = 0; i < 1000; ++i) {
+				await db.put(`foo-${i}`, `bar-${i}`);
+			}
+			await db.flush();
+			const sizeWithData = db.getDBIntProperty('rocksdb.estimate-live-data-size') ?? 0;
+			expect(sizeWithData).toBeGreaterThan(sizeStart);
+
+			for (let i = 0; i < 1000; ++i) {
+				await db.remove(`foo-${i}`);
+			}
+			await db.flush();
+			const sizeAfterRemove = db.getDBIntProperty('rocksdb.estimate-live-data-size') ?? 0;
+
+			db.compactSync();
+			const sizeAfterCompact = db.getDBIntProperty('rocksdb.estimate-live-data-size') ?? 0;
+			expect(sizeAfterCompact).toBeLessThan(sizeAfterRemove);
+		}));
+
+	it('should compact a specific key range', () =>
+		dbRunner(async ({ db }) => {
+			// Insert data with different prefixes
+			for (let i = 0; i < 100; ++i) {
+				await db.put(`aaa-${i}`, `value-${i}`);
+				await db.put(`bbb-${i}`, `value-${i}`);
+				await db.put(`ccc-${i}`, `value-${i}`);
+			}
+			await db.flush();
+
+			const sizeBeforeCompact = db.getDBIntProperty('rocksdb.estimate-live-data-size') ?? 0;
+
+			// Remove the 'bbb' prefix data to create tombstones
+			for (let i = 0; i < 100; ++i) {
+				await db.remove(`bbb-${i}`);
+			}
+			await db.flush();
+
+			// Compact only the 'bbb' range to remove tombstones
+			await db.compact({ start: 'bbb', end: 'bbc' });
+
+			const sizeAfterCompact = db.getDBIntProperty('rocksdb.estimate-live-data-size') ?? 0;
+			expect(sizeAfterCompact).toBeLessThan(sizeBeforeCompact);
+
+			// Verify data outside the compacted range is still accessible
+			expect(await db.get('aaa-0')).toBe('value-0');
+			expect(await db.get('ccc-0')).toBe('value-0');
+
+			// Remove 'aaa' data and test sync version
+			for (let i = 0; i < 100; ++i) {
+				await db.remove(`aaa-${i}`);
+			}
+			await db.flush();
+
+			const sizeBeforeSyncCompact = db.getDBIntProperty('rocksdb.estimate-live-data-size') ?? 0;
+			db.compactSync({ start: 'aaa', end: 'aab' });
+
+			const sizeAfterCompactSync = db.getDBIntProperty('rocksdb.estimate-live-data-size') ?? 0;
+			expect(sizeAfterCompactSync).toBeLessThan(sizeBeforeSyncCompact);
+		}));
+});

--- a/test/compaction.test.ts
+++ b/test/compaction.test.ts
@@ -146,23 +146,9 @@ describe('Compaction', () => {
 			}
 			await db.flush();
 
-			let firstResolved = false;
-			let secondResolved = false;
+			await Promise.all([db.compact(), db.compact()]);
 
-			const firstCompact = db.compact().then((r) => {
-				firstResolved = true;
-				return r;
-			});
-			const secondCompact = db.compact().then((r) => {
-				secondResolved = true;
-				return r;
-			});
-
-			await firstCompact;
-			expect(firstResolved).toBe(true);
-			expect(secondResolved).toBe(false);
-
-			await secondCompact;
-			expect(secondResolved).toBe(true);
+			expect(await db.get('foo-0')).toBe('bar-0');
+			expect(await db.get('foo-999')).toBe('bar-999');
 		}));
 });

--- a/test/compaction.test.ts
+++ b/test/compaction.test.ts
@@ -138,4 +138,31 @@ describe('Compaction', () => {
 
 			expect(sizeAfterSyncCompact).toBeLessThan(sizeBeforeSyncCompact);
 		}));
+
+	it('should not compact more than once at a time', () =>
+		dbRunner(async ({ db }) => {
+			for (let i = 0; i < 1000; ++i) {
+				await db.put(`foo-${i}`, `bar-${i}`);
+			}
+			await db.flush();
+
+			let firstResolved = false;
+			let secondResolved = false;
+
+			const firstCompact = db.compact().then((r) => {
+				firstResolved = true;
+				return r;
+			});
+			const secondCompact = db.compact().then((r) => {
+				secondResolved = true;
+				return r;
+			});
+
+			await firstCompact;
+			expect(firstResolved).toBe(true);
+			expect(secondResolved).toBe(false);
+
+			await secondCompact;
+			expect(secondResolved).toBe(true);
+		}));
 });

--- a/test/compaction.test.ts
+++ b/test/compaction.test.ts
@@ -1,9 +1,16 @@
+import { RocksDatabase } from '../src/index.js';
 import { dbRunner } from './lib/util.js';
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 
 describe('Compaction', () => {
+	afterEach(() => {
+		RocksDatabase.config({ compactOnClose: false });
+	});
+
 	it('should compact on close', () =>
 		dbRunner(async ({ db }) => {
+			RocksDatabase.config({ compactOnClose: true });
+
 			const sizeStart = db.getDBIntProperty('rocksdb.estimate-live-data-size') ?? 0;
 			for (let i = 0; i < 1000; ++i) {
 				await db.put(`foo-${i}`, `bar-${i}`);
@@ -22,6 +29,30 @@ describe('Compaction', () => {
 			db.open();
 			const sizeAfter = db.getDBIntProperty('rocksdb.estimate-live-data-size') ?? 0;
 			expect(sizeAfter).toBeLessThan(sizeAfterRemove);
+		}));
+
+	it('should not compact on close', () =>
+		dbRunner(async ({ db }) => {
+			RocksDatabase.config({ compactOnClose: false });
+
+			const sizeStart = db.getDBIntProperty('rocksdb.estimate-live-data-size') ?? 0;
+			for (let i = 0; i < 1000; ++i) {
+				await db.put(`foo-${i}`, `bar-${i}`);
+			}
+			await db.flush();
+			const sizeWithData = db.getDBIntProperty('rocksdb.estimate-live-data-size') ?? 0;
+			expect(sizeWithData).toBeGreaterThan(sizeStart);
+
+			for (let i = 0; i < 1000; ++i) {
+				await db.remove(`foo-${i}`);
+			}
+			await db.flush();
+			const sizeAfterRemove = db.getDBIntProperty('rocksdb.estimate-live-data-size') ?? 0;
+			db.close();
+
+			db.open();
+			const sizeAfter = db.getDBIntProperty('rocksdb.estimate-live-data-size') ?? 0;
+			expect(sizeAfter).toBe(sizeAfterRemove);
 		}));
 
 	it('should compact with compact()', () =>

--- a/test/compaction.test.ts
+++ b/test/compaction.test.ts
@@ -66,7 +66,7 @@ describe('Compaction', () => {
 			expect(sizeAfterCompact).toBeLessThan(sizeAfterRemove);
 		}));
 
-	it.only('should compact a specific key range', () =>
+	it('should compact a specific key range', () =>
 		dbRunner(async ({ db }) => {
 			// Insert data with different prefixes
 			for (let i = 0; i < 100; ++i) {

--- a/test/compaction.test.ts
+++ b/test/compaction.test.ts
@@ -66,7 +66,7 @@ describe('Compaction', () => {
 			expect(sizeAfterCompact).toBeLessThan(sizeAfterRemove);
 		}));
 
-	it('should compact a specific key range', () =>
+	it.only('should compact a specific key range', () =>
 		dbRunner(async ({ db }) => {
 			// Insert data with different prefixes
 			for (let i = 0; i < 100; ++i) {
@@ -76,7 +76,7 @@ describe('Compaction', () => {
 			}
 			await db.flush();
 
-			const sizeBeforeCompact = db.getDBIntProperty('rocksdb.estimate-live-data-size') ?? 0;
+			const sizeAfterInsert = db.getDBIntProperty('rocksdb.estimate-live-data-size') ?? 0;
 
 			// Remove the 'bbb' prefix data to create tombstones
 			for (let i = 0; i < 100; ++i) {
@@ -88,7 +88,7 @@ describe('Compaction', () => {
 			await db.compact({ start: 'bbb', end: 'bbc' });
 
 			const sizeAfterCompact = db.getDBIntProperty('rocksdb.estimate-live-data-size') ?? 0;
-			expect(sizeAfterCompact).toBeLessThan(sizeBeforeCompact);
+			expect(sizeAfterCompact).toBeLessThan(sizeAfterInsert);
 
 			// Verify data outside the compacted range is still accessible
 			expect(await db.get('aaa-0')).toBe('value-0');
@@ -103,7 +103,8 @@ describe('Compaction', () => {
 			const sizeBeforeSyncCompact = db.getDBIntProperty('rocksdb.estimate-live-data-size') ?? 0;
 			db.compactSync({ start: 'aaa', end: 'aab' });
 
-			const sizeAfterCompactSync = db.getDBIntProperty('rocksdb.estimate-live-data-size') ?? 0;
-			expect(sizeAfterCompactSync).toBeLessThan(sizeBeforeSyncCompact);
+			const sizeAfterSyncCompact = db.getDBIntProperty('rocksdb.estimate-live-data-size') ?? 0;
+
+			expect(sizeAfterSyncCompact).toBeLessThan(sizeBeforeSyncCompact);
 		}));
 });


### PR DESCRIPTION
I don't think compaction was ever being triggered, even on close. This PR adds compaction on close as well as an explicit `db.compact()` API that can be periodically invoked.