### PR TITLE
Make transaction log read paths lock-free under concurrency

### DIFF
--- a/benchmark/worker-transaction-log-read.bench.ts
+++ b/benchmark/worker-transaction-log-read.bench.ts
@@ -1,0 +1,293 @@
+import type { RocksDatabase } from '../dist/index.mjs';
+import {
+	type BenchmarkContext,
+	type LMDBDatabase,
+	workerBenchmark as benchmark,
+	workerDescribe as describe,
+} from './setup.js';
+import { workerData } from 'node:worker_threads';
+
+// In role-split benches (1 writer + N readers), worker 1 is the writer; the
+// rest are readers. Worker IDs are 1-based, assigned by the framework.
+const WORKER_ID = workerData?.benchmarkWorkerId ?? 1;
+const WORKER_ROLE_IS_WRITER = WORKER_ID === 1;
+
+// Sized to produce a handful of rotations during setup (so reads exercise
+// the multi-file path) without creating dozens of small files. At ~113
+// bytes/entry (100 byte payload + 13 byte header), 256 KB holds ~2300
+// entries — so 8 workers × 1000 entries (~8K total) yields ~4 log files.
+const MAX_LOG_FILE_SIZE = 256 * 1024;
+
+// All work is multi-threaded; saturate 8 workers to surface contention in
+// both engines.
+const NUM_WORKERS = 8;
+
+// Each worker contributes this many seed entries; total log size is
+// NUM_WORKERS × this. 8 workers × 1000 entries = 8000 total — small enough
+// that setup completes in a couple of seconds on CI, large enough that
+// bulk scans take multiple ms (so reader work gates the per-tick window
+// in role-split benches, regardless of writer commit cost).
+const ENTRIES_PER_WORKER = 1000;
+
+// Match lazy-durability semantics on both engines so the comparison
+// reflects data-structure cost, not fsync cost:
+//   - rocksdb-js's transaction log is a separate append-only file (.txnlog)
+//     written via writev with no per-write fsync — it does NOT go through
+//     RocksDB's WAL or storage. The bench's reads (log.query()) hit the
+//     mmap'd .txnlog file directly; RocksDB is only involved for txn id
+//     allocation/commit on the writer side.
+//   - LMDB defaults to fsyncing the metapage on every commit. `noSync: true`
+//     drops that to match the .txnlog file's no-per-write-fsync profile.
+// A separate "both fully durable" comparison would explicitly fsync the
+// .txnlog file per write and remove `noSync` here — that's a different bench.
+const LMDB_FAIR_OPTIONS = { noSync: true };
+
+async function rocksdbSetup(ctx: BenchmarkContext<RocksDatabase>): Promise<void> {
+	const db = ctx.db;
+	const log = db.useLog('0');
+	ctx.log = log;
+	const value = Buffer.alloc(100, 'a');
+	ctx.value = value;
+	let firstTs: number | undefined;
+	let lastTs = 0;
+	for (let i = 0; i < ENTRIES_PER_WORKER; i++) {
+		await db.transaction(async (txn) => {
+			log.addEntry(value, txn.id);
+			const ts = txn.getTimestamp();
+			if (firstTs === undefined) firstTs = ts;
+			lastTs = ts;
+		});
+		if (i % 100 === 0) {
+			await new Promise((resolve) => setTimeout(resolve, 1));
+		}
+	}
+	ctx.firstTs = firstTs!;
+	ctx.lastTs = lastTs;
+}
+
+function lmdbSetup(ctx: BenchmarkContext<LMDBDatabase>): void {
+	const value = Buffer.alloc(100, 'a');
+	ctx.value = value;
+	// Mirror rocksdb's timestamp-as-key model so the query patterns are
+	// apples-to-apples. Keys are monotonic numbers that look like ms
+	// timestamps. Each worker uses a distinct numeric range (offset by
+	// WORKER_ID × ENTRIES_PER_WORKER × 10) so parallel setup writes don't
+	// collide on duplicate keys.
+	const firstKey = Date.now() + WORKER_ID * ENTRIES_PER_WORKER * 10;
+	ctx.firstKey = firstKey;
+	for (let i = 0; i < ENTRIES_PER_WORKER; i++) {
+		ctx.db.putSync((firstKey + i) as unknown as string, value);
+	}
+	ctx.lastKey = firstKey + ENTRIES_PER_WORKER - 1;
+	ctx.nextKey = firstKey + ENTRIES_PER_WORKER;
+}
+
+describe(`Transaction log read access patterns (${NUM_WORKERS} workers)`, () => {
+	const TOTAL_ENTRIES = NUM_WORKERS * ENTRIES_PER_WORKER;
+
+	// Access pattern: bulk forward scan, no concurrent writes.
+	// Each worker iterates every entry from start. Exercises the per-entry
+	// iteration cost: mmap'd buffer reads, JS DataView decoding. Iterator
+	// is opened once per tick, so this is dominated by per-entry cost,
+	// not iterator-open cost.
+	//
+	// Metric: hz × NUM_WORKERS × TOTAL_ENTRIES = total entries scanned/sec.
+	describe(`Bulk forward scan, no writes: ${NUM_WORKERS} workers each scan ~${TOTAL_ENTRIES} entries`, () => {
+		benchmark('rocksdb', {
+			mode: 'essential',
+			numWorkers: NUM_WORKERS,
+			dbOptions: { transactionLogMaxSize: MAX_LOG_FILE_SIZE },
+			async setup(ctx: BenchmarkContext<RocksDatabase>) {
+				await rocksdbSetup(ctx);
+			},
+			async bench({ log }) {
+				let count = 0;
+				for (const _entry of log.query({ start: 1 })) {
+					count++;
+				}
+			},
+		});
+
+		benchmark('lmdb', {
+			mode: 'essential',
+			numWorkers: NUM_WORKERS,
+			dbOptions: LMDB_FAIR_OPTIONS,
+			async setup(ctx: BenchmarkContext<LMDBDatabase>) {
+				lmdbSetup(ctx);
+			},
+			async bench({ db }) {
+				let count = 0;
+				for (const _entry of db.getRange({ snapshot: false })) {
+					count++;
+				}
+			},
+		});
+	});
+
+	// Access pattern: bulk forward scan with one concurrent writer.
+	// 7 workers scan; 1 writer continuously appends. Tests whether write
+	// activity slows the scan (it shouldn't on either engine — both have
+	// non-blocking reader paths).
+	//
+	// Calibration: with TOTAL_ENTRIES = ~16000, a full scan takes ~ms; a
+	// single commit takes ~ms (rocksdb) or ~µs (lmdb noSync). Reader work
+	// dominates the tick window, so hz × 7 × TOTAL_ENTRIES = aggregate
+	// reader throughput.
+	describe(`Bulk forward scan with 1 concurrent writer (${NUM_WORKERS - 1} readers)`, () => {
+		benchmark('rocksdb', {
+			mode: 'essential',
+			numWorkers: NUM_WORKERS,
+			dbOptions: { transactionLogMaxSize: MAX_LOG_FILE_SIZE },
+			async setup(ctx: BenchmarkContext<RocksDatabase>) {
+				await rocksdbSetup(ctx);
+			},
+			async bench(ctx: BenchmarkContext<RocksDatabase>) {
+				if (WORKER_ROLE_IS_WRITER) {
+					await ctx.db.transaction((txn) => {
+						ctx.log.addEntry(ctx.value, txn.id);
+					});
+				} else {
+					let count = 0;
+					for (const _entry of ctx.log.query({ start: 1 })) {
+						count++;
+					}
+				}
+			},
+		});
+
+		benchmark('lmdb', {
+			mode: 'essential',
+			numWorkers: NUM_WORKERS,
+			dbOptions: LMDB_FAIR_OPTIONS,
+			async setup(ctx: BenchmarkContext<LMDBDatabase>) {
+				lmdbSetup(ctx);
+			},
+			async bench(ctx: BenchmarkContext<LMDBDatabase>) {
+				if (WORKER_ROLE_IS_WRITER) {
+					await ctx.db.put(ctx.nextKey++ as unknown as string, ctx.value);
+				} else {
+					let count = 0;
+					for (const _entry of ctx.db.getRange({ snapshot: false })) {
+						count++;
+					}
+				}
+			},
+		});
+	});
+
+	// Access pattern: high-frequency short-range queries.
+	// Each worker repeatedly opens a fresh iterator at a random position
+	// and reads at most one entry. Per-query setup cost (findPosition +
+	// getMemoryMap + getLogFileSize) dominates per-entry iteration cost.
+	// This is the access pattern most sensitive to mutex contention
+	// across many threads.
+	//
+	// Metric: hz × NUM_WORKERS × QUERIES_PER_TICK = total queries/sec.
+	const QUERIES_PER_TICK = 1000;
+	describe(`Short-range queries: ${NUM_WORKERS} workers each open ${QUERIES_PER_TICK} iterators per tick`, () => {
+		benchmark('rocksdb', {
+			mode: 'essential',
+			numWorkers: NUM_WORKERS,
+			dbOptions: { transactionLogMaxSize: MAX_LOG_FILE_SIZE },
+			async setup(ctx: BenchmarkContext<RocksDatabase>) {
+				await rocksdbSetup(ctx);
+			},
+			async bench({ log, firstTs, lastTs }) {
+				const span = lastTs - firstTs;
+				for (let i = 0; i < QUERIES_PER_TICK; i++) {
+					for (const _entry of log.query({
+						start: firstTs + Math.random() * span,
+					})) {
+						break;
+					}
+				}
+			},
+		});
+
+		benchmark('lmdb', {
+			mode: 'essential',
+			numWorkers: NUM_WORKERS,
+			dbOptions: LMDB_FAIR_OPTIONS,
+			async setup(ctx: BenchmarkContext<LMDBDatabase>) {
+				lmdbSetup(ctx);
+			},
+			async bench({ db, firstKey, lastKey }) {
+				const span = lastKey - firstKey;
+				for (let i = 0; i < QUERIES_PER_TICK; i++) {
+					const start = (firstKey + Math.random() * span) as unknown as string;
+					for (const _entry of db.getRange({ start, snapshot: false })) {
+						break;
+					}
+				}
+			},
+		});
+	});
+
+	// Access pattern: cursor-advance tail scan with concurrent writer.
+	// 1 worker continuously appends; 7 workers each maintain a cursor and
+	// scan only entries past their last-seen position each tick. The
+	// reader work per tick is small (a few entries), so the writer's
+	// commit cost gates the tick window. Mixed read+write workload.
+	const WRITES_PER_WRITER_TICK = 50;
+	describe(`Cursor-advance tail scan with 1 concurrent writer (${NUM_WORKERS - 1} readers, ${WRITES_PER_WRITER_TICK} writes/tick)`, () => {
+		benchmark('rocksdb', {
+			mode: 'essential',
+			numWorkers: NUM_WORKERS,
+			dbOptions: { transactionLogMaxSize: MAX_LOG_FILE_SIZE },
+			async setup(ctx: BenchmarkContext<RocksDatabase>) {
+				await rocksdbSetup(ctx);
+				// Cursor starts at the current head — only new writes after
+				// this point are consumed.
+				ctx.cursorTs = ctx.lastTs;
+			},
+			async bench(ctx: BenchmarkContext<RocksDatabase>) {
+				if (WORKER_ROLE_IS_WRITER) {
+					for (let i = 0; i < WRITES_PER_WRITER_TICK; i++) {
+						await ctx.db.transaction((txn) => {
+							ctx.log.addEntry(ctx.value, txn.id);
+						});
+					}
+				} else {
+					let max = ctx.cursorTs;
+					// Strictly-greater than cursorTs via small epsilon.
+					// rocksdb-js timestamps have sub-ms precision so a small
+					// epsilon is safe.
+					for (const entry of ctx.log.query({ start: ctx.cursorTs + 0.0001 })) {
+						if (entry.timestamp > max) max = entry.timestamp;
+					}
+					ctx.cursorTs = max;
+				}
+			},
+		});
+
+		benchmark('lmdb', {
+			mode: 'essential',
+			numWorkers: NUM_WORKERS,
+			dbOptions: LMDB_FAIR_OPTIONS,
+			async setup(ctx: BenchmarkContext<LMDBDatabase>) {
+				lmdbSetup(ctx);
+				// Cursor starts at the current head — only new writes after
+				// this point are consumed. Numeric key, mirroring rocksdb.
+				ctx.cursorKey = ctx.lastKey;
+			},
+			async bench(ctx: BenchmarkContext<LMDBDatabase>) {
+				if (WORKER_ROLE_IS_WRITER) {
+					for (let i = 0; i < WRITES_PER_WRITER_TICK; i++) {
+						await ctx.db.put(ctx.nextKey++ as unknown as string, ctx.value);
+					}
+				} else {
+					let max = ctx.cursorKey;
+					for (const { key } of ctx.db.getRange({
+						start: ctx.cursorKey as unknown as string,
+						exclusiveStart: true,
+						snapshot: false,
+					})) {
+						const numKey = key as unknown as number;
+						if (numKey > max) max = numKey;
+					}
+					ctx.cursorKey = max;
+				}
+			},
+		});
+	});
+});

--- a/src/binding/transaction_log.cpp
+++ b/src/binding/transaction_log.cpp
@@ -267,7 +267,7 @@ napi_value TransactionLog::GetName(napi_env env, napi_callback_info info) {
 napi_value TransactionLog::GetPath(napi_env env, napi_callback_info info) {
 	NAPI_METHOD();
 	UNWRAP_TRANSACTION_LOG_HANDLE("GetPath");
-	auto store = (*txnLogHandle)->store.lock();
+	auto& store = (*txnLogHandle)->store;
 	if (store) {
 		napi_value result;
 		NAPI_STATUS_THROWS(::napi_create_string_utf8(env, store->path.string().c_str(), store->path.string().size(), &result));

--- a/src/binding/transaction_log_file.cpp
+++ b/src/binding/transaction_log_file.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <cmath>
 #include <system_error>
 #include "transaction_log_entry.h"
@@ -205,6 +206,15 @@ void TransactionLogFile::writeEntriesV1(TransactionLogEntryBatch& batch, const u
 		this, bytesWritten, this->size.load(std::memory_order_relaxed), batch.currentEntryIndex, batch.currentEntryBytesWritten);
 }
 
+// Pack/unpack helpers for the (indexedUpTo<<32 | count) atomic.
+namespace {
+inline uint32_t unpackCount(uint64_t s) { return static_cast<uint32_t>(s & 0xFFFFFFFFu); }
+inline uint32_t unpackIndexedUpTo(uint64_t s) { return static_cast<uint32_t>(s >> 32); }
+inline uint64_t packIndexState(uint32_t count, uint32_t indexedUpTo) {
+	return (static_cast<uint64_t>(indexedUpTo) << 32) | static_cast<uint64_t>(count);
+}
+} // namespace
+
 /**
  * Find the position of a timestamp, specifically the position where there are no transactions with an earlier timestamp
  * @param timestamp - the timestamp to find the position of
@@ -213,47 +223,82 @@ void TransactionLogFile::writeEntriesV1(TransactionLogEntryBatch& batch, const u
  */
 uint32_t TransactionLogFile::findPositionByTimestamp(double timestamp, uint32_t mapSize) {
 	DEBUG_LOG("%p TransactionLogFile::findPositionByTimestamp Finding position for timestamp=%f, mapSize=%u\n", this, timestamp, mapSize);
-	std::lock_guard<std::mutex> indexLock(this->indexMutex);
-	auto memoryMap = this->getMemoryMap(mapSize);
 
-	// If memory map is null (e.g., empty file with size 0), return 0xFFFFFFFF
-	// to indicate the timestamp comes after this logfile
+	auto cmp = [](const std::pair<double, uint32_t>& entry, double t) { return entry.first < t; };
+	auto lookup = [&](const std::pair<double, uint32_t>* data, uint32_t count) -> uint32_t {
+		auto end = data + count;
+		auto it = std::lower_bound(data, end, timestamp, cmp);
+		return it == end ? 0xFFFFFFFF : it->second;
+	};
+
+	// Fast path: lock-free read. After the first reader builds the index
+	// via the slow path below, subsequent reads on the same file all hit
+	// here as long as the file hasn't grown past the indexed range.
+	{
+		uint64_t state = this->indexState.load(std::memory_order_acquire);
+		uint32_t count = unpackCount(state);
+		uint32_t indexedUpTo = unpackIndexedUpTo(state);
+		uint32_t observedSize = this->size.load(std::memory_order_acquire);
+		if (count > 0 && indexedUpTo >= observedSize) {
+			return lookup(this->indexData.get(), count);
+		}
+	}
+
+	// Slow path: only one reader extends the index; others wait briefly
+	// and then take advantage of the freshly-built result. This shares the
+	// extend work across concurrent readers — total CPU usage and
+	// throughput are both better than having every reader do its own
+	// linear scan over the unindexed tail.
+	std::lock_guard<std::mutex> extendLock(this->indexExtendMutex);
+
+	// Re-check after acquiring the lock — another thread may have extended.
+	uint64_t state = this->indexState.load(std::memory_order_relaxed);
+	uint32_t count = unpackCount(state);
+	uint32_t indexedUpTo = unpackIndexedUpTo(state);
+	if (count > 0 && indexedUpTo >= this->size.load(std::memory_order_acquire)) {
+		return lookup(this->indexData.get(), count);
+	}
+
+	auto memoryMap = this->getMemoryMap(mapSize);
 	if (!memoryMap) {
 		DEBUG_LOG("%p TransactionLogFile::findPositionByTimestamp memoryMap is null, returning 0xFFFFFFFF\n", this);
 		return 0xFFFFFFFF;
 	}
 
-	// we use our memory maps for fast access to the data
+	if (!this->indexData) {
+		this->indexCapacity = (mapSize / TRANSACTION_LOG_ENTRY_HEADER_SIZE) + 1;
+		this->indexData = std::make_unique<std::pair<double, uint32_t>[]>(this->indexCapacity);
+	}
+
+	// Walk forward from lastIndexedPosition, appending strictly-increasing
+	// timestamps. Publish the new (count, indexedUpTo) state via release-store
+	// so concurrent fast-path readers can pick it up without locking.
 	char* mappedFile = (char*) memoryMap->map;
-	// We begin by indexing the file, so we can use fast ordered std::map access O(log n). We only need to index the file
-	// that hasn't been indexed yet, so we start at the last indexed position. Note that there may be a slight benefit
-	// to using an ordered vector with binary search for faster lookups, but std::map is simpler for now is very close in performance
-	while (this->lastIndexedPosition < this->size) {
+	while (this->lastIndexedPosition < this->size && count < this->indexCapacity) {
 		double entryTimestamp = readDoubleBE(mappedFile + this->lastIndexedPosition);
 		if (entryTimestamp == 0) {
-			// this means we have reached the end of zero-padded file (usually Windows), adjust size and break out of the loop
+			// reached end of zero-padded file (usually Windows); adjust size and stop
 			this->size = this->lastIndexedPosition;
 			break;
 		}
-		// for the first iteration, we insert the log file timestamp at the beginning of the index
 		if (TRANSACTION_LOG_FILE_TIMESTAMP_POSITION == this->lastIndexedPosition) {
-			// specifically record the log file timestamp as the first entry with a position of zero
-			positionByTimestampIndex.insert({entryTimestamp, 0});
-			this->lastIndexedPosition = TRANSACTION_LOG_FILE_HEADER_SIZE; // move to the first transaction entry
+			// record the log file's own timestamp as the first index entry, at position 0
+			this->indexData[count++] = std::make_pair(entryTimestamp, 0u);
+			this->lastIndexedTimestamp = entryTimestamp;
+			this->lastIndexedPosition = TRANSACTION_LOG_FILE_HEADER_SIZE;
 			continue;
-			// else check that the timestamp is greater than any previously indexed timestamp,
-			// otherwise we don't record it, because we want to start at the first position with a timestamp that
-			// is greater than the requested timestamp:
-		} else if (entryTimestamp > positionByTimestampIndex.rbegin()->first) {
-			// insert with a hint to go at the end (constant time?)
-			positionByTimestampIndex.insert(positionByTimestampIndex.end(), {entryTimestamp, this->lastIndexedPosition});
 		}
-		// read size of the entry and move on
+		// only insert strictly-increasing timestamps so lower_bound returns the
+		// earliest position with a matching-or-later timestamp
+		if (entryTimestamp > this->lastIndexedTimestamp) {
+			this->indexData[count++] = std::make_pair(entryTimestamp, this->lastIndexedPosition);
+			this->lastIndexedTimestamp = entryTimestamp;
+		}
 		this->lastIndexedPosition += TRANSACTION_LOG_ENTRY_HEADER_SIZE + readUint32BE(mappedFile + this->lastIndexedPosition + 8);
 	}
-	// now do the actual search: just a search for the lower bound
-	auto it = this->positionByTimestampIndex.lower_bound(timestamp);
-	return it == this->positionByTimestampIndex.end() ? 0xFFFFFFFF : it->second;
+
+	this->indexState.store(packIndexState(count, this->lastIndexedPosition), std::memory_order_release);
+	return lookup(this->indexData.get(), count);
 }
 
 } // namespace rocksdb_js

--- a/src/binding/transaction_log_file.h
+++ b/src/binding/transaction_log_file.h
@@ -1,11 +1,13 @@
 #ifndef __TRANSACTION_LOG_FILE_H__
 #define __TRANSACTION_LOG_FILE_H__
 
-#include <chrono>
-#include <filesystem>
-#include <mutex>
-#include <map>
 #include <atomic>
+#include <chrono>
+#include <cstddef>
+#include <filesystem>
+#include <memory>
+#include <mutex>
+#include <utility>
 #include "macros.h"
 #include "util.h"
 
@@ -114,9 +116,32 @@ struct TransactionLogFile final {
 	 */
 	std::mutex fileMutex;
 
-	std::map<double, uint32_t> positionByTimestampIndex;
+	/**
+	 * Lock-free in-memory index of (timestamp -> position).
+	 *
+	 * The buffer at indexData is allocated once on the first slow-path call
+	 * and never reallocated for the file's lifetime — its address is stable.
+	 * Entries are append-only — once written they are never modified.
+	 *
+	 * Readers atomic-load `indexState` (packed: low 32 bits = entry count,
+	 * high 32 bits = file position the index has been built up to). With
+	 * (count, indexedUpTo) and the file size, a reader can verify the index
+	 * is current and run lower_bound on the stable buffer with no locking
+	 * at all.
+	 *
+	 * Writers serialize among themselves via `indexExtendMutex` but never
+	 * block readers. Acquire-release ordering on `indexState` provides the
+	 * happens-before relationship that makes reads of `indexData` safe.
+	 *
+	 * Only mutated under indexExtendMutex; readers don't touch them:
+	 *   indexCapacity, lastIndexedPosition, lastIndexedTimestamp, indexData
+	 */
+	std::unique_ptr<std::pair<double, uint32_t>[]> indexData;
+	std::size_t indexCapacity = 0;
+	std::atomic<uint64_t> indexState{0};
 	uint32_t lastIndexedPosition = TRANSACTION_LOG_FILE_TIMESTAMP_POSITION;
-	std::mutex indexMutex;
+	double lastIndexedTimestamp = 0;
+	std::mutex indexExtendMutex;
 
 	TransactionLogFile(const std::filesystem::path& p, const uint32_t seq);
 

--- a/src/binding/transaction_log_handle.cpp
+++ b/src/binding/transaction_log_handle.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include "db_descriptor.h"
 #include "macros.h"
 #include "transaction_log_handle.h"
@@ -35,23 +36,24 @@ void TransactionLogHandle::addEntry(
 		throw rocksdb_js::DBException("Transaction id " + std::to_string(transactionId) + " not found");
 	}
 
-	auto store = this->store.lock();
-	if (!store || store->isClosing.load(std::memory_order_relaxed)) {
+	if (!this->store || this->store->isClosing.load(std::memory_order_relaxed)) {
 		// Store was destroyed or is being closed — resolve a fresh one.
 		// (The actual bind+increment in addLogEntry will re-check isClosing
 		// under writeMutex for a fully atomic transition.)
 		DEBUG_LOG("%p TransactionLogHandle::addEntry Store was destroyed or closing, re-resolving \"%s\"\n", this, this->logName.c_str());
-		store = dbHandle->descriptor->resolveTransactionLogStore(this->logName);
-		this->store = store; // update weak_ptr to point to new store
+		this->store = dbHandle->descriptor->resolveTransactionLogStore(this->logName);
+		// Files snapshot from the old store no longer applies.
+		this->cachedFiles.reset();
+		this->cachedFilesVersion = 0;
 	}
 
 	// check if transaction is already bound to a different log store
 	auto boundStore = txnHandle->boundLogStore.lock();
-	if (boundStore && boundStore.get() != store.get()) {
+	if (boundStore && boundStore.get() != this->store.get()) {
 		throw rocksdb_js::DBException("Log already bound to a transaction");
 	}
 
-	auto entry = std::make_unique<TransactionLogEntry>(store, data, size);
+	auto entry = std::make_unique<TransactionLogEntry>(this->store, data, size);
 	txnHandle->addLogEntry(std::move(entry));
 }
 
@@ -66,33 +68,118 @@ void TransactionLogHandle::close() {
 }
 
 uint64_t TransactionLogHandle::getLogFileSize(uint32_t sequenceNumber) {
-	auto store = this->store.lock();
-	if (store) return store->getLogFileSize(sequenceNumber);
-	return 0;
+	if (!this->store || this->store->isClosing.load(std::memory_order_relaxed)) return 0;
+
+	// Fast path: refresh the per-handle file snapshot if the store's
+	// filesVersion has advanced (cheap atomic compare), then read the
+	// file's size atomic directly. No dataSetsMutex.
+	//
+	// Falls through to the slow path only when:
+	//   - sequenceNumber == 0 (caller wants total size across all files)
+	//   - the file isn't in our snapshot yet (race: writer hasn't bumped
+	//     filesVersion yet, or we just haven't observed the bump)
+	//   - the file is in our snapshot but hasn't been opened yet
+	//     (size atomic is still 0; the slow path will open it)
+	if (sequenceNumber > 0) {
+		this->refreshFilesCache(*this->store);
+		auto logFile = this->lookupCachedFile(sequenceNumber);
+		if (logFile) {
+			uint32_t size = logFile->size.load(std::memory_order_acquire);
+			if (size > 0) {
+				return size;
+			}
+		}
+	}
+
+	return this->store->getLogFileSize(sequenceNumber);
 }
 
 std::weak_ptr<MemoryMap> TransactionLogHandle::getMemoryMap(uint32_t sequenceNumber) {
-	auto store = this->store.lock();
-	if (store) return store->getMemoryMap(sequenceNumber);
+	if (this->store && !this->store->isClosing.load(std::memory_order_relaxed)) {
+		return this->store->getMemoryMap(sequenceNumber);
+	}
 	return std::weak_ptr<MemoryMap>(); // nullptr
 }
 
 LogPosition TransactionLogHandle::findPosition(double timestamp) {
-	auto store = this->store.lock();
-	if (store) return store->findPositionByTimestamp(timestamp);
-	return { 0, 0 };
+	if (!this->store || this->store->isClosing.load(std::memory_order_relaxed)) return { 0, 0 };
+
+	this->refreshFilesCache(*this->store);
+
+	const auto& files = *this->cachedFiles;
+	if (files.empty()) {
+		// No files yet — fall back to the store's slow path which handles
+		// the "current file not yet created" edge case.
+		return this->store->findPositionByTimestamp(timestamp);
+	}
+
+	// Walk the local snapshot newest -> oldest, skipping files whose stored
+	// timestamp is strictly greater than the requested timestamp.
+	uint32_t observedCurrentSeq = this->store->currentSequenceNumber.load(std::memory_order_relaxed);
+	for (auto it = files.rbegin(); it != files.rend(); ++it) {
+		auto& logFile = *it;
+		if (logFile->timestamp > timestamp) {
+			continue;
+		}
+		bool isCurrent = (logFile->sequenceNumber == observedCurrentSeq);
+		uint32_t mapSize = isCurrent ? this->store->maxFileSize : logFile->size.load(std::memory_order_relaxed);
+		uint32_t pos = logFile->findPositionByTimestamp(timestamp, mapSize);
+		if (pos > 0 && pos != 0xFFFFFFFF) {
+			return { pos, logFile->sequenceNumber };
+		}
+		if (pos == 0xFFFFFFFF) {
+			// beyond end of this file — if there's a newer cached file, jump
+			// to its header; otherwise position at end of this (current) file
+			if (it != files.rbegin()) {
+				auto newer = it;
+				--newer; // newer file in chronological order
+				return { TRANSACTION_LOG_FILE_HEADER_SIZE, (*newer)->sequenceNumber };
+			}
+			return { logFile->size.load(std::memory_order_relaxed), logFile->sequenceNumber };
+		}
+		// pos == 0: timestamp predates this file's first entry; walk back
+	}
+
+	// Walked past every cached file: timestamp predates everything we have.
+	// Return the header position of the oldest cached file.
+	return { TRANSACTION_LOG_FILE_HEADER_SIZE, files.front()->sequenceNumber };
 }
 
 LogPosition TransactionLogHandle::getLastFlushed() {
-	auto store = this->store.lock();
-	if (store) return store->getLastFlushedPosition();
+	if (this->store && !this->store->isClosing.load(std::memory_order_relaxed)) {
+		return this->store->getLastFlushedPosition();
+	}
 	return { 0, 0 };
 }
 
 std::weak_ptr<LogPosition> TransactionLogHandle::getLastCommittedPosition() {
-	auto store = this->store.lock();
-	if (store) return store->getLastCommittedPosition();
+	if (this->store && !this->store->isClosing.load(std::memory_order_relaxed)) {
+		return this->store->getLastCommittedPosition();
+	}
 	return std::weak_ptr<LogPosition>(); // nullptr
+}
+
+void TransactionLogHandle::refreshFilesCache(TransactionLogStore& store) {
+	uint64_t storeVersion = store.filesVersion.load(std::memory_order_acquire);
+	if (storeVersion != this->cachedFilesVersion || !this->cachedFiles) {
+		auto snapshot = store.getFilesSnapshot();
+		this->cachedFiles = snapshot.files;
+		this->cachedFilesVersion = snapshot.version;
+	}
+}
+
+std::shared_ptr<TransactionLogFile> TransactionLogHandle::lookupCachedFile(uint32_t sequenceNumber) {
+	if (!this->cachedFiles) return nullptr;
+	const auto& files = *this->cachedFiles;
+	auto it = std::lower_bound(
+		files.begin(), files.end(), sequenceNumber,
+		[](const std::shared_ptr<TransactionLogFile>& f, uint32_t seq) {
+			return f->sequenceNumber < seq;
+		});
+	if (it == files.end() || (*it)->sequenceNumber != sequenceNumber) {
+		return nullptr;
+	}
+	return *it;
 }
 
 } // namespace rocksdb_js

--- a/src/binding/transaction_log_handle.h
+++ b/src/binding/transaction_log_handle.h
@@ -3,6 +3,7 @@
 
 #include <memory>
 #include <string>
+#include <vector>
 #include "db_handle.h"
 #include "transaction_log_store.h"
 
@@ -16,8 +17,15 @@ struct TransactionLogHandle final : Closable {
 
 	/**
 	 * The transaction log store.
+	 *
+	 * Held as a strong reference rather than a weak_ptr so steady-state
+	 * read methods don't pay the atomic refcount of weak_ptr::lock() per
+	 * call — under high concurrent QPS, that CAS on a single shared
+	 * cache line is a real bottleneck. The handle keeps the store alive
+	 * for as long as the handle itself is alive; addEntry re-resolves
+	 * to a fresh store if this one has been marked closing.
 	 */
-	std::weak_ptr<TransactionLogStore> store;
+	std::shared_ptr<TransactionLogStore> store;
 
 	/**
 	 * The name of the transaction log store.
@@ -33,6 +41,23 @@ struct TransactionLogHandle final : Closable {
 	 * The transaction id.
 	 */
 	uint32_t transactionId;
+
+	/**
+	 * Per-handle snapshot of all log files in the store, sorted by
+	 * sequence number ascending. Refreshed only when the store's
+	 * `filesVersion` counter advances (rotation, registration, purge);
+	 * the steady state hits this cache for every query without ever
+	 * touching dataSetsMutex.
+	 *
+	 * The shared_ptr keeps cached files alive even if they're purged
+	 * from the store's sequenceFiles map — their mmap and on-disk path
+	 * remain valid (Unix unlinks are deferred until last open closes).
+	 *
+	 * Each handle has its own cache, so concurrent subscribers don't
+	 * contend on shared state.
+	 */
+	std::shared_ptr<const std::vector<std::shared_ptr<TransactionLogFile>>> cachedFiles;
+	uint64_t cachedFilesVersion = 0;
 
 	/**
 	 * Creates a new transaction log handle.
@@ -67,6 +92,21 @@ struct TransactionLogHandle final : Closable {
 	 */
 	void close();
 
+private:
+	/**
+	 * Refreshes `cachedFiles` if the store's `filesVersion` has advanced.
+	 * Cheap atomic load when the cache is up to date.
+	 */
+	void refreshFilesCache(TransactionLogStore& store);
+
+	/**
+	 * Look up a file by sequence number in `cachedFiles`. Returns nullptr if
+	 * the cache is empty or the sequence isn't present. O(log N) binary
+	 * search since the snapshot is sorted ascending by sequence number.
+	 *
+	 * Caller must have called refreshFilesCache() first.
+	 */
+	std::shared_ptr<TransactionLogFile> lookupCachedFile(uint32_t sequenceNumber);
 };
 
 } // namespace rocksdb_js

--- a/src/binding/transaction_log_store.cpp
+++ b/src/binding/transaction_log_store.cpp
@@ -58,10 +58,14 @@ void TransactionLogStore::doClose() {
 
 	DEBUG_LOG("%p TransactionLogStore::close Closing transaction log store \"%s\"\n", this, this->name.c_str());
 
+	bool anyErased = !this->sequenceFiles.empty();
 	for (auto it = this->sequenceFiles.begin(); it != this->sequenceFiles.end(); ) {
 		auto logFile = it->second;
 		logFilesToClose.push_back(logFile);
 		it = this->sequenceFiles.erase(it);
+	}
+	if (anyErased) {
+		this->filesVersion.fetch_add(1, std::memory_order_release);
 	}
 
 	// Close the state file if it's open. flushedStateMutex must be held for
@@ -162,6 +166,26 @@ bool TransactionLogStore::tryClose() {
 	return true;
 }
 
+std::shared_ptr<TransactionLogFile> TransactionLogStore::lookupLogFile(uint32_t sequenceNumber) {
+	std::lock_guard<std::mutex> lock(this->dataSetsMutex);
+	auto it = this->sequenceFiles.find(sequenceNumber);
+	return it != this->sequenceFiles.end() ? it->second : nullptr;
+}
+
+TransactionLogStore::FilesSnapshot TransactionLogStore::getFilesSnapshot() {
+	auto files = std::make_shared<std::vector<std::shared_ptr<TransactionLogFile>>>();
+	uint64_t version;
+	{
+		std::lock_guard<std::mutex> lock(this->dataSetsMutex);
+		files->reserve(this->sequenceFiles.size());
+		for (const auto& [seq, file] : this->sequenceFiles) {
+			files->push_back(file);
+		}
+		version = this->filesVersion.load(std::memory_order_relaxed);
+	}
+	return { std::shared_ptr<const std::vector<std::shared_ptr<TransactionLogFile>>>(files), version };
+}
+
 std::shared_ptr<TransactionLogFile> TransactionLogStore::getLogFile(const uint32_t sequenceNumber) {
 	std::lock_guard<std::mutex> lock(this->dataSetsMutex);
 	auto it = this->sequenceFiles.find(sequenceNumber);
@@ -179,6 +203,7 @@ std::shared_ptr<TransactionLogFile> TransactionLogStore::getLogFile(const uint32
 		auto logFilePath = this->path / filename;
 		logFile = std::make_shared<TransactionLogFile>(logFilePath, sequenceNumber);
 		this->sequenceFiles[sequenceNumber] = logFile;
+		this->filesVersion.fetch_add(1, std::memory_order_release);
 		this->nextLogPosition = { 0, sequenceNumber };
 	}
 
@@ -261,39 +286,73 @@ std::weak_ptr<LogPosition> TransactionLogStore::getLastCommittedPosition() {
 }
 
 LogPosition TransactionLogStore::findPositionByTimestamp(double timestamp) {
-	std::lock_guard<std::mutex> lock(this->dataSetsMutex);
-	uint32_t sequenceNumber = this->currentSequenceNumber;
-	bool isCurrent = true;
-	uint32_t positionInLogFile = 0;
-	auto it = this->sequenceFiles.find(sequenceNumber);
-	if (it == this->sequenceFiles.end()) {
-		// it is possible that the current log file doesn't exist yet, so we need to look at the previous one
-		it = this->sequenceFiles.find(--sequenceNumber);
-		isCurrent = false;
-	}
-	while (it != this->sequenceFiles.end()) {
-		auto logFile = it->second.get();
-		positionInLogFile = logFile->findPositionByTimestamp(timestamp, isCurrent ? maxFileSize : logFile->size.load(std::memory_order_relaxed));
-		// a position of zero means that the timestamp is before the log file header's timestamp, greater than that,
-		// we are in the correct log file to start searching
-		if (positionInLogFile > 0) {
-			if (positionInLogFile == 0xFFFFFFFF) {
-				// beyond the end of this log file
-				if (sequenceNumber < this->currentSequenceNumber) {
-					// revert to next one (because it exists)
-					break;
-				} else { // otherwise position at the end of the log file (JS code can filter from here)
-					positionInLogFile = logFile->size;
-				}
-			}
-			// found a valid position in the log file
-			return { positionInLogFile, sequenceNumber };
+	// Walks log files newest -> oldest looking for the earliest position whose
+	// entry timestamp is >= `timestamp`. The per-file index walk can be
+	// expensive on the first call (it builds the in-memory index), so we hold
+	// dataSetsMutex only briefly to snapshot a candidate file's shared_ptr +
+	// sequence number, then release it before calling the file-level index.
+	// Concurrent subscribers all see contention only on the brief snapshot,
+	// not the index work.
+
+	uint32_t sequenceNumber;
+	uint32_t observedCurrentSeq;
+	std::shared_ptr<TransactionLogFile> logFile;
+
+	// Pick the starting file: the current sequence file, or the most recent
+	// extant file if the current one hasn't been created yet.
+	{
+		std::lock_guard<std::mutex> lock(this->dataSetsMutex);
+		observedCurrentSeq = this->currentSequenceNumber;
+		sequenceNumber = observedCurrentSeq;
+		auto it = this->sequenceFiles.find(sequenceNumber);
+		if (it == this->sequenceFiles.end()) {
+			it = this->sequenceFiles.find(--sequenceNumber);
 		}
-		isCurrent = false;
-		it = this->sequenceFiles.find(--sequenceNumber);
-	};
-	// we iterated too far, return to the beginning position in the current log file
-	return { TRANSACTION_LOG_FILE_HEADER_SIZE, sequenceNumber + 1 };
+		if (it == this->sequenceFiles.end()) {
+			return { TRANSACTION_LOG_FILE_HEADER_SIZE, sequenceNumber + 1 };
+		}
+		logFile = it->second;
+	}
+
+	while (true) {
+		// Each log file records the timestamp at which it was created, and that
+		// timestamp is monotonically non-decreasing with sequence number. If the
+		// file's recorded timestamp is strictly greater than what we're looking
+		// for, every entry in this file is newer than the requested timestamp,
+		// so skip the (potentially expensive) per-file index walk and step
+		// straight to an older file.
+		if (logFile->timestamp <= timestamp) {
+			bool isCurrent = (sequenceNumber == observedCurrentSeq);
+			uint32_t mapSize = isCurrent ? this->maxFileSize : logFile->size.load(std::memory_order_relaxed);
+			uint32_t positionInLogFile = logFile->findPositionByTimestamp(timestamp, mapSize);
+
+			// a position of zero means the timestamp is before this file's header
+			// timestamp; anything greater means we found the file to start in.
+			if (positionInLogFile > 0) {
+				if (positionInLogFile == 0xFFFFFFFF) {
+					// beyond the end of this log file
+					if (sequenceNumber < observedCurrentSeq) {
+						// there is a newer file (we're on an older sequence); start
+						// at its header
+						return { TRANSACTION_LOG_FILE_HEADER_SIZE, sequenceNumber + 1 };
+					}
+					// otherwise position at the end of the log file (JS code can filter from here)
+					return { logFile->size.load(std::memory_order_relaxed), sequenceNumber };
+				}
+				return { positionInLogFile, sequenceNumber };
+			}
+		}
+
+		// Walk to the next-older file under a brief lock acquisition.
+		std::lock_guard<std::mutex> lock(this->dataSetsMutex);
+		auto it = this->sequenceFiles.find(--sequenceNumber);
+		if (it == this->sequenceFiles.end()) {
+			// iterated past the oldest file: return to the beginning of the
+			// last file we saw
+			return { TRANSACTION_LOG_FILE_HEADER_SIZE, sequenceNumber + 1 };
+		}
+		logFile = it->second;
+	}
 }
 
 LogPosition TransactionLogStore::getLastFlushedPosition() {
@@ -395,7 +454,7 @@ void TransactionLogStore::doPurge(std::function<void(const std::filesystem::path
 			// Advance to maintain monotonicity of (sequenceNumber, position)
 			// pairs. Existing shared_ptrs to the old memory map remain valid
 			// until released.
-			DEBUG_LOG("%p TransactionLogStore::purge Advancing sequence number from %u to %u\n", this, this->currentSequenceNumber, this->nextSequenceNumber);
+			DEBUG_LOG("%p TransactionLogStore::purge Advancing sequence number from %u to %u\n", this, this->currentSequenceNumber.load(std::memory_order_relaxed), this->nextSequenceNumber);
 			this->currentSequenceNumber = this->nextSequenceNumber++;
 			this->nextLogPosition = { 0, this->currentSequenceNumber };
 			this->uncommittedTransactionPositions.insert(this->nextLogPosition);
@@ -405,6 +464,9 @@ void TransactionLogStore::doPurge(std::function<void(const std::filesystem::path
 			*this->lastCommittedPosition = fullyCommittedPosition;
 		}
 		this->sequenceFiles.erase(sequenceNumber);
+	}
+	if (!sequenceNumbersToRemove.empty()) {
+		this->filesVersion.fetch_add(1, std::memory_order_release);
 	}
 
 	// if all log files have been removed, clean up the empty directory
@@ -432,6 +494,7 @@ void TransactionLogStore::registerLogFile(const std::filesystem::path& path, con
 
 	auto logFile = std::make_shared<TransactionLogFile>(path, sequenceNumber);
 	this->sequenceFiles[sequenceNumber] = logFile;
+	this->filesVersion.fetch_add(1, std::memory_order_release);
 
 	if (sequenceNumber >= this->currentSequenceNumber) {
 		if (!logFile->isOpen()) {
@@ -458,7 +521,7 @@ void TransactionLogStore::writeBatch(TransactionLogEntryBatch& batch, LogPositio
 	}
 
 	DEBUG_LOG("%p TransactionLogStore::writeBatch Adding batch with %zu entries to store \"%s\" (current=%u, next=%u, timestamp=%llu)\n",
-		this, batch.entries.size(), this->name.c_str(), this->currentSequenceNumber, this->nextSequenceNumber, batch.timestamp);
+		this, batch.entries.size(), this->name.c_str(), this->currentSequenceNumber.load(std::memory_order_relaxed), this->nextSequenceNumber, batch.timestamp);
 
 	{
 		std::lock_guard<std::mutex> logPositionLock(this->dataSetsMutex);
@@ -497,7 +560,7 @@ void TransactionLogStore::writeBatch(TransactionLogEntryBatch& batch, LogPositio
 			// this prevents infinite loops when file open fails (even with maxIndexSize=0)
 			if (logFile == nullptr || this->maxFileSize > 0) {
 				DEBUG_LOG("%p TransactionLogStore::writeBatch Advancing sequence number from %u to %u for store \"%s\" (logFile=%p, maxIndexSize=%u)\n",
-					this, this->currentSequenceNumber, this->nextSequenceNumber, this->name.c_str(), static_cast<void*>(logFile.get()), this->maxFileSize);
+					this, this->currentSequenceNumber.load(std::memory_order_relaxed), this->nextSequenceNumber, this->name.c_str(), static_cast<void*>(logFile.get()), this->maxFileSize);
 				this->currentSequenceNumber = this->nextSequenceNumber++;
 				logFile = nullptr;
 			}
@@ -541,7 +604,7 @@ void TransactionLogStore::writeBatch(TransactionLogEntryBatch& batch, LogPositio
 					this, fileAgeMs.count());
 				if (fileAgeMs >= thresholdDuration) {
 					DEBUG_LOG("%p TransactionLogStore::writeBatch Log file is older than threshold (%lld ms >= %lld ms), advancing from %u to %u for store \"%s\"\n",
-						this, fileAgeMs.count(), thresholdDuration.count(), this->currentSequenceNumber, this->nextSequenceNumber, this->name.c_str());
+						this, fileAgeMs.count(), thresholdDuration.count(), this->currentSequenceNumber.load(std::memory_order_relaxed), this->nextSequenceNumber, this->name.c_str());
 					this->currentSequenceNumber = this->nextSequenceNumber++;
 					continue;
 				}
@@ -579,15 +642,15 @@ void TransactionLogStore::writeBatch(TransactionLogEntryBatch& batch, LogPositio
 
 		// if no progress was made, rotate to the next file to avoid infinite loop
 		if (logFile->size == sizeBefore) {
-			DEBUG_LOG("%p TransactionLogStore::writeBatch No progress made (size unchanged), advancing from %u to %u for store \"%s\"\n", this, this->currentSequenceNumber, this->nextSequenceNumber, this->name.c_str());
+			DEBUG_LOG("%p TransactionLogStore::writeBatch No progress made (size unchanged), advancing from %u to %u for store \"%s\"\n", this, this->currentSequenceNumber.load(std::memory_order_relaxed), this->nextSequenceNumber, this->name.c_str());
 			this->currentSequenceNumber = this->nextSequenceNumber++;
 		} else if (this->maxFileSize > 0 && logFile->size >= this->maxFileSize) {
 			// we've reached or exceeded the max size, rotate to the next file
-			DEBUG_LOG("%p TransactionLogStore::writeBatch Log file reached max size, advancing from %u to %u for store \"%s\"\n", this, this->currentSequenceNumber, this->nextSequenceNumber, this->name.c_str());
+			DEBUG_LOG("%p TransactionLogStore::writeBatch Log file reached max size, advancing from %u to %u for store \"%s\"\n", this, this->currentSequenceNumber.load(std::memory_order_relaxed), this->nextSequenceNumber, this->name.c_str());
 			this->currentSequenceNumber = this->nextSequenceNumber++;
 		} else if (!batch.isComplete()) {
 			// we've written some entries, but the batch is not complete, rotate to the next file
-			DEBUG_LOG("%p TransactionLogStore::writeBatch Batch is not complete, advancing from %u to %u for store \"%s\"\n", this, this->currentSequenceNumber, this->nextSequenceNumber, this->name.c_str());
+			DEBUG_LOG("%p TransactionLogStore::writeBatch Batch is not complete, advancing from %u to %u for store \"%s\"\n", this, this->currentSequenceNumber.load(std::memory_order_relaxed), this->nextSequenceNumber, this->name.c_str());
 			this->currentSequenceNumber = this->nextSequenceNumber++;
 		}
 		{

--- a/src/binding/transaction_log_store.h
+++ b/src/binding/transaction_log_store.h
@@ -10,6 +10,7 @@
 #include <mutex>
 #include <atomic>
 #include <functional>
+#include <vector>
 #include "rocksdb/db.h"
 #include "transaction_log_entry.h"
 #include "transaction_log_file.h"
@@ -120,8 +121,12 @@ struct TransactionLogStore final {
 
 	/**
 	 * The current sequence number of the transaction log file.
+	 *
+	 * Atomic so per-handle fast-path readers can compare without acquiring
+	 * dataSetsMutex. Mutations are still serialized by writeMutex /
+	 * dataSetsMutex; the atomic just makes reads race-free.
 	 */
-	uint32_t currentSequenceNumber = 1;
+	std::atomic<uint32_t> currentSequenceNumber{1};
 
 	/**
 	 * The next sequence number to use for the transaction log file.
@@ -132,6 +137,16 @@ struct TransactionLogStore final {
 	 * The map of sequence numbers to transaction log files.
 	 */
 	std::map<uint32_t, std::shared_ptr<TransactionLogFile>> sequenceFiles;
+
+	/**
+	 * Generation counter, bumped whenever sequenceFiles is mutated
+	 * (rotation, registration, purge, close). Per-handle multi-file caches
+	 * compare this against their cached version to detect when they need
+	 * to refresh their snapshot. Mutations happen under dataSetsMutex; the
+	 * counter is published with release ordering so handles' acquire load
+	 * synchronizes-with the corresponding sequenceFiles state.
+	 */
+	std::atomic<uint64_t> filesVersion{0};
 
 	/**
 	 * The mutex to protect writing with the transaction log store.
@@ -299,6 +314,30 @@ struct TransactionLogStore final {
 	 * Get the shared represention object representing the last committed position.
 	 **/
 	std::weak_ptr<LogPosition> getLastCommittedPosition();
+
+	/**
+	 * Look up a log file by sequence number without creating it. Returns
+	 * nullptr if the file isn't currently in sequenceFiles. Read-only;
+	 * intended for use by per-handle caches that want to refresh after
+	 * observing a sequence-number bump.
+	 */
+	std::shared_ptr<TransactionLogFile> lookupLogFile(uint32_t sequenceNumber);
+
+	/**
+	 * Returns an immutable snapshot of all currently-known log files,
+	 * sorted by sequence number ascending. The result also reports the
+	 * version of `filesVersion` that the snapshot corresponds to, so
+	 * callers can compare against later observations of `filesVersion`
+	 * to detect when the snapshot has gone stale.
+	 *
+	 * Acquires `dataSetsMutex` briefly to copy the map; the returned
+	 * vector is then independent of further sequenceFiles mutations.
+	 */
+	struct FilesSnapshot {
+		std::shared_ptr<const std::vector<std::shared_ptr<TransactionLogFile>>> files;
+		uint64_t version;
+	};
+	FilesSnapshot getFilesSnapshot();
 
 	/**
 	 * Finds the transaction log file position with the oldest transaction that is equal to, or

--- a/test/transaction-log.test.ts
+++ b/test/transaction-log.test.ts
@@ -453,6 +453,409 @@ describe('Transaction Log', () => {
 				});
 				expect(Array.from(queryIterator).length).toBe(1); // latest should show up now
 			}));
+
+		// Regression: per-handle file-list cache must be invalidated after the
+		// store rotates to a new file. Same log handle queries before and
+		// after writes that cross a rotation boundary; the second query must
+		// observe entries in the newly-rotated file.
+		it('should observe new entries after rotation in the same handle', () =>
+			dbRunner({ dbOptions: [{ transactionLogMaxSize: 200 }] }, async ({ db }) => {
+				const log = db.useLog('foo');
+				const value = Buffer.alloc(100, 'a');
+
+				const startTs = Date.now() - 1000;
+
+				// First query: pre-rotation. Forces the handle to cache its file
+				// list at the current filesVersion.
+				await db.transaction(async (txn) => {
+					log.addEntry(value, txn.id);
+				});
+				let results = Array.from(log.query({ start: startTs }));
+				expect(results.length).toBe(1);
+
+				// Rotate by writing entries that exceed maxFileSize. With
+				// transactionLogMaxSize=200 and ~113 byte entries (100 byte payload
+				// plus 13 byte header), every other write rotates.
+				for (let i = 0; i < 5; i++) {
+					await delay(2);
+					await db.transaction(async (txn) => {
+						log.addEntry(value, txn.id);
+					});
+				}
+
+				// Second query on the same handle: must see ALL 6 entries,
+				// not just the 1 from before rotation. A stale per-handle
+				// cache pointing only to file 1 would miss the new files.
+				results = Array.from(log.query({ start: startTs }));
+				expect(results.length).toBe(6);
+			}));
+
+		// Regression: a query should return correct results even with concurrent
+		// writes happening to the same log. Exercises the lock-free index reader
+		// against a writer extending the file/index.
+		it('should return correct results with concurrent writes', () =>
+			dbRunner(async ({ db }) => {
+				const log = db.useLog('foo');
+				const value = Buffer.alloc(50, 'a');
+				const startTs = Date.now() - 1000;
+
+				// Seed with some entries.
+				for (let i = 0; i < 10; i++) {
+					await db.transaction(async (txn) => {
+						log.addEntry(value, txn.id);
+					});
+				}
+
+				// Run 30 more writes concurrently with 30 queries; verify
+				// every query returns at least the seed count (10) and at
+				// most the total possible (40), and never returns garbage.
+				const writes: Array<Promise<unknown>> = [];
+				const queries: number[] = [];
+				for (let i = 0; i < 30; i++) {
+					writes.push(
+						db.transaction(async (txn) => {
+							log.addEntry(value, txn.id);
+						})
+					);
+					queries.push(Array.from(log.query({ start: startTs })).length);
+				}
+				await Promise.all(writes);
+
+				// Every query observed at least the 10 seeded entries; final
+				// query observes all 40.
+				for (const count of queries) {
+					expect(count).toBeGreaterThanOrEqual(10);
+					expect(count).toBeLessThanOrEqual(40);
+				}
+				const finalCount = Array.from(log.query({ start: startTs })).length;
+				expect(finalCount).toBe(40);
+			}));
+
+		// Regression: a query handle that was cached pre-purge must produce
+		// results consistent with the post-purge state. Either purge is a
+		// no-op (entries weren't flushed yet) and the query returns the same
+		// data, OR purge removes files and the query returns the remaining
+		// data — never garbage entries.
+		it('should handle queries after attempting to purge earlier files', () =>
+			dbRunner({ dbOptions: [{ transactionLogMaxSize: 200 }] }, async ({ db }) => {
+				const log = db.useLog('foo');
+				const value = Buffer.alloc(100, 'a');
+
+				const startTs = Date.now() - 1000;
+
+				// Seed enough entries to create multiple log files.
+				for (let i = 0; i < 4; i++) {
+					await db.transaction(async (txn) => {
+						log.addEntry(value, txn.id);
+					});
+					await delay(2);
+				}
+
+				// First query — populates the handle's per-handle file cache.
+				const beforePurge = Array.from(log.query({ start: startTs }));
+				expect(beforePurge.length).toBe(4);
+
+				// purgeLogs({destroy: true}) attempts to tryClose each store
+				// regardless of whether any files were physically removed (e.g.
+				// unflushed files are not removed but the store still closes
+				// if there are no pending/uncommitted transactions). After
+				// close, reads through the same handle return empty — the
+				// handle holds a strong reference to the now-closed store
+				// and treats isClosing the same as "store gone". Either an
+				// empty result or the original 4 are valid outcomes; the
+				// guard is that we never see garbage.
+				db.purgeLogs({ destroy: true });
+				const afterPurge = Array.from(log.query({ start: startTs }));
+				expect(afterPurge.length).toBeLessThanOrEqual(beforePurge.length);
+				expect(afterPurge.length).toBeLessThanOrEqual(4);
+			}));
+
+		// Regression: documents the observable behavior of `purgeLogs({destroy: true})`
+		// when no files are physically purgable (writes haven't been flushed
+		// to RocksDB yet). The store may or may not be closed by tryClose
+		// depending on internal state (uncommittedTransactionPositions,
+		// pendingTransactionCount) at the time of the call. The handle must
+		// behave safely in either case:
+		//   - If the store stays open: queries return the original entries.
+		//   - If the store closed: queries return empty (handle observes
+		//     isClosing on every read method and short-circuits).
+		// In neither case should we see crashes, leaks, or garbage entries.
+		it('should behave safely when purgeLogs({destroy: true}) may or may not close the store', () =>
+			dbRunner(async ({ db }) => {
+				const log = db.useLog('foo');
+				const value = Buffer.alloc(50, 'a');
+				const startTs = Date.now() - 1000;
+
+				for (let i = 0; i < 5; i++) {
+					await db.transaction(async (txn) => {
+						log.addEntry(value, txn.id);
+					});
+				}
+				expect(Array.from(log.query({ start: startTs })).length).toBe(5);
+
+				db.purgeLogs({ destroy: true });
+
+				// Either 0 (store closed → empty) or 5 (store stayed open).
+				// Anything in between would be a bug — partial entries imply
+				// stale per-handle cache state.
+				const afterDestroy = Array.from(log.query({ start: startTs }));
+				expect([0, 5]).toContain(afterDestroy.length);
+
+				// A fresh handle resolves a fresh store — should always work.
+				const freshLog = db.useLog('foo');
+				const fromFresh = Array.from(freshLog.query({ start: startTs }));
+				expect(fromFresh.length).toBeGreaterThanOrEqual(0);
+				expect(fromFresh.length).toBeLessThanOrEqual(5);
+			}));
+
+		// Stress: many concurrent reads while a destroyer thread races
+		// purgeLogs({destroy: true}) calls. Validates shared_ptr cache
+		// safety — handles must not crash or return garbage while their
+		// store is being closed concurrently.
+		it('should remain crash-free under concurrent reads + destroy attempts', () =>
+			dbRunner(async ({ db }) => {
+				const log = db.useLog('foo');
+				const value = Buffer.alloc(50, 'a');
+				const startTs = Date.now() - 1000;
+
+				for (let i = 0; i < 50; i++) {
+					await db.transaction(async (txn) => {
+						log.addEntry(value, txn.id);
+					});
+				}
+
+				// 64 concurrent reads interleaved with 4 destroy attempts
+				// (most will be no-ops since reads keep transactions in flight,
+				// but the calls still try to flip isClosing on the store).
+				const ops: Array<Promise<unknown>> = [];
+				for (let i = 0; i < 64; i++) {
+					ops.push(Promise.resolve().then(() => Array.from(log.query({ start: startTs })).length));
+				}
+				for (let i = 0; i < 4; i++) {
+					ops.push(
+						Promise.resolve().then(() => {
+							db.purgeLogs({ destroy: true });
+						})
+					);
+				}
+				const results = await Promise.all(ops);
+
+				// All read results must be a valid count (0..50). No NaN,
+				// no -1, no unbounded values that would indicate corruption.
+				for (let i = 0; i < 64; i++) {
+					const count = results[i] as number;
+					expect(count).toBeGreaterThanOrEqual(0);
+					expect(count).toBeLessThanOrEqual(50);
+				}
+
+				// A fresh handle and fresh transaction must still be usable.
+				const freshLog = db.useLog('foo');
+				await db.transaction(async (txn) => {
+					freshLog.addEntry(value, txn.id);
+				});
+				const final = Array.from(freshLog.query({ start: startTs }));
+				expect(final.length).toBeGreaterThanOrEqual(1);
+				expect(final.length).toBeLessThanOrEqual(51);
+			}));
+
+		// Regression for the lock-free getLogFileSize fast path: a reader
+		// crossing log file boundaries during ongoing rotations must observe
+		// each rotated file's size correctly. The fast path reads the file's
+		// size atomic directly from the per-handle snapshot; the slow path
+		// fallback handles the "file in snapshot but not yet opened (size==0)"
+		// race window.
+		it('should report correct size and entries for queries crossing rotated files under writes', () =>
+			dbRunner({ dbOptions: [{ transactionLogMaxSize: 200 }] }, async ({ db }) => {
+				const log = db.useLog('foo');
+				const value = Buffer.alloc(100, 'a');
+				const startTs = Date.now() - 1000;
+
+				// Seed 3 entries → triggers one rotation. Caches file list in
+				// the handle.
+				for (let i = 0; i < 3; i++) {
+					await db.transaction(async (txn) => {
+						log.addEntry(value, txn.id);
+					});
+					await delay(2);
+				}
+				const initial = Array.from(log.query({ start: startTs }));
+				expect(initial.length).toBe(3);
+
+				// Concurrent writes (forcing more rotations) interleaved with
+				// queries. The query path will call getLogFileSize for each
+				// rotated file as it crosses boundaries; the fast path must
+				// return the correct size or fall through to the slow path.
+				const writes: Array<Promise<unknown>> = [];
+				const counts: number[] = [];
+				for (let i = 0; i < 20; i++) {
+					writes.push(
+						db.transaction(async (txn) => {
+							log.addEntry(value, txn.id);
+						})
+					);
+					counts.push(Array.from(log.query({ start: startTs })).length);
+				}
+				await Promise.all(writes);
+
+				// Every query observes at least the 3 seeded entries and at
+				// most the total possible (3 + 20).
+				for (const count of counts) {
+					expect(count).toBeGreaterThanOrEqual(3);
+					expect(count).toBeLessThanOrEqual(23);
+				}
+				const finalCount = Array.from(log.query({ start: startTs })).length;
+				expect(finalCount).toBe(23);
+			}));
+
+		// Regression: the per-handle file snapshot must stay correct across
+		// many rotations. With a small max file size, every other write
+		// rotates; the handle's filesVersion-driven cache invalidation has
+		// to keep up.
+		it('should remain correct across many rotations on a single long-lived handle', () =>
+			dbRunner({ dbOptions: [{ transactionLogMaxSize: 200 }] }, async ({ db }) => {
+				const log = db.useLog('foo');
+				const value = Buffer.alloc(100, 'a');
+				const startTs = Date.now() - 1000;
+
+				// 100 entries with 100-byte payloads at maxFileSize=200 forces
+				// ~50 rotations. The cache should see filesVersion advance ~50
+				// times via the handle's lock-free findPosition path.
+				for (let i = 0; i < 100; i++) {
+					await db.transaction(async (txn) => {
+						log.addEntry(value, txn.id);
+					});
+					if (i % 10 === 0) await delay(1);
+				}
+
+				// Query repeatedly through the same handle, checking that
+				// every query sees all 100 entries — proves the cache stays
+				// fresh through every rotation.
+				for (let i = 0; i < 5; i++) {
+					const results = Array.from(log.query({ start: startTs }));
+					expect(results.length).toBe(100);
+				}
+			}));
+
+		// Regression: lock-free index correctness under concurrent first-time
+		// readers. After a fresh re-open of the database, no thread has built
+		// the in-memory index yet. Many concurrent queries should serialize
+		// briefly on indexExtendMutex (only one builds, others wait), and all
+		// of them should return correct results.
+		it('should handle concurrent first-time readers on an unindexed log', () =>
+			dbRunner(async ({ db, dbPath }) => {
+				const log = db.useLog('foo');
+				const value = Buffer.alloc(50, 'a');
+				const startTs = Date.now() - 1000;
+
+				// Seed 200 entries.
+				for (let i = 0; i < 200; i++) {
+					await db.transaction(async (txn) => {
+						log.addEntry(value, txn.id);
+					});
+				}
+
+				// Close and reopen so the index is empty on first query.
+				db.close();
+				const reopened = RocksDatabase.open(dbPath);
+				const reopenedLog = reopened.useLog('foo');
+
+				try {
+					// 32 concurrent queries — first one to acquire indexExtendMutex
+					// builds the index; others wait briefly and then use the
+					// freshly-built result. Use readUncommitted so the query
+					// reads the entire log (lastCommittedPosition is 0 after a
+					// fresh open).
+					const queries = await Promise.all(
+						Array.from({ length: 32 }, () =>
+							Promise.resolve().then(
+								() =>
+									Array.from(reopenedLog.query({ start: startTs, readUncommitted: true })).length
+							)
+						)
+					);
+					for (const count of queries) {
+						expect(count).toBe(200);
+					}
+				} finally {
+					reopened.close();
+				}
+			}));
+
+		// Regression: two handles on the same log have independent
+		// cachedFiles snapshots. Both must see the same data; refresh must
+		// fire correctly per-handle.
+		it('should serve consistent results across multiple handles on the same log', () =>
+			dbRunner({ dbOptions: [{ transactionLogMaxSize: 200 }] }, async ({ db }) => {
+				const log1 = db.useLog('foo');
+				const log2 = db.useLog('foo');
+				const value = Buffer.alloc(100, 'a');
+				const startTs = Date.now() - 1000;
+
+				// Seed.
+				for (let i = 0; i < 5; i++) {
+					await db.transaction(async (txn) => {
+						log1.addEntry(value, txn.id);
+					});
+					await delay(1);
+				}
+
+				// Both handles populate their caches.
+				expect(Array.from(log1.query({ start: startTs })).length).toBe(5);
+				expect(Array.from(log2.query({ start: startTs })).length).toBe(5);
+
+				// Force several rotations via writes through log1.
+				for (let i = 0; i < 10; i++) {
+					await db.transaction(async (txn) => {
+						log1.addEntry(value, txn.id);
+					});
+					await delay(1);
+				}
+
+				// log2's cache was stale at the start of this query; it must
+				// observe the filesVersion bump and refresh, then return the
+				// same count as log1.
+				const fromLog1 = Array.from(log1.query({ start: startTs })).length;
+				const fromLog2 = Array.from(log2.query({ start: startTs })).length;
+				expect(fromLog1).toBe(15);
+				expect(fromLog2).toBe(15);
+			}));
+
+		// Regression: a reused query iterator must continue to produce
+		// correct entries when the log rotates between iterator yields.
+		// The iterator's internal log file pointer crosses the boundary
+		// via getLogFileSize (newly lock-free) + getMemoryMap.
+		it('should continue iterating correctly across rotations within a reused iterator', () =>
+			dbRunner({ dbOptions: [{ transactionLogMaxSize: 200 }] }, async ({ db }) => {
+				const log = db.useLog('foo');
+				const value = Buffer.alloc(100, 'a');
+				const startTs = Date.now() - 1000;
+
+				// Seed 2 entries (within first file).
+				for (let i = 0; i < 2; i++) {
+					await db.transaction(async (txn) => {
+						log.addEntry(value, txn.id);
+					});
+					await delay(1);
+				}
+
+				const iterator = log.query({ start: startTs });
+				const initial = Array.from(iterator);
+				expect(initial.length).toBe(2);
+
+				// Add more entries, forcing rotations.
+				for (let i = 0; i < 10; i++) {
+					await db.transaction(async (txn) => {
+						log.addEntry(value, txn.id);
+					});
+					await delay(1);
+				}
+
+				// Resume the same iterator — it should pick up only the new
+				// entries (8+) added after rotations, not duplicate the
+				// original 2.
+				const resumed = Array.from(iterator);
+				expect(resumed.length).toBe(10);
+			}));
 	});
 
 	describe('addEntry()', () => {


### PR DESCRIPTION
Eliminates dataSetsMutex and weak_ptr::lock() contention from the steady-state read path, unlocking high-QPS workloads with many concurrent subscribers (e.g., CDC replication).

Read-path changes (TransactionLogStore + TransactionLogHandle):

- Per-handle file snapshot cache (cachedFiles + filesVersion). Handles refresh the snapshot only when the store's filesVersion atomic advances (rotation, registration, purge); steady-state reads walk the local snapshot lock-free.
- Lock-free findPosition: walks cachedFiles newest-to-oldest, skipping files by their stored timestamp. Falls back to the store-level slow path only when the snapshot is empty.
- Lock-free getLogFileSize fast path: reads logFile->size atomic via the cached snapshot. Falls through to the slow path only when sequenceNumber=0 or the file is in the snapshot but not yet opened.
- Cached shared_ptr<TransactionLogStore> on the handle replaces the per-call weak_ptr::lock() CAS. Each read-method now does an isClosing.load() check instead. addEntry re-resolves to a fresh store and clears cachedFiles when isClosing is observed.
- currentSequenceNumber is now atomic (was plain uint32_t) so handle fast-path readers can compare without acquiring dataSetsMutex.

Per-file index changes (TransactionLogFile):

- Lock-free in-file timestamp index using a stable buffer + packed atomic state (low 32 bits = entry count, high 32 bits = position indexed up to). Replaces the std::map + indexMutex serialization. Acquire/release ordering on indexState publishes new entries safely to lock-free readers.
- Slow-path index extension serializes only on indexExtendMutex (per-file), not the global dataSetsMutex.
- Removed eager ensureIndexUpToDate at registerLogFile — saves up to maxFileSize/13 × 16 bytes per recovered file at startup. The lazy slow path handles the first reader instead.
- Inlined extendIndexLocked into findPositionByTimestamp (only caller).

Test coverage:

Adds 9 new regression tests covering the cases the changes affected:
- per-handle cache invalidation across many rotations
- concurrent first-time readers on a freshly-opened (unindexed) log
- multiple handles on the same log staying consistent
- iterator resume across rotations
- crash-free behavior under concurrent reads + purgeLogs(destroy:true)
- queries after attempting to purge earlier files
- ...and more

Bench:

Adds benchmark/worker-transaction-log-read.bench.ts — 4 access patterns (bulk forward scan, bulk forward scan with concurrent writer, high-frequency short-range queries, cursor-advance tail scan with writer) at 8 workers, comparing rocksdb-js against lmdb with matched lazy-durability semantics (noSync) and Harper-realistic LMDB options (snapshot:false, numeric keys).