### PR TITLE
Guard against out-of-bounds DataView read in transaction log iterator

### DIFF
--- a/src/transaction-log-reader.ts
+++ b/src/transaction-log-reader.ts
@@ -93,9 +93,12 @@ Object.defineProperty(TransactionLog.prototype, 'query', {
 			}
 
 			if (logBuffer === undefined) {
-				// create a fake log buffer if we don't have any log buffer yet
+				// create a placeholder log buffer if we couldn't acquire a memory map.
+				// preserve the intended logId (when > 0) so the iterator's read guard can
+				// retry the mmap if a non-zero size from loadLastPosition() disagrees with
+				// the placeholder's length.
 				logBuffer = Buffer.alloc(0) as unknown as LogBuffer;
-				logBuffer.logId = 0;
+				logBuffer.logId = logId > 0 ? logId : 0;
 				logBuffer.size = 0;
 				logBuffer.dataView = new DataView(logBuffer.buffer);
 			}
@@ -150,6 +153,23 @@ Object.defineProperty(TransactionLog.prototype, 'query', {
 				}
 
 				while (position < size) {
+					if (position + TRANSACTION_LOG_ENTRY_HEADER_SIZE > logBuffer!.length) {
+						// the size reported by loadLastPosition() exceeds the actual mapped
+						// buffer length. can happen if _getMemoryMapOfFile returned undefined
+						// (transient state during log rotation, 0-byte file at mmap time,
+						// or an inconsistent _lastCommittedPosition referencing an unmappable
+						// logId) and we installed an empty placeholder buffer. try to
+						// re-acquire the mmap; if it still can't cover this read, end the
+						// iteration safely — the caller can re-query when state is consistent.
+						const remapped =
+							logBuffer!.logId > 0 ? getLogMemoryMap(transactionLog, logBuffer!.logId) : undefined;
+						if (remapped && position + TRANSACTION_LOG_ENTRY_HEADER_SIZE <= remapped.length) {
+							logBuffer = remapped;
+							dataView = remapped.dataView;
+						} else {
+							return { done: true, value: undefined };
+						}
+					}
 					try {
 						timestamp = dataView.getFloat64(position);
 					} catch (error) {

--- a/src/transaction-log-reader.ts
+++ b/src/transaction-log-reader.ts
@@ -93,14 +93,19 @@ Object.defineProperty(TransactionLog.prototype, 'query', {
 			}
 
 			if (logBuffer === undefined) {
-				// create a placeholder log buffer if we couldn't acquire a memory map.
-				// preserve the intended logId (when > 0) so the iterator's read guard can
-				// retry the mmap if a non-zero size from loadLastPosition() disagrees with
-				// the placeholder's length.
+				// create a fake log buffer if we don't have any log buffer yet
 				logBuffer = Buffer.alloc(0) as unknown as LogBuffer;
-				logBuffer.logId = logId > 0 ? logId : 0;
+				logBuffer.logId = 0;
 				logBuffer.size = 0;
 				logBuffer.dataView = new DataView(logBuffer.buffer);
+				// the outer size variable was set from loadLastPosition() above, but if we
+				// couldn't acquire a memory map for that logId (e.g. the committed-position
+				// references a logId that doesn't exist on disk — purged, never created, or
+				// torn write of the position word), reading at any non-zero size would read
+				// past the empty buffer. force size to match the empty buffer; the iterator's
+				// position-vs-size logic then routes through the existing advance-to-next-log
+				// path, which correctly returns done when no log file can be mapped.
+				size = 0;
 			}
 		}
 
@@ -153,23 +158,6 @@ Object.defineProperty(TransactionLog.prototype, 'query', {
 				}
 
 				while (position < size) {
-					if (position + TRANSACTION_LOG_ENTRY_HEADER_SIZE > logBuffer!.length) {
-						// the size reported by loadLastPosition() exceeds the actual mapped
-						// buffer length. can happen if _getMemoryMapOfFile returned undefined
-						// (transient state during log rotation, 0-byte file at mmap time,
-						// or an inconsistent _lastCommittedPosition referencing an unmappable
-						// logId) and we installed an empty placeholder buffer. try to
-						// re-acquire the mmap; if it still can't cover this read, end the
-						// iteration safely — the caller can re-query when state is consistent.
-						const remapped =
-							logBuffer!.logId > 0 ? getLogMemoryMap(transactionLog, logBuffer!.logId) : undefined;
-						if (remapped && position + TRANSACTION_LOG_ENTRY_HEADER_SIZE <= remapped.length) {
-							logBuffer = remapped;
-							dataView = remapped.dataView;
-						} else {
-							return { done: true, value: undefined };
-						}
-					}
 					try {
 						timestamp = dataView.getFloat64(position);
 					} catch (error) {

--- a/test/transaction-log.test.ts
+++ b/test/transaction-log.test.ts
@@ -352,6 +352,43 @@ describe('Transaction Log', () => {
 				expect(queryResults[0].endTxn).toBe(true);
 			}));
 
+		it('should not throw when the memory map for the latest log cannot be acquired', () =>
+			dbRunner(async ({ db }) => {
+				const log = db.useLog('foo');
+				const value = Buffer.alloc(10, 'a');
+				for (let i = 0; i < 3; i++) {
+					await db.transaction(async (txn) => {
+						log.addEntry(value, txn.id);
+					});
+				}
+				// prime the query path so _logBuffers and _lastCommittedPosition are initialized
+				expect(Array.from(log.query({ start: 0 })).length).toBe(3);
+
+				// simulate the inconsistent state where _lastCommittedPosition reports a
+				// non-zero size for a logId whose memory map cannot be acquired (transient
+				// state during rotation, 0-byte file at mmap time, FS race, etc.)
+				log._logBuffers.clear();
+				(log as { _currentLogBuffer?: unknown })._currentLogBuffer = undefined;
+				const realGetMmapDescriptor = Object.getOwnPropertyDescriptor(
+					Object.getPrototypeOf(log),
+					'_getMemoryMapOfFile'
+				)!;
+				Object.defineProperty(log, '_getMemoryMapOfFile', {
+					value: () => undefined,
+					configurable: true,
+					writable: true,
+				});
+				try {
+					// should terminate iteration cleanly rather than throw RangeError
+					const results = Array.from(log.query({ start: 0 }));
+					expect(results.length).toBe(0);
+				} finally {
+					Object.defineProperty(log, '_getMemoryMapOfFile', realGetMmapDescriptor);
+				}
+				// once the mmap works again, the data must still be readable
+				expect(Array.from(log.query({ start: 0 })).length).toBe(3);
+			}));
+
 		it('should query a transaction log after re-opening database', () =>
 			dbRunner(async ({ db, dbPath }) => {
 				try {


### PR DESCRIPTION
## Summary

Defensive fix for a `RangeError: Offset is outside the bounds of the DataView` crash in `TransactionLog.prototype.query`'s iterator, observed in production via the aggregating iterator at `RocksTransactionLogStore.ts:232`:

```
RangeError: Offset is outside the bounds of the DataView at position 13 of log 0 (size=13156, log buffer length=0)
    at DataView.prototype.getFloat64 (<anonymous>)
    at Object.next (transaction-log-reader.ts:154:28)
```

## What was happening

1. `loadLastPosition()` returns `{ logId, size }` from native committed-position state — e.g. `{ logId: 0, size: 13156 }` (torn write of the position word) or a stale `{ logId: N, size: M }` referencing a logId that's been purged/never created.
2. `getLogMemoryMap(this, logId)` returns `undefined` because `_getMemoryMapOfFile` can't map the file (the logId doesn't correspond to a real file on disk).
3. The pre-existing code installed a 0-length placeholder `Buffer` but did **not** reset the outer `size` variable. The size-reset block at line 106 only fires when `latestLogId !== logId`.
4. The iterator entered `while (position < size)` (e.g. `13 < 13156`), called `dataView.getFloat64(13)` on the empty view, and threw.

## Fix

One line added after the placeholder buffer is installed in `src/transaction-log-reader.ts`:

```ts
size = 0;
```

That re-establishes the invariant `size <= logBuffer.length`. The iterator's `next()` then routes through the existing `position >= size` → `loadLastPosition()` → advance-to-next-log path, which already correctly handles `getLogMemoryMap()` returning `undefined` by leaving the empty buffer in place and falling through to `while (position < 0)` → `return { done: true }`.

The caller (aggregating iterator in `RocksTransactionLogStore.ts:200+`) calls `updateIterators()` periodically and re-queries — so returning `done: true` on a transient state naturally surfaces the data on the next pass, instead of crashing.

## Where to look

- `src/transaction-log-reader.ts:101` — the new `size = 0;` plus a comment explaining why. That's the entire fix.
- **Behavior change**: previously a crash; now a clean `done: true`. If the underlying state is persistently corrupt (e.g. committed position permanently references an unmappable logId), iteration silently returns no entries. That's arguably better than crashing the caller, but worth a log/warning at the native boundary as a follow-up if this fires in healthy clusters.

## Out of scope

This patch addresses the JS-layer crash. It does **not** investigate why `_lastCommittedPosition` ends up referencing an unmappable logId — likely a torn-write/atomicity issue on the native committed-position update, or stale state after purging. Worth a separate look on the native side.

## Test plan

Added `test/transaction-log.test.ts` "should not throw when the memory map for the latest log cannot be acquired":

- Commits 3 entries
- Clears `_logBuffers` / `_currentLogBuffer`
- Stubs `_getMemoryMapOfFile` to return `undefined`
- Verifies `Array.from(log.query({ start: 0 }))` returns `[]` (not throw)
- Restores the stub and verifies all 3 entries are readable again (no permanent state damage)

Verified the test reproduces the exact original error (`RangeError ... size=82, log buffer length=0`) when run against unchanged source. All 46 transaction-log tests pass with the fix.

## Commit history

Two commits — the first attempted a more surgical fix (preserve intended logId on the placeholder + in-loop bounds guard); the second simplified it to a one-line `size = 0;` after we confirmed sequence ids aren't reused and the surgical retry path was redundant in practice. Squashing on merge is fine.

---

🤖 This PR was generated by Claude (claude-opus-4-7) at the user's direction. Cross-model reviewed by Gemini.