### PR TITLE
Fixed bug with transaction logs not binding to transactions

### DIFF
--- a/src/binding/transaction.cpp
+++ b/src/binding/transaction.cpp
@@ -635,7 +635,8 @@ napi_value Transaction::UseLog(napi_env env, napi_callback_info info) {
 	// check if transaction is already bound to a different log store
 	auto boundStore = (*txnHandle)->boundLogStore.lock();
 	if (boundStore && boundStore->name != name) {
-		::napi_throw_error(env, nullptr, "Log already bound to a transaction");
+		std::string errorMessage = "Transaction " + std::to_string((*txnHandle)->id) + " is already bound to the log store \"" + boundStore->name + "\"";
+		::napi_throw_error(env, nullptr, errorMessage.c_str());
 		return nullptr;
 	}
 
@@ -674,13 +675,14 @@ napi_value Transaction::UseLog(napi_env env, napi_callback_info info) {
 	napi_value jsDatabase;
 	NAPI_STATUS_THROWS_ERROR(::napi_get_reference_value(env, (*txnHandle)->jsDatabaseRef, &jsDatabase), "Failed to get 'jsDatabase' reference");
 
-	napi_value args[2];
+	napi_value args[3];
 	args[0] = jsDatabase;
 
 	NAPI_STATUS_THROWS_ERROR(::napi_create_string_utf8(env, name.c_str(), name.size(), &args[1]), "Invalid log name");
+	NAPI_STATUS_THROWS_ERROR(::napi_create_uint32(env, (*txnHandle)->id, &args[2]), "Failed to create transaction id argument");
 
 	napi_value instance;
-	NAPI_STATUS_THROWS_ERROR(::napi_new_instance(env, transactionLogCtor, 2, args, &instance), "Failed to create new TransactionLog instance");
+	NAPI_STATUS_THROWS_ERROR(::napi_new_instance(env, transactionLogCtor, 3, args, &instance), "Failed to create new TransactionLog instance");
 
 	return instance;
 }

--- a/src/binding/transaction_handle.cpp
+++ b/src/binding/transaction_handle.cpp
@@ -66,6 +66,15 @@ TransactionHandle::~TransactionHandle() {
 
 /**
  * Adds a log entry to the specified transaction log store's batch.
+ *
+ * @example
+ * ```typescript
+ * await db.transaction(async (txn) => {
+ *   const log = txn.useLog('foo'); // transaction log store will be bound to this transaction
+ *   log.addEntry(Buffer.from('hello'));
+ *   log.addEntry(Buffer.from('world'));
+ * });
+ * ```
  */
 void TransactionHandle::addLogEntry(std::unique_ptr<TransactionLogEntry> entry) {
 	DEBUG_LOG("%p TransactionHandle::addLogEntry Adding log entry to store \"%s\" for transaction %u (size=%zu)\n",
@@ -76,7 +85,8 @@ void TransactionHandle::addLogEntry(std::unique_ptr<TransactionLogEntry> entry) 
 	if (currentBoundStore) {
 		// transaction is already bound to a log store
 		if (currentBoundStore.get() != entry->store.get()) {
-			throw rocksdb_js::DBException("Log already bound to a transaction");
+			std::string errorMessage = "Transaction " + std::to_string(this->id) + " is already bound to the log store \"" + currentBoundStore->name + "\"";
+			throw rocksdb_js::DBException(errorMessage);
 		}
 	} else {
 		// Bind under transactionBindMutex so the bind+increment is atomic with

--- a/src/binding/transaction_handle.cpp
+++ b/src/binding/transaction_handle.cpp
@@ -84,7 +84,7 @@ void TransactionHandle::addLogEntry(std::unique_ptr<TransactionLogEntry> entry) 
 	auto currentBoundStore = this->boundLogStore.lock();
 	if (currentBoundStore) {
 		// transaction is already bound to a log store
-		if (currentBoundStore.get() != entry->store.get()) {
+		if (currentBoundStore->name != entry->store->name) {
 			std::string errorMessage = "Transaction " + std::to_string(this->id) + " is already bound to the log store \"" + currentBoundStore->name + "\"";
 			throw rocksdb_js::DBException(errorMessage);
 		}

--- a/src/binding/transaction_log.cpp
+++ b/src/binding/transaction_log.cpp
@@ -29,21 +29,41 @@ namespace rocksdb_js {
  * @example
  * ```typescript
  * const db = RocksDatabase.open('/tmp/testdb');
- * db.open('/tmp/testdb');
- * const txnLog = new NativeTransactionLog(db, 'test');
+ *
+ * // create a log that is NOT bound to a transaction; transaction id must be passed into
+ * // `txnLog.addEntry()`
+ * const log = db.useLog('test');
+ * await db.transaction(async (txn) => {
+ *   log.addEntry(Buffer.from('hello'), txn.id);
+ * });
+ *
+ * // create a log that is bound to a transaction; transaction id is set automatically
+ * await db.transaction(async (txn) => {
+ *   const txnLog = txn.useLog('test');
+ *   txnLog.addEntry(Buffer.from('hello'));
+ * });
  * ```
  */
 napi_value TransactionLog::Constructor(napi_env env, napi_callback_info info) {
-	NAPI_CONSTRUCTOR_ARGV_WITH_DATA("TransactionLog", 2);
+	NAPI_CONSTRUCTOR_ARGV_WITH_DATA("TransactionLog", 3);
 
 	napi_ref exportsRef = reinterpret_cast<napi_ref>(data);
 	NAPI_GET_DB_HANDLE(argv[0], exportsRef, dbHandle, "Invalid argument, expected Database instance");
 
 	NAPI_GET_STRING(argv[1], name, "Transaction log store name is required");
 
+	// optional 3rd arg: transactionId (set when created via txn.useLog())
+	uint32_t transactionId = 0;
+	napi_valuetype thirdArgType;
+	NAPI_STATUS_THROWS(::napi_typeof(env, argv[2], &thirdArgType));
+	if (thirdArgType == napi_number) {
+		NAPI_STATUS_THROWS(::napi_get_value_uint32(env, argv[2], &transactionId));
+	}
+
 	std::shared_ptr<TransactionLogHandle>* txnLogHandle = new std::shared_ptr<TransactionLogHandle>(
 		std::make_shared<TransactionLogHandle>(*dbHandle, name, (*dbHandle)->descriptor->readOnly)
 	);
+	(*txnLogHandle)->transactionId = transactionId;
 
 	DEBUG_LOG("TransactionLog::Constructor Creating NativeTransactionLog TransactionLogHandle=%p\n", txnLogHandle->get());
 

--- a/src/binding/transaction_log_handle.cpp
+++ b/src/binding/transaction_log_handle.cpp
@@ -47,7 +47,7 @@ void TransactionLogHandle::addEntry(
 
 	// check if transaction is already bound to a different log store
 	auto boundStore = txnHandle->boundLogStore.lock();
-	if (boundStore && boundStore.get() != store.get()) {
+	if (boundStore && boundStore->name != store->name) {
 		std::string errorMessage = "Transaction " + std::to_string(transactionId) + " is already bound to the log store \"" + boundStore->name + "\"";
 		throw rocksdb_js::DBException(errorMessage);
 	}

--- a/src/binding/transaction_log_handle.cpp
+++ b/src/binding/transaction_log_handle.cpp
@@ -48,7 +48,8 @@ void TransactionLogHandle::addEntry(
 	// check if transaction is already bound to a different log store
 	auto boundStore = txnHandle->boundLogStore.lock();
 	if (boundStore && boundStore.get() != store.get()) {
-		throw rocksdb_js::DBException("Log already bound to a transaction");
+		std::string errorMessage = "Transaction " + std::to_string(transactionId) + " is already bound to the log store \"" + boundStore->name + "\"";
+		throw rocksdb_js::DBException(errorMessage);
 	}
 
 	auto entry = std::make_unique<TransactionLogEntry>(store, data, size);

--- a/test/block-cache.test.ts
+++ b/test/block-cache.test.ts
@@ -44,8 +44,8 @@ describe('Block Cache', () => {
 		}));
 
 	it('should throw error when block cache size is negative', () => {
-		expect(() => RocksDatabase.config({ blockCacheSize: -1 })).toThrowError(
-			'Block cache size must be a positive integer or 0 to disable caching'
+		expect(() => RocksDatabase.config({ blockCacheSize: -1 })).toThrow(
+			new Error('Block cache size must be a positive integer or 0 to disable caching')
 		);
 	});
 });

--- a/test/block-cache.test.ts
+++ b/test/block-cache.test.ts
@@ -45,7 +45,7 @@ describe('Block Cache', () => {
 
 	it('should throw error when block cache size is negative', () => {
 		expect(() => RocksDatabase.config({ blockCacheSize: -1 })).toThrow(
-			new Error('Block cache size must be a positive integer or 0 to disable caching')
+			new RangeError('Block cache size must be a positive integer or 0 to disable caching')
 		);
 	});
 });

--- a/test/transaction-log.test.ts
+++ b/test/transaction-log.test.ts
@@ -127,23 +127,39 @@ describe('Transaction Log', () => {
 			})
 		);
 
-		it('should error if log already bound to a transaction', () =>
+		it('should error if transaction is already bound to an unbounded log', () =>
 			dbRunner(async ({ db }) => {
 				const log1 = db.useLog('log1');
 				const log2 = db.useLog('log2');
+
 				await db.transaction(async (txn) => {
 					log1.addEntry(Buffer.from('hello'), txn.id);
 					log1.addEntry(Buffer.from('world'), txn.id);
-					expect(() => log2.addEntry(Buffer.from('nope'), txn.id)).toThrowError(
-						new Error('Log already bound to a transaction')
+					expect(() => log2.addEntry(Buffer.from('nope'), txn.id)).toThrow(
+						new Error(`Transaction ${txn.id} is already bound to the log store "log1"`)
 					);
 				});
+			}));
 
+		it('should error if transaction is already bound to a different bounded log', () =>
+			dbRunner(async ({ db }) => {
 				await db.transaction(async (txn) => {
 					txn.useLog('log3');
 					txn.useLog('log3'); // do it twice
-					expect(() => txn.useLog('log4')).toThrowError(
-						new Error('Log already bound to a transaction')
+					expect(() => txn.useLog('log4')).toThrow(
+						new Error(`Transaction ${txn.id} is already bound to the log store "log3"`)
+					);
+				});
+			}));
+
+		it('should error if transaction is already bound to a bounded log', () =>
+			dbRunner(async ({ db }) => {
+				const log1 = db.useLog('log1');
+
+				await db.transaction(async (txn) => {
+					txn.useLog('log4');
+					expect(() => log1.addEntry(Buffer.from('world'), txn.id)).toThrow(
+						new Error(`Transaction ${txn.id} is already bound to the log store "log4"`)
 					);
 				});
 			}));
@@ -1061,13 +1077,13 @@ describe('Transaction Log', () => {
 
 		it('should error if the log name is invalid', () =>
 			dbRunner(async ({ db }) => {
-				expect(() => db.useLog(undefined as any)).toThrowError(
+				expect(() => db.useLog(undefined as any)).toThrow(
 					new TypeError('Log name must be a string or number')
 				);
-				expect(() => db.useLog([] as any)).toThrowError(
+				expect(() => db.useLog([] as any)).toThrow(
 					new TypeError('Log name must be a string or number')
 				);
-				await expect(db.transaction((txn) => txn.useLog(undefined as any))).rejects.toThrowError(
+				await expect(db.transaction((txn) => txn.useLog(undefined as any))).rejects.toThrow(
 					new TypeError('Log name must be a string or number')
 				);
 			}));
@@ -1076,10 +1092,10 @@ describe('Transaction Log', () => {
 			dbRunner(async ({ db }) => {
 				const log = db.useLog('foo');
 				await db.transaction(async (txn) => {
-					expect(() => log.addEntry(undefined as any, txn.id)).toThrowError(
+					expect(() => log.addEntry(undefined as any, txn.id)).toThrow(
 						new TypeError('Invalid log entry, expected a Buffer or ArrayBuffer')
 					);
-					expect(() => log.addEntry([] as any, txn.id)).toThrowError(
+					expect(() => log.addEntry([] as any, txn.id)).toThrow(
 						new TypeError('Invalid log entry, expected a Buffer or ArrayBuffer')
 					);
 				});
@@ -1089,10 +1105,10 @@ describe('Transaction Log', () => {
 			dbRunner(async ({ db }) => {
 				const log = db.useLog('foo');
 				await db.transaction(async (_txn) => {
-					expect(() => log.addEntry(Buffer.from('hello'), undefined as any)).toThrowError(
+					expect(() => log.addEntry(Buffer.from('hello'), undefined as any)).toThrow(
 						new TypeError('Missing argument, transaction id is required')
 					);
-					expect(() => log.addEntry(Buffer.from('hello'), [] as any)).toThrowError(
+					expect(() => log.addEntry(Buffer.from('hello'), [] as any)).toThrow(
 						new TypeError('Invalid argument, transaction id must be a non-negative integer')
 					);
 				});
@@ -1220,6 +1236,34 @@ describe('Transaction Log', () => {
 				const logPath = join(dbPath, 'transaction_logs', 'foo', '1.txnlog');
 				const info = parseTransactionLog(logPath);
 				expect(info.entries.length).toBe(2);
+			}));
+
+		it('should bind a transaction log to a transaction', () =>
+			dbRunner(async ({ db, dbPath }) => {
+				const value = Buffer.alloc(10, 'a');
+
+				await db.transaction(async (txn) => {
+					const log = txn.useLog('foo');
+					log.addEntry(value, txn.id);
+				});
+
+				const logPath = join(dbPath, 'transaction_logs', 'foo', '1.txnlog');
+				const info = parseTransactionLog(logPath);
+				expect(info.size).toBe(
+					TRANSACTION_LOG_FILE_HEADER_SIZE + TRANSACTION_LOG_ENTRY_HEADER_SIZE + 10
+				);
+				expect(info.version).toBe(1);
+				expect(info.entries.length).toBe(1);
+				expect(info.entries[0].timestamp).toBeGreaterThanOrEqual(Date.now() - 1000);
+				expect(info.entries[0].length).toBe(10);
+				expect(info.entries[0].data).toEqual(value);
+
+				const log = db.useLog('foo');
+				const queryResults = Array.from(log.query({ start: 0 }));
+				expect(queryResults.length).toBe(1);
+				expect(queryResults[0].data).toEqual(value);
+				expect(queryResults[0].timestamp).toBeGreaterThanOrEqual(Date.now() - 1000);
+				expect(queryResults[0].endTxn).toBe(true);
 			}));
 	});
 


### PR DESCRIPTION
This PR started out with addressing the confusing "Log already bound to a transaction" error message. Logs are not bound to transactions, but rather transactions are bound to log stores.

Upon fixing this, I noticed that adding an entry to a bound transaction log instances was throwing an error that the `transactionId` was not set. The README example is correct, but the code didn't pass the `transactionId` into the `TransactionLogHandle` instance. Furthermore, we had zero tests for bounded transaction log instances.

This PR now lets you do:
```typescript
await db.transaction(async (txn) => {
  const log = txn.useLog('foo');
  log.addEntry(Buffer.from('hello')); // no transaction id required
});
```

And if you try to add an entry to the wrong store, it errors with a message like `Transaction 123 is already bound to the log store "foo"`.

After all these fixes, I found a huge bug where the "already bound" error was being thrown because when the store is closing and addEntry re-opens it, the new store instance didn't match the previous store because it was comparing the memory address and not the store names. This simple incorrect comparison caused it to think the store is not the same and throw.