### PR TITLE
chore: update CODEOWNERS to explicit maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,6 @@
-# By default, everything must be reviewed by someone in the core engineering team
-*          @HarperFast/developers
+# By default, everything must be reviewed by a core maintainer
+*          @kriszyp @cb1kenobi
+
+# Dependency-only changes don't require kriszyp
+package.json    @cb1kenobi
+pnpm-lock.yaml  @cb1kenobi


### PR DESCRIPTION
Stop spamming the whole engineering team with PR review requests from rocksdb-js.
Humans should never be reviewing numbers (dependabot), this isn't severance. Or at least not me.

## Summary
- Replace `@HarperFast/developers` team with `@kriszyp` and `@cb1kenobi` as explicit owners
- Exempt `package.json` and `pnpm-lock.yaml` from requiring `@kriszyp` so dependency bumps (e.g. Dependabot) don't annoy him
