### PR TITLE
Fix transaction log shutdown race with flush callbacks

### DIFF
--- a/src/binding/transaction_log_store.cpp
+++ b/src/binding/transaction_log_store.cpp
@@ -664,7 +664,7 @@ void TransactionLogStore::databaseFlushBegin(rocksdb::SequenceNumber rocksSequen
  */
 void TransactionLogStore::databaseFlushed(rocksdb::SequenceNumber rocksSequenceNumber) {
 	if (this->isClosing.load(std::memory_order_relaxed)) {
-		throw rocksdb_js::DBException("Transaction log store is closed");
+		return;
 	}
 
 	LogPosition latestSequencePosition = { 0, 0 };

--- a/src/binding/transaction_log_store.cpp
+++ b/src/binding/transaction_log_store.cpp
@@ -630,6 +630,10 @@ bool operator>(const LogPosition a, const LogPosition b) {
  * log file (until it expires), even after crash.
  */
 void TransactionLogStore::databaseFlushBegin(rocksdb::SequenceNumber rocksSequenceNumber) {
+	if (this->isClosing.load(std::memory_order_relaxed)) {
+		throw rocksdb_js::DBException("Transaction log store is closed");
+	}
+
 	std::vector<std::shared_ptr<TransactionLogFile>> logFilesToFlush;
 
 	{
@@ -659,6 +663,10 @@ void TransactionLogStore::databaseFlushBegin(rocksdb::SequenceNumber rocksSequen
  * after restart or crash
  */
 void TransactionLogStore::databaseFlushed(rocksdb::SequenceNumber rocksSequenceNumber) {
+	if (this->isClosing.load(std::memory_order_relaxed)) {
+		throw rocksdb_js::DBException("Transaction log store is closed");
+	}
+
 	LogPosition latestSequencePosition = { 0, 0 };
 	{
 		std::lock_guard<std::mutex> lock(this->dataSetsMutex);

--- a/src/binding/transaction_log_store.cpp
+++ b/src/binding/transaction_log_store.cpp
@@ -631,7 +631,7 @@ bool operator>(const LogPosition a, const LogPosition b) {
  */
 void TransactionLogStore::databaseFlushBegin(rocksdb::SequenceNumber rocksSequenceNumber) {
 	if (this->isClosing.load(std::memory_order_relaxed)) {
-		throw rocksdb_js::DBException("Transaction log store is closed");
+		return;
 	}
 
 	std::vector<std::shared_ptr<TransactionLogFile>> logFilesToFlush;

--- a/src/binding/transaction_log_store_registry.cpp
+++ b/src/binding/transaction_log_store_registry.cpp
@@ -385,7 +385,7 @@ std::vector<std::shared_ptr<TransactionLogStore>> TransactionLogStoreRegistry::G
 		return result;
 	}
 
-	TransactionLogStoreRegistryEntry* entry = nullptr;
+	std::shared_ptr<TransactionLogStoreRegistryEntry> entry;
 
 	{
 		std::lock_guard<std::mutex> lock(instance->entriesMutex);
@@ -395,7 +395,7 @@ std::vector<std::shared_ptr<TransactionLogStore>> TransactionLogStoreRegistry::G
 			return result;
 		}
 
-		entry = it->second.get();
+		entry = it->second;
 	}
 
 	std::lock_guard<std::mutex> storeLock(entry->storesMutex);


### PR DESCRIPTION
Fix transaction log shutdown race with flush callbacks

During `db.shutdown()`, `DBDescriptor::close()` calls `Unregister()` before `db.reset()`, so RocksDB can still invoke `OnFlushBegin/OnFlushCompleted` on background threads while stores are closing.

Hold a `shared_ptr` to the registry entry in `GetStores()` so `Unregister` cannot destroy the entry between releasing `entriesMutex` and locking `storesMutex`. Reject flush handler work on stores that have already set `isClosing`, matching `writeBatch()`.

This PR should have been apart of https://github.com/HarperFast/rocksdb-js/pull/559.