### PR TITLE
Expose write buffer options and retune defaults for transactional load

### DIFF
--- a/src/binding/database.cpp
+++ b/src/binding/database.cpp
@@ -1166,6 +1166,10 @@ napi_value Database::Open(napi_env env, napi_callback_info info) {
 	NAPI_STATUS_THROWS(rocksdb_js::getProperty(env, options, "noBlockCache", dbHandleOptions.noBlockCache));
 	NAPI_STATUS_THROWS(rocksdb_js::getProperty(env, options, "readOnly", dbHandleOptions.readOnly));
 	NAPI_STATUS_THROWS(rocksdb_js::getProperty(env, options, "parallelismThreads", dbHandleOptions.parallelismThreads));
+	NAPI_STATUS_THROWS(rocksdb_js::getProperty(env, options, "writeBufferSize", dbHandleOptions.writeBufferSize));
+	NAPI_STATUS_THROWS(rocksdb_js::getProperty(env, options, "maxWriteBufferNumber", dbHandleOptions.maxWriteBufferNumber));
+	NAPI_STATUS_THROWS(rocksdb_js::getProperty(env, options, "dbWriteBufferSize", dbHandleOptions.dbWriteBufferSize));
+	NAPI_STATUS_THROWS(rocksdb_js::getProperty(env, options, "maxWriteBufferSizeToMaintain", dbHandleOptions.maxWriteBufferSizeToMaintain));
 	NAPI_STATUS_THROWS(rocksdb_js::getProperty(env, options, "transactionLogMaxAgeThreshold", dbHandleOptions.transactionLogMaxAgeThreshold));
 	NAPI_STATUS_THROWS(rocksdb_js::getProperty(env, options, "transactionLogMaxSize", dbHandleOptions.transactionLogMaxSize));
 	NAPI_STATUS_THROWS(rocksdb_js::getProperty(env, options, "transactionLogRetentionMs", dbHandleOptions.transactionLogRetentionMs));

--- a/src/binding/db_descriptor.cpp
+++ b/src/binding/db_descriptor.cpp
@@ -667,7 +667,7 @@ std::shared_ptr<DBDescriptor> DBDescriptor::open(const std::string& path, const 
 	dbOptions.comparator = rocksdb::BytewiseComparator();
 	dbOptions.create_if_missing = !options.readOnly;
 	dbOptions.create_missing_column_families = !options.readOnly;
-	dbOptions.db_write_buffer_size = 32 << 20; // 32MB total database write buffer size (may want to make this configurable)
+	dbOptions.db_write_buffer_size = static_cast<size_t>(options.dbWriteBufferSize);
 	dbOptions.IncreaseParallelism(options.parallelismThreads);
 	dbOptions.keep_log_file_num = 5; // these are informational log files that clutter up the database directory
 	dbOptions.persist_user_defined_timestamps = true;
@@ -683,6 +683,9 @@ std::shared_ptr<DBDescriptor> DBDescriptor::open(const std::string& path, const 
 	cfOptions.enable_blob_files = true;
 	cfOptions.min_blob_size = 2048;
 	cfOptions.enable_blob_garbage_collection = true;
+	cfOptions.write_buffer_size = static_cast<size_t>(options.writeBufferSize);
+	cfOptions.max_write_buffer_number = options.maxWriteBufferNumber;
+	cfOptions.max_write_buffer_size_to_maintain = options.maxWriteBufferSizeToMaintain;
 	cfOptions.table_factory.reset(rocksdb::NewBlockBasedTableFactory(tableOptions));
 
 	// create a shared pointer to hold the weak descriptor reference for the event listener

--- a/src/binding/db_options.h
+++ b/src/binding/db_options.h
@@ -1,6 +1,7 @@
 #ifndef __DB_OPTIONS_H__
 #define __DB_OPTIONS_H__
 
+#include <cstdint>
 #include <string>
 #include <thread>
 
@@ -19,8 +20,23 @@ enum class DBMode {
  * values passed in from public `open()` method.
  */
 struct DBOptions final {
+	// Global memtable size trigger across all column families. When the sum of
+	// all memtables reaches this size, the largest memtable is flushed. With
+	// `atomic_flush = true`, this triggers flushes across every CF. 0 disables
+	// the global trigger so per-CF `writeBufferSize` drives flushing.
+	uint64_t dbWriteBufferSize = 0;
 	bool disableWAL = false;
 	bool enableStats = false;
+	// Maximum number of memtables that can be queued per column family before
+	// writes stall. Higher values absorb write bursts while flushes catch up,
+	// at the cost of memory (roughly `maxWriteBufferNumber * writeBufferSize`
+	// per CF).
+	int32_t maxWriteBufferNumber = 16;
+	// Bytes of recent memtable history to retain in memory for transaction
+	// conflict checking. -1 derives the value from
+	// `maxWriteBufferNumber * writeBufferSize` (the RocksDB-recommended default
+	// for OptimisticTransactionDB).
+	int64_t maxWriteBufferSizeToMaintain = -1;
 	DBMode mode = DBMode::Optimistic;
 	std::string name;
 	bool noBlockCache = false;
@@ -31,6 +47,10 @@ struct DBOptions final {
 	uint32_t transactionLogMaxSize = 16 * 1024 * 1024; // 16MB
 	uint32_t transactionLogRetentionMs = 3 * 24 * 60 * 60 * 1000; // 3 days
 	std::string transactionLogsPath;
+	// Per-CF memtable size at which the memtable is sealed and flushed. Smaller
+	// values produce more frequent, faster flushes; larger values batch more
+	// writes per SST file.
+	uint64_t writeBufferSize = 16ULL * 1024 * 1024; // 16MB
 };
 
 } // namespace rocksdb_js

--- a/src/load-binding.ts
+++ b/src/load-binding.ts
@@ -106,8 +106,11 @@ export declare class NativeIteratorCls {
 export type NativeDatabaseMode = 'optimistic' | 'pessimistic';
 
 export type NativeDatabaseOptions = {
+	dbWriteBufferSize?: number;
 	disableWAL?: boolean;
 	enableStats?: boolean;
+	maxWriteBufferNumber?: number;
+	maxWriteBufferSizeToMaintain?: number;
 	mode?: NativeDatabaseMode;
 	name?: string;
 	noBlockCache?: boolean;
@@ -118,6 +121,7 @@ export type NativeDatabaseOptions = {
 	transactionLogMaxSize?: number;
 	transactionLogRetentionMs?: number;
 	transactionLogsPath?: string;
+	writeBufferSize?: number;
 };
 
 type ResolveCallback<T> = (value: T) => void;

--- a/src/store.ts
+++ b/src/store.ts
@@ -201,6 +201,27 @@ export class Store {
 	maxKeySize: number;
 
 	/**
+	 * The maximum number of memtables that can be queued per column family
+	 * before writes stall. Higher values absorb write bursts while flushes catch
+	 * up, at the cost of memory.
+	 */
+	maxWriteBufferNumber?: number;
+
+	/**
+	 * The bytes of recent memtable history to retain in memory for transaction
+	 * conflict checking. `-1` derives the value from
+	 * `maxWriteBufferNumber * writeBufferSize`.
+	 */
+	maxWriteBufferSizeToMaintain?: number;
+
+	/**
+	 * The total memtable budget in bytes across all column families. When the
+	 * sum of memtables reaches this size, RocksDB flushes the largest one. `0`
+	 * disables the global trigger so per-CF `writeBufferSize` drives flushing.
+	 */
+	dbWriteBufferSize?: number;
+
+	/**
 	 * The name of the store (e.g. the column family). Defaults to `'default'`.
 	 */
 	name: string;
@@ -212,9 +233,10 @@ export class Store {
 
 	/**
 	 * The number of threads to use for parallel operations. This is a RocksDB
-	 * option.
+	 * option. When undefined, the native layer picks
+	 * `max(1, hardware_concurrency() / 2)`.
 	 */
-	parallelismThreads: number;
+	parallelismThreads?: number;
 
 	/**
 	 * The path to the database.
@@ -282,6 +304,12 @@ export class Store {
 	transactionLogsPath?: string;
 
 	/**
+	 * The per-column-family memtable size in bytes at which the memtable is
+	 * sealed and flushed.
+	 */
+	writeBufferSize?: number;
+
+	/**
 	 * The function used to encode keys using the shared `keyBuffer`.
 	 */
 	writeKey: WriteKeyFunction;
@@ -307,6 +335,7 @@ export class Store {
 		);
 
 		this.db = new NativeDatabase();
+		this.dbWriteBufferSize = options?.dbWriteBufferSize;
 		this.decoder = options?.decoder ?? null;
 		this.disableWAL = options?.disableWAL ?? false;
 		this.enableStats = options?.enableStats ?? false;
@@ -317,9 +346,11 @@ export class Store {
 		this.keyBuffer = KEY_BUFFER;
 		this.keyEncoding = keyEncoding;
 		this.maxKeySize = options?.maxKeySize ?? MAX_KEY_SIZE;
+		this.maxWriteBufferNumber = options?.maxWriteBufferNumber;
+		this.maxWriteBufferSizeToMaintain = options?.maxWriteBufferSizeToMaintain;
 		this.name = options?.name ?? 'default';
 		this.noBlockCache = options?.noBlockCache;
-		this.parallelismThreads = options?.parallelismThreads ?? 1;
+		this.parallelismThreads = options?.parallelismThreads;
 		this.path = path;
 		this.pessimistic = options?.pessimistic ?? false;
 		this.readOnly = options?.readOnly ?? false;
@@ -331,6 +362,7 @@ export class Store {
 		this.transactionLogMaxSize = options?.transactionLogMaxSize;
 		this.transactionLogRetention = options?.transactionLogRetention;
 		this.transactionLogsPath = options?.transactionLogsPath;
+		this.writeBufferSize = options?.writeBufferSize;
 		this.writeKey = writeKey;
 	}
 
@@ -746,8 +778,11 @@ export class Store {
 		}
 
 		this.db.open(this.path, {
+			dbWriteBufferSize: this.dbWriteBufferSize,
 			disableWAL: this.disableWAL,
 			enableStats: this.enableStats,
+			maxWriteBufferNumber: this.maxWriteBufferNumber,
+			maxWriteBufferSizeToMaintain: this.maxWriteBufferSizeToMaintain,
 			mode: this.pessimistic ? 'pessimistic' : 'optimistic',
 			name: this.name,
 			noBlockCache: this.noBlockCache,
@@ -760,6 +795,7 @@ export class Store {
 				? parseDuration(this.transactionLogRetention)
 				: undefined,
 			transactionLogsPath: this.transactionLogsPath,
+			writeBufferSize: this.writeBufferSize,
 		});
 
 		return false;

--- a/test/db-options.test.ts
+++ b/test/db-options.test.ts
@@ -1,0 +1,57 @@
+import { dbRunner } from './lib/util.js';
+import { describe, expect, it } from 'vitest';
+
+describe('Database write buffer options', () => {
+	it('should open with default write buffer settings', () =>
+		dbRunner(async ({ db }) => {
+			await db.put('foo', 'bar');
+			expect(await db.get('foo')).toBe('bar');
+		}));
+
+	it('should open with custom writeBufferSize and maxWriteBufferNumber', () =>
+		dbRunner(
+			{
+				dbOptions: [
+					{
+						maxWriteBufferNumber: 8,
+						writeBufferSize: 4 * 1024 * 1024,
+					},
+				],
+			},
+			async ({ db }) => {
+				await db.put('foo', 'bar');
+				expect(await db.get('foo')).toBe('bar');
+			}
+		));
+
+	it('should open with dbWriteBufferSize set', () =>
+		dbRunner({ dbOptions: [{ dbWriteBufferSize: 64 * 1024 * 1024 }] }, async ({ db }) => {
+			await db.put('foo', 'bar');
+			expect(await db.get('foo')).toBe('bar');
+		}));
+
+	it('should open with maxWriteBufferSizeToMaintain set', () =>
+		dbRunner(
+			{ dbOptions: [{ maxWriteBufferSizeToMaintain: 128 * 1024 * 1024 }] },
+			async ({ db }) => {
+				await db.put('foo', 'bar');
+				expect(await db.get('foo')).toBe('bar');
+			}
+		));
+
+	it('should flush memtables when writeBufferSize is exceeded', () =>
+		dbRunner({ dbOptions: [{ writeBufferSize: 64 * 1024 }] }, async ({ db }) => {
+			// 64KB memtable; write enough data to force at least one flush.
+			// `num-files-at-level0` can be racy under background compaction, so
+			// check on-disk SST size instead — once any flush has happened it is
+			// non-zero regardless of which level the data settled on.
+			const value = 'x'.repeat(1024);
+			for (let i = 0; i < 256; i++) {
+				await db.put(`key-${i.toString().padStart(6, '0')}`, value);
+			}
+			await db.flush();
+			const sstSize = db.getDBIntProperty('rocksdb.total-sst-files-size');
+			expect(sstSize).toBeDefined();
+			expect(sstSize!).toBeGreaterThan(0);
+		}));
+});


### PR DESCRIPTION
Backport of https://github.com/HarperFast/rocksdb-js/pull/575

The hardcoded `dbOptions.db_write_buffer_size = 32 << 20` in `db_descriptor.cpp`, combined with `atomic_flush = true` and no explicit `max_write_buffer_size_to_maintain`, caused OptimisticTransactionDB conflict-check failures under burst load: memtables flushed before enough write history was retained for snapshot-based conflict detection, producing repeated "Transaction could not check for conflicts ... MemTable only contains changes newer than SequenceNumber" errors and cascading transaction retries.

This change:

* Exposes `writeBufferSize`, `maxWriteBufferNumber`, `dbWriteBufferSize`, and `maxWriteBufferSizeToMaintain` as DB open options through both the TS API and the native binding.
* Retunes defaults toward "flush fast, queue deep":
  - `writeBufferSize`: 16MB (RocksDB default was 64MB) — smaller memtables flush sooner.
  - `maxWriteBufferNumber`: 16 (RocksDB default was 2) — deep memtable queue absorbs write bursts without stalling.
  - `dbWriteBufferSize`: 0, i.e. no global cap (was a hardcoded 32MB) — per-CF settings drive flushing; the global cap was the root cause of the conflict-check failures with `atomic_flush = true`.
  - `maxWriteBufferSizeToMaintain`: -1, which makes RocksDB use the `max_write_buffer_number * write_buffer_size` formula (256MB with the new defaults) explicitly rather than relying on the OptimisticTransactionDB auto-default.
* Drops `parallelismThreads ?? 1` in the TS layer so the native default of `max(1, hardware_concurrency() / 2)` actually applies; the previous default starved background flush/compaction on multi-core hosts.

Memory implication: with N column families the worst-case memtable ceiling is roughly `N * maxWriteBufferNumber * writeBufferSize` (≈256MB per CF). Users with many column families on memory-constrained hosts should set `dbWriteBufferSize` explicitly to cap it.