### PR TITLE
fix: treat dropped column family as empty in clear()

### DIFF
--- a/src/binding/database/db_handle.cpp
+++ b/src/binding/database/db_handle.cpp
@@ -35,6 +35,12 @@ rocksdb::Status DBHandle::clear() {
 		nullptr
 	);
 	if (!status.ok()) {
+		// A dropped column family is effectively already empty — clear is a no-op.
+		// Callers that subsequently write to the same handle will receive
+		// kColumnFamilyDropped at write time and can handle recovery there.
+		if (status.IsColumnFamilyDropped()) {
+			return rocksdb::Status::OK();
+		}
 		return status;
 	}
 	// it appears we do not need to call WaitForCompact for this to work

--- a/test/clear.test.ts
+++ b/test/clear.test.ts
@@ -43,6 +43,13 @@ describe('Clear', () => {
 			10_000
 		);
 
+		it('should succeed when column family has been dropped', () =>
+			dbRunner({ dbOptions: [{ name: 'test' }] }, async ({ db }) => {
+				db.putSync('key', 'value');
+				db.dropSync();
+				await expect(db.clear()).resolves.toBeUndefined();
+			}));
+
 		it('should only remove entries in one column family', () =>
 			dbRunner({ dbOptions: [{}, { name: 'second' }] }, async ({ db }, { db: db2 }) => {
 				for (let i = 0; i < 10; i++) {


### PR DESCRIPTION
## Summary

- `DBHandle::clear()` now returns `OK` when `compactRange` reports `kColumnFamilyDropped` rather than propagating the error
- A dropped CF is already empty, so `clear()` is a no-op in this case

## Context

When a concurrent `drop_table` races with `clear()` (e.g. `runIndexing` clearing an index CF just as the table is dropped), RocksDB returns `kColumnFamilyDropped` from `compactRange`. Before this fix, that error surfaced to JavaScript callers as `ERR_COLUMN_FAMILY_DROPPED`, which forced them into an unnecessary error state. Subsequent writes to the same handle will still receive the error at write time and can handle recovery there.

Closes #598

> Generated by Claude Sonnet 4.6