### PR TITLE
Improve CLI transaction log viewing and error checking

### DIFF
--- a/bin/rocksdb-js.mjs
+++ b/bin/rocksdb-js.mjs
@@ -382,7 +382,7 @@ async function logCommand(args) {
 			if (!logFile.endsWith('.txnlog')) continue;
 			console.log(hl(logFile));
 
-			const log = parseTransactionLog(join(logPath, logFile));
+			const log = parseTransactionLog(join(logPath, logFile), { skipData: true });
 			const ts =
 				Number.isFinite(log.timestamp) && log.timestamp > 0
 					? new Date(log.timestamp).toISOString()

--- a/bin/rocksdb-js.mjs
+++ b/bin/rocksdb-js.mjs
@@ -2,7 +2,7 @@
 
 import { RocksDatabase, parseTransactionLog, versions } from '../dist/index.mjs';
 import { existsSync, readdirSync } from 'node:fs';
-import { mkdir, readdir } from 'node:fs/promises';
+import { mkdir, readdir, stat } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
 import { stdin, stdout } from 'node:process';
 import { createInterface } from 'node:readline/promises';
@@ -19,6 +19,7 @@ const COMMANDS = {
 	get: getCommand,
 	help: helpCommand,
 	log: logCommand,
+	logs: logCommand, // alias for log
 	prop: propCommand,
 	'purge-logs': purgeLogsCommand,
 	put: putCommand,
@@ -66,12 +67,12 @@ function completer(line) {
 		return [hits.length ? hits : columns, arg];
 	}
 
-	if (command === 'log' && currentDB) {
+	if ((command === 'log' || command === 'logs') && currentDB) {
 		if (parts.length === 2) {
 			const arg = parts[1];
 			const logs = currentDB.listLogs();
 			const hits = logs.filter((l) => l.startsWith(arg));
-			return [hits.length ? hits : logs, arg];
+			return [(hits.length ? hits : logs).map((s) => `${s} `), arg];
 		} else if (parts.length === 3) {
 			const [name, store] = parts.slice(1);
 			const logs = currentDB.listLogs();
@@ -81,7 +82,7 @@ function completer(line) {
 				const logFiles = readdirSync(logPath).filter(
 					(f) => (!store || f.startsWith(store)) && f.endsWith('.txnlog')
 				);
-				return [logFiles.length ? logFiles : [], store, name];
+				return [logFiles.length ? logFiles.map((f) => `${f} `) : [], store, name];
 			}
 			return [[], store, name];
 		}
@@ -147,6 +148,34 @@ function wrapColumns(columns) {
 	}
 	if (line) lines.push(line);
 	return prefix + lines.join('\n' + indent);
+}
+
+function formatHexDump(data) {
+	const bytesPerRow = 16;
+	const lines = [];
+	for (let offset = 0; offset < data.length; offset += bytesPerRow) {
+		const chunk = data.subarray(offset, offset + bytesPerRow);
+		const hexParts = [];
+		for (let i = 0; i < bytesPerRow; i++) {
+			if (i === 8) hexParts.push('');
+			hexParts.push(i < chunk.length ? chunk[i].toString(16).padStart(2, '0') : '  ');
+		}
+		let ascii = '';
+		for (const byte of chunk) {
+			ascii += byte >= 0x20 && byte <= 0x7e ? String.fromCharCode(byte) : '.';
+		}
+		lines.push(
+			`${note(offset.toString(16).padStart(8, '0'))}  ${hl(hexParts.join(' '))}  ${note('|')}${hl(ascii)}${note('|')}`
+		);
+	}
+	return lines.join('\n');
+}
+
+function formatBytes(bytes) {
+	if (bytes < 1024) return `${bytes} B`;
+	if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(2)} KB`;
+	if (bytes < 1024 * 1024 * 1024) return `${(bytes / 1024 / 1024).toFixed(2)} MB`;
+	return `${(bytes / 1024 / 1024 / 1024).toFixed(2)} GB`;
 }
 
 async function run(fn) {
@@ -320,40 +349,72 @@ async function logCommand(args) {
 				}
 				const { data } = log.entries[entry - 1];
 				console.log(`Entry ${entry} (${data.length.toLocaleString()} bytes)\n`);
-				console.log(
-					hl(
-						data
-							.toString('hex')
-							.match(/.{1,2}/g)
-							.join(' ')
-					)
-				);
+				console.log(formatHexDump(data));
 				console.log();
 				return;
 			}
 
-			console.log(`Size      = ${hl(`${log.size.toLocaleString()} bytes`)}`);
-			console.log(`Version   = ${hl(log.version)}`);
-			console.log(`Timestamp = ${hl(new Date(log.timestamp).toISOString())}`);
-			console.log(`Entries   = ${hl(log.entries.length)}`);
+			for (const anomaly of log.anomalies) {
+				console.log(bad(`!  ${anomaly}`));
+			}
 			let i = 1;
 			for (const entry of log.entries) {
+				const ts =
+					Number.isFinite(entry.timestamp) && entry.timestamp > 0
+						? new Date(entry.timestamp).toISOString()
+						: String(entry.timestamp);
 				console.log(
-					`${String(i++).padStart(3)})  ${hl(new Date(entry.timestamp).toISOString())}  ${entry.length.toLocaleString()} bytes  ${entry.flags & 0x01 ? '' : note('(continued in next file)')}`
+					`${String(i++).padStart(3)})  ${hl(ts)}  ${entry.length.toLocaleString()} bytes  ${entry.flags & 0x01 ? note('(end of transaction)') : ''}`
 				);
+				if (entry.anomalies) {
+					for (const anomaly of entry.anomalies) {
+						console.log(`     ${bad(`! ${anomaly}`)}`);
+					}
+				}
 			}
 			console.log();
 			return;
 		}
+
 		const logPath = join(currentDB.path, 'transaction_logs', name);
 		const logFiles = await readdir(logPath);
 		for (const logFile of logFiles) {
 			if (!logFile.endsWith('.txnlog')) continue;
 			console.log(hl(logFile));
+
+			const log = parseTransactionLog(join(logPath, logFile));
+			const ts =
+				Number.isFinite(log.timestamp) && log.timestamp > 0
+					? new Date(log.timestamp).toISOString()
+					: String(log.timestamp);
+			console.log(`  Size      = ${hl(`${log.size.toLocaleString()} bytes`)}`);
+			console.log(`  Version   = ${hl(log.version)}`);
+			console.log(`  Timestamp = ${hl(ts)}`);
+			console.log(`  Entries   = ${hl(log.entries.length)}`);
+			const totalAnomalies = log.anomalies.length + log.entryAnomalyCount;
+			if (totalAnomalies > 0) {
+				console.log(`  Anomalies = ${bad(totalAnomalies)}`);
+				for (const anomaly of log.anomalies) {
+					console.log(`    ${bad(`! ${anomaly}`)}`);
+				}
+				if (log.entryAnomalyCount > 0) {
+					console.log(
+						`    ${bad(`! ${log.entryAnomalyCount} entr${log.entryAnomalyCount === 1 ? 'y has' : 'ies have'} anomalies (run "log ${name} ${logFile}" for details)`)}`
+					);
+				}
+			}
 		}
 	} else if (logs.length > 0) {
-		for (const log of logs) {
-			console.log(hl(log));
+		for (const name of logs) {
+			const files = (await readdir(join(currentDB.path, 'transaction_logs', name))).filter((f) =>
+				f.endsWith('.txnlog')
+			);
+			const maxlen = files.reduce((max, file) => Math.max(max, file.length), 0);
+			console.log(hl(name));
+			for (const file of files) {
+				const { size } = await stat(join(currentDB.path, 'transaction_logs', name, file));
+				console.log(`  ${file.padEnd(maxlen)} ${note(`(${formatBytes(size)})`)}`);
+			}
 		}
 	} else {
 		console.log('No log stores found');
@@ -533,6 +594,7 @@ async function main() {
 			const command = line[0];
 			if (!command) continue;
 			const commandFn = COMMANDS[command];
+			console.log();
 			if (commandFn) {
 				try {
 					await commandFn(line.slice(1));

--- a/src/parse-transaction-log.ts
+++ b/src/parse-transaction-log.ts
@@ -5,7 +5,7 @@ const { TRANSACTION_LOG_TOKEN } = constants;
 
 // Transaction log files did not exist before this date, so any timestamp that
 // predates it indicates corruption.
-const MIN_VALID_TIMESTAMP = Date.UTC(2017, 2, 1); // 2017-03-01
+const MIN_VALID_TIMESTAMP = Date.UTC(2026, 0, 27); // 2026-01-27
 
 // Currently only bit 0 (TRANSACTION_LOG_ENTRY_LAST_FLAG) is defined.
 const VALID_FLAGS_MASK = 0x01;
@@ -80,7 +80,7 @@ export function parseTransactionLog(path: string): TransactionLog {
 		const timestamp = read(8).readDoubleBE(0);
 		const anomalies: string[] = [];
 		if (!Number.isFinite(timestamp) || timestamp < MIN_VALID_TIMESTAMP) {
-			anomalies.push(`Header timestamp ${timestamp} predates 2017-03-01 (possible corruption)`);
+			anomalies.push(`Header timestamp ${timestamp} predates 2026-01-27 (possible corruption)`);
 		}
 
 		// read the entries
@@ -100,7 +100,7 @@ export function parseTransactionLog(path: string): TransactionLog {
 
 			const entryAnomalies: string[] = [];
 			if (!Number.isFinite(timestamp) || timestamp < MIN_VALID_TIMESTAMP) {
-				entryAnomalies.push(`timestamp ${timestamp} predates 2017-03-01 (possible corruption)`);
+				entryAnomalies.push(`timestamp ${timestamp} predates 2026-01-27 (possible corruption)`);
 			}
 			if ((flags & ~VALID_FLAGS_MASK) !== 0) {
 				entryAnomalies.push(

--- a/src/parse-transaction-log.ts
+++ b/src/parse-transaction-log.ts
@@ -3,7 +3,15 @@ import { closeSync, openSync, readSync, type Stats, statSync } from 'node:fs';
 
 const { TRANSACTION_LOG_TOKEN } = constants;
 
+// Transaction log files did not exist before this date, so any timestamp that
+// predates it indicates corruption.
+const MIN_VALID_TIMESTAMP = Date.UTC(2017, 2, 1); // 2017-03-01
+
+// Currently only bit 0 (TRANSACTION_LOG_ENTRY_LAST_FLAG) is defined.
+const VALID_FLAGS_MASK = 0x01;
+
 interface LogEntry {
+	anomalies?: string[];
 	data: Buffer;
 	flags: number;
 	length: number;
@@ -11,7 +19,9 @@ interface LogEntry {
 }
 
 interface TransactionLog {
+	anomalies: string[];
 	entries: LogEntry[];
+	entryAnomalyCount: number;
 	timestamp: number;
 	size: number;
 	version: number;
@@ -68,9 +78,14 @@ export function parseTransactionLog(path: string): TransactionLog {
 		}
 
 		const timestamp = read(8).readDoubleBE(0);
+		const anomalies: string[] = [];
+		if (!Number.isFinite(timestamp) || timestamp < MIN_VALID_TIMESTAMP) {
+			anomalies.push(`Header timestamp ${timestamp} predates 2017-03-01 (possible corruption)`);
+		}
 
 		// read the entries
 		const entries: LogEntry[] = [];
+		let entryAnomalyCount = 0;
 
 		while (fileOffset < size) {
 			const timestamp = read(8).readDoubleBE(0);
@@ -82,10 +97,25 @@ export function parseTransactionLog(path: string): TransactionLog {
 			const length = read(4).readUInt32BE(0);
 			const flags = read(1).readUInt8(0);
 			const data = read(length);
-			entries.push({ timestamp, length, flags, data });
+
+			const entryAnomalies: string[] = [];
+			if (!Number.isFinite(timestamp) || timestamp < MIN_VALID_TIMESTAMP) {
+				entryAnomalies.push(`timestamp ${timestamp} predates 2017-03-01 (possible corruption)`);
+			}
+			if ((flags & ~VALID_FLAGS_MASK) !== 0) {
+				entryAnomalies.push(
+					`flags 0x${flags.toString(16).padStart(2, '0')} contains undefined bits (expected 0x00 or 0x01)`
+				);
+			}
+			const entry: LogEntry = { timestamp, length, flags, data };
+			if (entryAnomalies.length > 0) {
+				entry.anomalies = entryAnomalies;
+				entryAnomalyCount += entryAnomalies.length;
+			}
+			entries.push(entry);
 		}
 
-		return { entries, timestamp, size, version };
+		return { anomalies, entries, entryAnomalyCount, timestamp, size, version };
 	} catch (error) {
 		if (error instanceof Error) {
 			error.message = `Invalid transaction log file: ${error.message}`;

--- a/src/parse-transaction-log.ts
+++ b/src/parse-transaction-log.ts
@@ -12,7 +12,7 @@ const VALID_FLAGS_MASK = 0x01;
 
 interface LogEntry {
 	anomalies?: string[];
-	data: Buffer;
+	data?: Buffer;
 	flags: number;
 	length: number;
 	timestamp?: number;
@@ -32,7 +32,10 @@ interface TransactionLog {
  * @param path - The path to the transaction log file.
  * @returns The transaction log.
  */
-export function parseTransactionLog(path: string): TransactionLog {
+export function parseTransactionLog(
+	path: string,
+	options: { skipData?: boolean } = {}
+): TransactionLog {
 	let stats: Stats;
 	try {
 		stats = statSync(path);
@@ -107,7 +110,12 @@ export function parseTransactionLog(path: string): TransactionLog {
 					`flags 0x${flags.toString(16).padStart(2, '0')} contains undefined bits (expected 0x00 or 0x01)`
 				);
 			}
-			const entry: LogEntry = { timestamp, length, flags, data };
+			const entry: LogEntry = {
+				timestamp,
+				length,
+				flags,
+				data: options.skipData ? undefined : Buffer.from(data),
+			};
 			if (entryAnomalies.length > 0) {
 				entry.anomalies = entryAnomalies;
 				entryAnomalyCount += entryAnomalies.length;


### PR DESCRIPTION
Added a `logs` alias for the `log` command because I can never remember if its `log` or `logs`.

Viewing a transaction log entry looks like a hexdump:

<img width="651" height="186" alt="image" src="https://github.com/user-attachments/assets/be6d8dfa-0e90-43f5-a0d0-95f200cb1fc0" />

Added crude transaction log error checker to `parseTransactionLog()`. It alerts if the entry timestamp is older than Jan 27, 2026 (rocksdb-js@0.1.0 release date) or if the entry flags are not `0x00` or `0x01`.

