### PR TITLE
Backport fix/publish target branch

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -160,8 +160,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
-          ref: main
-          fetch-depth: 0
+          ref: ${{ github.event.release.target_commitish }}
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
@@ -216,7 +215,7 @@ jobs:
           set -o pipefail
           git add package.json
           git commit -m "v${{ needs.preflight.outputs.version }}"
-          git push origin main
+          git push origin HEAD:${{ github.event.release.target_commitish }}
 
       - name: Get package.json info
         id: get-package-info
@@ -260,7 +259,7 @@ jobs:
         run: |
           git add pnpm-lock.yaml
           git commit -m "chore(package): update pnpm-lock.yaml after publishing ${{ needs.preflight.outputs.version }}"
-          git push origin main
+          git push origin HEAD:${{ github.event.release.target_commitish }}
 
   on-publish-success:
     if: success() && !cancelled()


### PR DESCRIPTION
Publish the selected release branch instead of always publishing from `main`.

Backport of https://github.com/HarperFast/rocksdb-js/pull/603