### PR TITLE
Ignore `.antigravitycli` dot folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 !/deps/gtest.gyp
 /dist
 node_modules
+.antigravitycli
 .clangd
 .claude
 .DS_Store


### PR DESCRIPTION
We love our `.antigravitycli` folder, just not in our repo.