### PR TITLE
Harden transaction-log readers against corrupt entry lengths

### DIFF
--- a/src/parse-transaction-log.ts
+++ b/src/parse-transaction-log.ts
@@ -1,7 +1,7 @@
 import { constants } from './load-binding.js';
 import { closeSync, openSync, readSync, type Stats, statSync } from 'node:fs';
 
-const { TRANSACTION_LOG_TOKEN } = constants;
+const { TRANSACTION_LOG_TOKEN, TRANSACTION_LOG_ENTRY_HEADER_SIZE } = constants;
 
 interface LogEntry {
 	data: Buffer;
@@ -46,10 +46,13 @@ export function parseTransactionLog(path: string): TransactionLog {
 		const bytesRead = readSync(fileHandle, buffer, 0, numBytes, fileOffset);
 		fileOffset += bytesRead;
 		if (bytesRead !== numBytes) {
+			// Only hex-dump the bytes actually read, capped at 64. A corrupt length
+			// can request a huge read; dumping the whole (largely uninitialized)
+			// buffer can exceed V8's max string length and mask the real error.
+			const previewBytes = Math.min(bytesRead, 64);
+			const preview = buffer.subarray(0, previewBytes).toString('hex');
 			throw new Error(
-				`Expected to read ${numBytes} bytes but only read ${bytesRead}, file offset: ${fileOffset}, file size: ${size}, file path: ${path}, buffer: ${buffer.toString(
-					'hex'
-				)}`
+				`Expected to read ${numBytes} bytes but only read ${bytesRead}, file offset: ${fileOffset}, file size: ${size}, file path: ${path}, buffer (first ${previewBytes} bytes): ${preview}`
 			);
 		}
 		return buffer;
@@ -81,6 +84,18 @@ export function parseTransactionLog(path: string): TransactionLog {
 			}
 			const length = read(4).readUInt32BE(0);
 			const flags = read(1).readUInt8(0);
+			// Validate the declared length against the bytes actually remaining
+			// before allocating. A torn/corrupt entry can claim a length far larger
+			// than the file (e.g. a partial write that left header bytes pointing
+			// past the data), which would otherwise drive an unbounded allocUnsafe
+			// and OOM the process during log replay.
+			const remaining = size - fileOffset;
+			if (length > remaining) {
+				const entryOffset = fileOffset - TRANSACTION_LOG_ENTRY_HEADER_SIZE;
+				throw new Error(
+					`Corrupt entry at offset ${entryOffset}: declared length ${length} exceeds ${remaining} bytes remaining (file size: ${size})`
+				);
+			}
 			const data = read(length);
 			entries.push({ timestamp, length, flags, data });
 		}

--- a/src/parse-transaction-log.ts
+++ b/src/parse-transaction-log.ts
@@ -52,7 +52,7 @@ export function parseTransactionLog(path: string): TransactionLog {
 			const previewBytes = Math.min(bytesRead, 64);
 			const preview = buffer.subarray(0, previewBytes).toString('hex');
 			throw new Error(
-				`Expected to read ${numBytes} bytes but only read ${bytesRead}, file offset: ${fileOffset}, file size: ${size}, file path: ${path}, buffer (first ${previewBytes} bytes): ${preview}`
+				`Expected to read ${numBytes} bytes but only read ${bytesRead}, file offset: ${fileOffset.toString(16)}, file size: ${size}, file path: ${path}, buffer (first ${previewBytes} bytes): ${preview}`
 			);
 		}
 		return buffer;
@@ -93,7 +93,7 @@ export function parseTransactionLog(path: string): TransactionLog {
 			if (length > remaining) {
 				const entryOffset = fileOffset - TRANSACTION_LOG_ENTRY_HEADER_SIZE;
 				throw new Error(
-					`Corrupt entry at offset ${entryOffset}: declared length ${length} exceeds ${remaining} bytes remaining (file size: ${size})`
+					`Corrupt entry at offset ${entryOffset.toString(16)}: declared length ${length} exceeds ${remaining} bytes remaining (file size: ${size})`
 				);
 			}
 			const data = read(length);

--- a/src/transaction-log-reader.ts
+++ b/src/transaction-log-reader.ts
@@ -161,7 +161,7 @@ Object.defineProperty(TransactionLog.prototype, 'query', {
 					try {
 						timestamp = dataView.getFloat64(position);
 					} catch (error) {
-						(error as Error).message += ` at position ${position} of log ${
+						(error as Error).message += ` at position ${position.toString(16)} of log ${
 							logBuffer!.logId
 						} (size=${size}, log buffer length=${logBuffer!.length})`;
 						throw error;
@@ -181,7 +181,7 @@ Object.defineProperty(TransactionLog.prototype, 'query', {
 					const limit = readUncommitted ? logBuffer!.length : size;
 					if (position + TRANSACTION_LOG_ENTRY_HEADER_SIZE > limit) {
 						throw new RangeError(
-							`Corrupt transaction log: truncated entry header at position ${position} of log ${
+							`Corrupt transaction log: truncated entry header at position ${position.toString(16)} of log ${
 								logBuffer!.logId
 							} (available=${limit - position})`
 						);
@@ -189,7 +189,7 @@ Object.defineProperty(TransactionLog.prototype, 'query', {
 					const length = dataView.getUint32(position + 8);
 					if (position + TRANSACTION_LOG_ENTRY_HEADER_SIZE + length > limit) {
 						throw new RangeError(
-							`Corrupt transaction log entry at position ${position} of log ${
+							`Corrupt transaction log entry at position ${position.toString(16)} of log ${
 								logBuffer!.logId
 							}: declared length ${length} overruns the log (limit=${limit})`
 						);

--- a/src/transaction-log-reader.ts
+++ b/src/transaction-log-reader.ts
@@ -171,7 +171,29 @@ Object.defineProperty(TransactionLog.prototype, 'query', {
 						return { done: true, value: undefined };
 					}
 
+					// Corruption bound: a committed read can't legitimately extend past
+					// the committed `size` (a true entry boundary); an uncommitted read is
+					// bounded only by the physically mapped buffer. A torn/corrupt entry
+					// can declare a length far past this bound — without the checks below,
+					// `position` runs past the buffer, `subarray` hands back a misframed
+					// (garbage) transaction, and the advance-to-next-log path can
+					// dereference an undefined buffer. Fail loudly with a bounded error.
+					const limit = readUncommitted ? logBuffer!.length : size;
+					if (position + TRANSACTION_LOG_ENTRY_HEADER_SIZE > limit) {
+						throw new RangeError(
+							`Corrupt transaction log: truncated entry header at position ${position} of log ${
+								logBuffer!.logId
+							} (available=${limit - position})`
+						);
+					}
 					const length = dataView.getUint32(position + 8);
+					if (position + TRANSACTION_LOG_ENTRY_HEADER_SIZE + length > limit) {
+						throw new RangeError(
+							`Corrupt transaction log entry at position ${position} of log ${
+								logBuffer!.logId
+							}: declared length ${length} overruns the log (limit=${limit})`
+						);
+					}
 					position += TRANSACTION_LOG_ENTRY_HEADER_SIZE;
 					let matchesRange: boolean;
 					if (foundExactStart) {
@@ -212,13 +234,20 @@ Object.defineProperty(TransactionLog.prototype, 'query', {
 						);
 						size = latestSize;
 						if (latestLogId > logBuffer!.logId) {
-							logBuffer = getLogMemoryMap(transactionLog, logBuffer!.logId + 1)!;
-							dataView = logBuffer!.dataView;
-							size = logBuffer!.size;
+							const nextLogBuffer = getLogMemoryMap(transactionLog, logBuffer!.logId + 1);
+							if (!nextLogBuffer) {
+								// the next log file can't be mapped (purged, mid-rotation,
+								// 0-byte at mmap time, FS race); stop cleanly rather than
+								// dereferencing an undefined buffer
+								return { done: true, value: undefined };
+							}
+							logBuffer = nextLogBuffer;
+							dataView = logBuffer.dataView;
+							size = logBuffer.size;
 							if (size == undefined) {
-								size = transactionLog.getLogFileSize(logBuffer!.logId);
+								size = transactionLog.getLogFileSize(logBuffer.logId);
 								if (!readUncommitted) {
-									logBuffer!.size = size;
+									logBuffer.size = size;
 								}
 							}
 							position = TRANSACTION_LOG_FILE_HEADER_SIZE;

--- a/test/transaction-log.test.ts
+++ b/test/transaction-log.test.ts
@@ -1340,6 +1340,102 @@ describe('Transaction Log', () => {
 			}));
 	});
 
+	describe('corruption handling', () => {
+		// A torn/corrupt entry can declare a length far larger than the bytes
+		// actually present (e.g. a partial write that left a header pointing past
+		// its data). The readers must fail with a bounded, diagnosable error
+		// rather than driving an unbounded allocUnsafe (OOM), building a multi-GB
+		// hex string, or dereferencing an undefined buffer. Regression for the
+		// race_alerts crash-loop investigation.
+
+		function buildLogBuffer(
+			entries: { timestamp: number; length: number; flags: number; data: Buffer }[]
+		): Buffer {
+			const header = Buffer.alloc(TRANSACTION_LOG_FILE_HEADER_SIZE);
+			header.writeUInt32BE(TRANSACTION_LOG_TOKEN >>> 0, 0);
+			header.writeUInt8(1, 4); // version
+			header.writeDoubleBE(Date.now(), 5);
+			const parts: Buffer[] = [header];
+			for (const entry of entries) {
+				const entryHeader = Buffer.alloc(TRANSACTION_LOG_ENTRY_HEADER_SIZE);
+				entryHeader.writeDoubleBE(entry.timestamp, 0);
+				entryHeader.writeUInt32BE(entry.length >>> 0, 8);
+				entryHeader.writeUInt8(entry.flags, 12);
+				parts.push(entryHeader, entry.data);
+			}
+			return Buffer.concat(parts);
+		}
+
+		it('parseTransactionLog() throws a bounded error when an entry length overruns the file', async () => {
+			const path = `${generateDBPath()}.txnlog`;
+			// one valid entry, then a header claiming ~2GB with no data behind it
+			const buffer = buildLogBuffer([
+				{ timestamp: Date.now(), length: 4, flags: 1, data: Buffer.from([1, 2, 3, 4]) },
+				{ timestamp: Date.now(), length: 0x7fffffff, flags: 1, data: Buffer.alloc(0) },
+			]);
+			await writeFile(path, buffer);
+
+			let error: Error | undefined;
+			try {
+				parseTransactionLog(path);
+			} catch (caught) {
+				error = caught as Error;
+			}
+			expect(error).toBeInstanceOf(Error);
+			expect(error!.message).toMatch(/Corrupt entry at offset/);
+			// must not regress into the unbounded-allocation / oversized-string symptom
+			expect(error!.message).not.toMatch(/Cannot create a string longer than/);
+			expect(error!.message.length).toBeLessThan(1000);
+		});
+
+		it('query() throws a bounded RangeError when an entry length overruns the log buffer', () =>
+			dbRunner(async ({ db }) => {
+				const log = db.useLog('foo');
+				const value = Buffer.alloc(10, 'a');
+				for (let i = 0; i < 3; i++) {
+					await db.transaction(async (txn) => {
+						log.addEntry(value, txn.id);
+					});
+				}
+				// prime the query path so _lastCommittedPosition / _logBuffers init
+				expect(Array.from(log.query({ start: 0 })).length).toBe(3);
+
+				// Build a standalone-ArrayBuffer copy of the real memory map and corrupt
+				// the length field of the 2nd entry so it overruns the buffer. Returning
+				// the copy from _getMemoryMapOfFile lets us exercise the reader's framing
+				// path without a read-only mmap we can't mutate in place.
+				const real = log._getMemoryMapOfFile(1)!;
+				const copyBuffer = Buffer.from(new ArrayBuffer(real.length));
+				real.copy(copyBuffer);
+				const secondEntryLengthOffset =
+					TRANSACTION_LOG_FILE_HEADER_SIZE + (TRANSACTION_LOG_ENTRY_HEADER_SIZE + 10) + 8;
+				copyBuffer.writeUInt32BE(0x7fffffff, secondEntryLengthOffset);
+
+				log._logBuffers.clear();
+				(log as { _currentLogBuffer?: unknown })._currentLogBuffer = undefined;
+				const realDescriptor = Object.getOwnPropertyDescriptor(
+					Object.getPrototypeOf(log),
+					'_getMemoryMapOfFile'
+				)!;
+				Object.defineProperty(log, '_getMemoryMapOfFile', {
+					value: () => copyBuffer,
+					configurable: true,
+					writable: true,
+				});
+				try {
+					expect(() => Array.from(log.query({ start: 0 }))).toThrow(
+						/Corrupt transaction log entry/
+					);
+				} finally {
+					Object.defineProperty(log, '_getMemoryMapOfFile', realDescriptor);
+				}
+				// once the real mmap is restored, the valid data must still be readable
+				log._logBuffers.clear();
+				(log as { _currentLogBuffer?: unknown })._currentLogBuffer = undefined;
+				expect(Array.from(log.query({ start: 0 })).length).toBe(3);
+			}));
+	});
+
 	describe('purgeLogs', () => {
 		it('should purge all transaction log files', () =>
 			dbRunner({ skipOpen: true }, async ({ db, dbPath }) => {


### PR DESCRIPTION
## Summary

Hardens the two transaction-log **read** paths so an already-corrupt `.txnlog` fails with a precise, bounded error instead of OOMing or crash-looping.

A torn/truncated entry can leave a 4-byte big-endian length header claiming far more data than is physically present. (The *writer* bug that produces this is fixed separately in #573; this PR is the complementary read-side hardening, since corrupt files already exist in the field on un-upgraded nodes and #573 can't retroactively repair them.) Two reader defects turned such a file into a fatal:

- **`parse-transaction-log.ts`** — `Buffer.allocUnsafe(length)` on a bogus ~2 GB length, then the short-read error path hex-dumped the oversized buffer → `Cannot create a string longer than 0x1fffffe8` / heap OOM during startup "replaying transaction logs" replay.
- **`transaction-log-reader.ts` `next()`** — added the bogus length to `position`, then the advance-to-next-log path dereferenced an undefined buffer (`getLogMemoryMap(...)!` returning `undefined`) → `Cannot read properties of undefined (reading 'dataView')` on every commit during replication catch-up.

## Changes

- `parse-transaction-log.ts`: validate declared length against bytes remaining **before** allocating; throw a bounded `Corrupt entry at offset…` error. Cap the short-read error's hex preview to the first 64 bytes actually read.
- `transaction-log-reader.ts`: bound each entry against the committed `size` (or the physical mapped buffer when reading uncommitted); add a truncated-entry-header guard; throw a bounded `RangeError` on overrun. Convert the unguarded `getLogMemoryMap(...)!` into an `undefined` check that stops iteration cleanly (matching the existing guarded pattern a few lines above).
- Tests: new `corruption handling` block covering the parser (overrun length → bounded error, no oversized string) and the reader iterator (overrun length → bounded `RangeError`, valid data still readable afterward).

## Where to focus review

- **Throw vs fail-soft (design decision):** a corrupt *length* throws loudly (genuine corruption — surfacing it beats silently truncating the log view and risking replication divergence), whereas a transient *missing memory map* (rotation / FS race) stops cleanly with `done`. Is that distinction right for the replication-catch-up consumer, or should a corrupt length also stop cleanly?
- **The bound:** committed reads are bounded by `size` (a true entry boundary, so no false positives); uncommitted reads only by the physical buffer length. This was tightened from buffer-length-only after cross-model review — please sanity-check the `readUncommitted` branch.
- Mid-buffer subtle corruption (a length smaller than the bound but still misframed) is intentionally *not* caught here — that's the writer's job (#573 + the follow-up truncate-on-open PR).

## Test plan

- [x] `test/transaction-log.test.ts` — full file (53 tests) passes, incl. new corruption cases
- [x] Full vitest suite — 458 passed / 1 skipped, 0 failures
- [x] `pnpm type-check`, `pnpm lint`, `pnpm fmt` clean

A companion PR will address the writer side (truncate-to-last-valid-frame on open), closing #573's documented out-of-scope `O_APPEND` gap.

🤖 Generated by Claude (Opus 4.7) for @kriszyp. Cross-model reviewed via Gemini before opening.