### PR TITLE
Mutate iovec array in place in writeBatchToFile

### DIFF
--- a/src/binding/transaction_log/transaction_log_file.h
+++ b/src/binding/transaction_log/transaction_log_file.h
@@ -233,8 +233,17 @@ private:
 
 	/**
 	 * Platform specific function that writes multiple buffers to the log file.
+	 *
+	 * NOTE: `iovecs` is non-const and may be mutated on partial writes (the
+	 * partially-written iovec is advanced in place). Callers must not reuse
+	 * the array after this returns. Taking a mutable pointer lets us avoid
+	 * copying into a scratch buffer on the hot write path.
+	 *
+	 * POSIX advances partially-written iovecs in place; Windows writes from
+	 * local state and leaves the array untouched. Callers must treat it as
+	 * consumed in either case.
 	 */
-	int64_t writeBatchToFile(const iovec* iovecs, int iovcnt);
+	int64_t writeBatchToFile(iovec* iovecs, int iovcnt);
 
 	/**
 	 * Writes a batch of transaction log entries to the log file using version 1

--- a/src/binding/transaction_log/transaction_log_file_posix.cpp
+++ b/src/binding/transaction_log/transaction_log_file_posix.cpp
@@ -251,7 +251,7 @@ bool TransactionLogFile::removeFile() {
 	return true;
 }
 
-int64_t TransactionLogFile::writeBatchToFile(const iovec* iovecs, int iovcnt) {
+int64_t TransactionLogFile::writeBatchToFile(iovec* iovecs, int iovcnt) {
 	if (iovcnt <= 0) {
 		return 0;
 	}
@@ -259,14 +259,15 @@ int64_t TransactionLogFile::writeBatchToFile(const iovec* iovecs, int iovcnt) {
 	// writev has a per-call iovec limit (IOV_MAX) and may return short on
 	// partial writes (EINTR, ENOSPC, NFS/FUSE, etc.). Track byte progress
 	// through the iovec array and advance into a partial iovec's remainder so
-	// a short writev does not silently drop the tail of an entry.
+	// a short writev does not silently drop the tail of an entry. The caller's
+	// iovec array is mutated in place to avoid a scratch allocation on the hot
+	// write path.
 	int64_t totalWritten = 0;
-	std::vector<iovec> pending(iovecs, iovecs + iovcnt);
-	size_t pendingIdx = 0;
+	int pendingIdx = 0;
 
-	while (pendingIdx < pending.size()) {
-		int toWrite = static_cast<int>(std::min(pending.size() - pendingIdx, static_cast<size_t>(IOV_MAX)));
-		ssize_t written = ROCKSDB_JS_WRITEV(this->fd, &pending[pendingIdx], toWrite);
+	while (pendingIdx < iovcnt) {
+		int toWrite = std::min(iovcnt - pendingIdx, static_cast<int>(IOV_MAX));
+		ssize_t written = ROCKSDB_JS_WRITEV(this->fd, &iovecs[pendingIdx], toWrite);
 
 		if (written < 0) {
 			if (errno == EINTR) {
@@ -283,8 +284,8 @@ int64_t TransactionLogFile::writeBatchToFile(const iovec* iovecs, int iovcnt) {
 		totalWritten += written;
 
 		size_t remainingBytes = static_cast<size_t>(written);
-		while (remainingBytes > 0 && pendingIdx < pending.size()) {
-			iovec& iov = pending[pendingIdx];
+		while (remainingBytes > 0 && pendingIdx < iovcnt) {
+			iovec& iov = iovecs[pendingIdx];
 			if (remainingBytes >= iov.iov_len) {
 				remainingBytes -= iov.iov_len;
 				++pendingIdx;

--- a/src/binding/transaction_log/transaction_log_file_windows.cpp
+++ b/src/binding/transaction_log/transaction_log_file_windows.cpp
@@ -350,8 +350,8 @@ bool TransactionLogFile::removeFile() {
 	return true;
 }
 
-int64_t TransactionLogFile::writeBatchToFile(const iovec* iovecs, int iovcnt) {
-	if (iovcnt == 0) {
+int64_t TransactionLogFile::writeBatchToFile(iovec* iovecs, int iovcnt) {
+	if (iovcnt <= 0) {
 		return 0;
 	}
 

--- a/test/native/transaction_log_writev_test.cc
+++ b/test/native/transaction_log_writev_test.cc
@@ -44,7 +44,7 @@ extern "C" ssize_t rocksdb_js_mock_writev(int fd, const struct iovec* iov, int i
 // ---------------------------------------------------------------------------
 
 struct WriteBatchToFileTestAccessor {
-	static int64_t call(rocksdb_js::TransactionLogFile& f, const iovec* iovecs, int iovcnt) {
+	static int64_t call(rocksdb_js::TransactionLogFile& f, iovec* iovecs, int iovcnt) {
 		return f.writeBatchToFile(iovecs, iovcnt);
 	}
 };


### PR DESCRIPTION
This PR is in response to this PR comment: https://github.com/HarperFast/rocksdb-js/pull/613#discussion_r3344005436

## Summary
Drop the `std::vector<iovec>` scratch copy from the POSIX partial-writev retry loop in `TransactionLogFile::writeBatchToFile`. The function now advances the caller's iovec array in place when `writev` returns short, eliminating one heap allocation per batch on the transaction-log write hot path.

The sole production caller (`writeEntriesV1` in [src/binding/transaction_log/transaction_log_file.cpp:207](https://github.com/HarperFast/rocksdb-js/blob/main/src/binding/transaction_log/transaction_log_file.cpp#L207)) builds a fresh stack- or heap-allocated `iovec[]` per call and does not reuse it, so in-place mutation is safe. The mutation contract is documented in the header.

Also tightens the Windows `iovcnt` guard from `== 0` to `<= 0` to match POSIX, and updates the gtest accessor signature to take a mutable pointer.

## Where to look
- **Signature change is private-with-test-accessor-friend.** The function is `private` on `TransactionLogFile`, friended only for `WriteBatchToFileTestAccessor` in test builds. No external API impact.
- **POSIX vs Windows asymmetry.** POSIX actually mutates the array on partial `writev`; Windows writes from local pointers and never mutates. The header comment documents this so future readers don't go hunting for the missing Windows mutation. I considered making Windows mutate too for symmetry, but it would add risk without benefit since the Windows code path is already correct.
- **No new test for the mutation contract.** The existing tests already cover the externally observable behavior (partial writes retry until complete, IOV_MAX chunking, etc.). Adding a test that asserts the iovec array state after a partial write would lock in the contract, but no caller depends on it. Happy to add one if reviewers prefer.

## Tests
- `pnpm test:native` — 12/12 pass, including all 6 `WriteBatchToFile` cases (zero/bad-fd/single/multi/partial-writes-retry/above-IOV_MAX).
- `pnpm fmt:check` — clean.

🤖 Generated by Claude Opus 4.7. Pre-merge cross-model review by Gemini 3.1 Pro (via AntiGravity CLI) — symmetry suggestion on the Windows `iovcnt` guard was applied.