### PR TITLE
Set dependabot cool down to match pnpm (24 hours)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,9 @@ updates:
       day: 'monday'
       time: '05:15' # UTC
     open-pull-requests-limit: 10
+    # Wait 24h after a release before proposing an update, to match pnpm's minimumReleaseAge policy.
+    cooldown:
+      default-days: 1
     # Group updates to reduce PR noise. Major version updates will fall through to individual PRs.
     groups:
       # Group all other patch updates

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,3 +5,6 @@ allowBuilds:
   msgpackr-extract: true
 minimumReleaseAgeExclude:
   - '@harperfast/*'
+  - 'lmdb'
+  - 'msgpackr'
+  - 'ordered-binary'


### PR DESCRIPTION
In theory, this will fix dependabot CI errors like:
```
Run pnpm install --ignore-scripts --no-frozen-lockfile
? Verifying lockfile against supply-chain policies (303 entries)...
✗ Lockfile failed supply-chain policy check (303 entries in 1.2s)
[ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION] 9 lockfile entries failed verification:
  @lmdb/lmdb-darwin-arm64@3.5.5 was published at 2026-06-02T00:10:35.470Z, within the minimumReleaseAge cutoff (2026-06-01T16:05:18.932Z)
  @lmdb/lmdb-darwin-x64@3.5.5 was published at 2026-06-02T00:10:32.107Z, within the minimumReleaseAge cutoff (2026-06-01T16:05:18.932Z)
  @lmdb/lmdb-linux-arm@3.5.5 was published at 2026-06-02T00:10:48.647Z, within the minimumReleaseAge cutoff (2026-06-01T16:05:18.932Z)
  @lmdb/lmdb-linux-arm64@3.5.5 was published at 2026-06-02T00:10:45.898Z, within the minimumReleaseAge cutoff (2026-06-01T16:05:18.932Z)
  @lmdb/lmdb-linux-x64@3.5.5 was published at 2026-06-02T00:10:41.089Z, within the minimumReleaseAge cutoff (2026-06-01T16:05:18.932Z)
  @lmdb/lmdb-win32-arm64@3.5.5 was published at 2026-06-02T00:10:29.877Z, within the minimumReleaseAge cutoff (2026-06-01T16:05:18.932Z)
  @lmdb/lmdb-win32-x64@3.5.5 was published at 2026-06-02T00:10:27.461Z, within the minimumReleaseAge cutoff (2026-06-01T16:05:18.932Z)
  lmdb@3.5.5 was published at 2026-06-02T00:10:52.421Z, within the minimumReleaseAge cutoff (2026-06-01T16:05:18.932Z)
  tar@7.5.16 was published at 2026-06-01T16:20:51.215Z, within the minimumReleaseAge cutoff (2026-06-01T16:05:18.932Z)

The lockfile contains entries that the active policies reject. This can mean the lockfile is stale, or that someone committed a lockfile that bypassed the policy locally — inspect recent changes to pnpm-lock.yaml before trusting it. If the changes look expected, run "pnpm clean --lockfile" and then "pnpm install" to rebuild from a fresh resolution. Alternatively, relax the policy that flagged them.
```