### PR TITLE
Fix Node 26 Windows native build broken by leaked Clang LTO flags

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -1,4 +1,29 @@
 {
+	# Node 26's Windows headers (common.gypi) inject Clang ThinLTO options
+	# (-flto=thin and /opt:lldltojobs=N) into every Release target. The official
+	# Node Windows build is now compiled with ClangCL + ThinLTO, but this addon
+	# builds with MSVC (cl.exe / link.exe), which rejects those LLVM-only flags:
+	# link.exe aborts with "LNK1117: syntax error in option 'opt:lldltojobs=2'".
+	# Strip them from the MSVC tool invocations via regex exclusion (value- and
+	# thin/full-agnostic). This lives under msvs_settings, so it is inert on the
+	# Linux/macOS generators and leaves their LTO behavior untouched.
+	'target_defaults': {
+		'configurations': {
+			'Release': {
+				'msvs_settings': {
+					'VCCLCompilerTool': {
+						'AdditionalOptions/': [['exclude', 'flto'], ['exclude', 'lldltojobs']],
+					},
+					'VCLibrarianTool': {
+						'AdditionalOptions/': [['exclude', 'flto'], ['exclude', 'lldltojobs']],
+					},
+					'VCLinkerTool': {
+						'AdditionalOptions/': [['exclude', 'flto'], ['exclude', 'lldltojobs']],
+					},
+				},
+			},
+		},
+	},
 	'targets': [
 		{
 			'target_name': 'rocksdb-js',

--- a/deps/gtest.gyp
+++ b/deps/gtest.gyp
@@ -7,6 +7,27 @@
 		# on a download action is too late.
 		'_init_gtest': '<!(<(module_root_dir)/node_modules/.bin/tsx <(module_root_dir)/scripts/init-gtest/main.ts)',
 	},
+	# See binding.gyp: Node 26's Windows headers inject Clang ThinLTO options
+	# (-flto=thin / /opt:lldltojobs=N) into every Release target, which MSVC's
+	# cl.exe and lib.exe reject. Strip them here too so the gtest_main library
+	# builds cleanly. Inert on the Linux/macOS generators.
+	'target_defaults': {
+		'configurations': {
+			'Release': {
+				'msvs_settings': {
+					'VCCLCompilerTool': {
+						'AdditionalOptions/': [['exclude', 'flto'], ['exclude', 'lldltojobs']],
+					},
+					'VCLibrarianTool': {
+						'AdditionalOptions/': [['exclude', 'flto'], ['exclude', 'lldltojobs']],
+					},
+					'VCLinkerTool': {
+						'AdditionalOptions/': [['exclude', 'flto'], ['exclude', 'lldltojobs']],
+					},
+				},
+			},
+		},
+	},
 	'targets': [
 		{
 			'target_name': 'gtest_main',


### PR DESCRIPTION
## Summary

The CI job **Test on Node.js 26 and windows-latest** fails at the native **Build** step:

```
LINK : warning LNK4044: unrecognized option '/flto=thin'; ignored
LINK : fatal error LNK1117: syntax error in option 'opt:lldltojobs=2'
```

This strips those LLVM-only options from the MSVC tool invocations in `binding.gyp` and `deps/gtest.gyp`.

## Root cause

Node 26's official **Windows** binary is now built with **ClangCL + ThinLTO**, so its headers (`config.gypi`) carry `enable_thin_lto="true"` and `lto_jobs="2"`. Node's `common.gypi` then appends `-flto=thin` and `/opt:lldltojobs=<lto_jobs>` into the **Release** `msvs_settings` `AdditionalOptions` of **every** target via `target_defaults`:

- `VCCLCompilerTool` / `VCLibrarianTool` / `VCLinkerTool` → `-flto=thin`
- `VCLinkerTool` → `/opt:lldltojobs=2`

But this addon builds with **MSVC** (`cl.exe` / `link.exe`), which doesn't understand Clang LTO flags. `cl.exe` merely warns (D9002), but `link.exe` aborts with `LNK1117`. Node 24 + Windows passes because it didn't inject these; the standalone native-test job passes because it pins Node 24.

## The fix

A `target_defaults` using gyp's regex list-exclusion inside `configurations.Release.msvs_settings`:

```python
'AdditionalOptions/': [['exclude', 'flto'], ['exclude', 'lldltojobs']]
```

- **Value-agnostic** — survives Node switching to `-flto=full` or a different `lto_jobs` count.
- **Scoped to `msvs_settings`** — inert on the Linux/macOS (make/ninja/xcode) generators, so their build/LTO behavior is unchanged.
- Applied to both `binding.gyp` (the addon + native-tests targets) and `deps/gtest.gyp` (the `gtest_main` lib, which otherwise emits cosmetic `-flto=thin` warnings).

## Where to focus review

- **The exclusion mechanism is the crux.** `'AdditionalOptions/'` (trailing slash) is gyp's regex filter; `[['exclude', <regex>]]` removes list items whose string matches the substring. Verified that `flto` / `lldltojobs` don't collide with any legitimate MSVC option (`/LTCG`, `/Zc:__cplusplus`, `/std:c++20`, etc.).
- **Duplication across two gyp files** is intentional — a shared `.gypi` include would need fragile cross-directory pathing into `deps/`; keeping each build file self-contained is cleaner.

## Validation

- **gypd dump of the real `binding.gyp`** (simulating Node 26's injection): diff vs. unmodified shows the *only* change is `-flto=thin` and `/opt:lldltojobs=2` moving from active `AdditionalOptions` to `AdditionalOptions_excluded`; `/std:c++20` and `/Zc:__cplusplus` are preserved.
- **Linux `pnpm rebuild`**: parses both gyp files and links `rocksdb-js.node` cleanly (exit 0), confirming no regression.
- **Cross-model review** (Gemini via `agy`): LGTM, non-blocking.
- True Windows validation will come from this PR's CI (the Node 26 + Windows job).

🤖 Generated by Claude (Opus 4.7). Reviewer suggested per the RocksDB area of the expertise matrix.