### PR TITLE
Fix flaky Deno unit tests in Vitest fork and worker teardown

### DIFF
--- a/test/events.test.ts
+++ b/test/events.test.ts
@@ -1,5 +1,10 @@
 import { withResolvers } from '../src/util.js';
-import { createWorkerBootstrapScript, dbRunner, generateDBPath } from './lib/util.js';
+import {
+	createWorkerBootstrapScript,
+	dbRunner,
+	generateDBPath,
+	terminateWorker,
+} from './lib/util.js';
 import EventEmitter, { once } from 'node:events';
 import { setTimeout as delay } from 'node:timers/promises';
 import { Worker } from 'node:worker_threads';
@@ -274,23 +279,7 @@ describe('Events', () => {
 
 			resolver = withResolvers<void>();
 			worker.postMessage({ close: true });
-
-			if (process.versions.deno) {
-				// there is something buggy with Deno where calling `await delay(100)` freezes the
-				// process, but advancing a microtask seems to unfreeze it
-				await new Promise<void>((resolve) => {
-					const timer = setTimeout(() => {
-						worker.terminate();
-						resolve();
-					}, 100);
-
-					worker.on('exit', () => {
-						clearTimeout(timer);
-						resolve();
-					});
-				});
-			}
-
+			await terminateWorker(worker);
 			await resolver.promise;
 		}));
 

--- a/test/lib/util.ts
+++ b/test/lib/util.ts
@@ -4,6 +4,7 @@ import { mkdirSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { setTimeout as delay } from 'node:timers/promises';
+import type { Worker } from 'node:worker_threads';
 
 export function generateDBPath(): string {
 	const testDir = join(tmpdir(), 'rocksdb-js-tests');
@@ -102,6 +103,31 @@ export async function dbRunner(options: TestOptions | TestFn, test?: TestFn): Pr
 			}
 		}
 	}
+}
+
+/**
+ * Waits for a worker thread to exit. On Deno and Bun, worker threads often fail
+ * to exit after `close` messages, so we force-terminate after a short timeout.
+ */
+export async function terminateWorker(worker: Worker): Promise<void> {
+	if (process.versions.deno || process.versions.bun) {
+		await new Promise<void>((resolve) => {
+			const timer = setTimeout(() => {
+				worker.terminate();
+				resolve();
+			}, 100);
+
+			worker.on('exit', () => {
+				clearTimeout(timer);
+				resolve();
+			});
+		});
+		return;
+	}
+
+	await new Promise<void>((resolve) => {
+		worker.on('exit', () => resolve());
+	});
 }
 
 /**

--- a/test/lib/util.ts
+++ b/test/lib/util.ts
@@ -110,6 +110,11 @@ export async function dbRunner(options: TestOptions | TestFn, test?: TestFn): Pr
  * to exit after `close` messages, so we force-terminate after a short timeout.
  */
 export async function terminateWorker(worker: Worker): Promise<void> {
+	// check if the worker is already terminated
+	if (worker.threadId === -1) {
+		return;
+	}
+
 	if (process.versions.deno || process.versions.bun) {
 		await new Promise<void>((resolve) => {
 			const timer = setTimeout(() => {

--- a/test/lock.test.ts
+++ b/test/lock.test.ts
@@ -1,4 +1,4 @@
-import { createWorkerBootstrapScript, dbRunner } from './lib/util.js';
+import { createWorkerBootstrapScript, dbRunner, terminateWorker } from './lib/util.js';
 import { setTimeout as delay } from 'node:timers/promises';
 import { Worker } from 'node:worker_threads';
 import { describe, expect, it, vi } from 'vitest';
@@ -143,6 +143,7 @@ describe('Lock', () => {
 					expect(db.tryLock('foo', () => resolve())).toBe(false);
 					worker.postMessage({ close: true });
 				});
+				await terminateWorker(worker);
 			}));
 	});
 
@@ -295,22 +296,7 @@ describe('Lock', () => {
 				expect(spy).toHaveBeenCalledTimes(3);
 
 				worker.postMessage({ close: true });
-
-				if (process.versions.deno) {
-					// there is something buggy with Deno where calling `await delay(100)` freezes the
-					// process, but advancing a microtask seems to unfreeze it
-					await new Promise<void>((resolve) => {
-						const timer = setTimeout(() => {
-							worker.terminate();
-							resolve();
-						}, 100);
-
-						worker.on('exit', () => {
-							clearTimeout(timer);
-							resolve();
-						});
-					});
-				}
+				await terminateWorker(worker);
 			}));
 	});
 });

--- a/test/thread-id.test.ts
+++ b/test/thread-id.test.ts
@@ -1,5 +1,5 @@
 import { currentThreadId } from '../src/index.js';
-import { createWorkerBootstrapScript } from './lib/util.js';
+import { createWorkerBootstrapScript, terminateWorker } from './lib/util.js';
 import { Worker } from 'node:worker_threads';
 import { describe, expect, it } from 'vitest';
 
@@ -29,6 +29,7 @@ describe('threadId', () => {
 
 			expect(threadIds.has(workerThreadId)).toBe(false);
 			threadIds.add(workerThreadId);
+			await terminateWorker(worker);
 		}
 	});
 });

--- a/test/transaction-log.test.ts
+++ b/test/transaction-log.test.ts
@@ -2,7 +2,12 @@ import { RocksDatabase, Transaction } from '../src/index.js';
 import { constants, type TransactionLog } from '../src/load-binding.js';
 import { parseTransactionLog } from '../src/parse-transaction-log.js';
 import { withResolvers } from '../src/util.js';
-import { createWorkerBootstrapScript, dbRunner, generateDBPath } from './lib/util.js';
+import {
+	createWorkerBootstrapScript,
+	dbRunner,
+	generateDBPath,
+	terminateWorker,
+} from './lib/util.js';
 import assert from 'node:assert';
 import { existsSync, readFileSync, statSync } from 'node:fs';
 import { mkdir, readdir, stat, utimes, writeFile } from 'node:fs/promises';
@@ -914,23 +919,7 @@ describe('Transaction Log', () => {
 
 					resolver = withResolvers<void>();
 					worker.postMessage({ close: true });
-
-					if (process.versions.deno) {
-						// there is something buggy with Deno where calling `await delay(100)` freezes the
-						// process, but advancing a microtask seems to unfreeze it
-						await new Promise<void>((resolve) => {
-							const timer = setTimeout(() => {
-								worker.terminate();
-								resolve();
-							}, 100);
-
-							worker.on('exit', () => {
-								clearTimeout(timer);
-								resolve();
-							});
-						});
-					}
-
+					await terminateWorker(worker);
 					await resolver.promise;
 				}),
 			60000

--- a/test/user-shared-buffer-notify.test.ts
+++ b/test/user-shared-buffer-notify.test.ts
@@ -1,0 +1,69 @@
+import type { BufferWithDataView } from '../src/encoding.js';
+import { dbRunner } from './lib/util.js';
+import { setTimeout as delay } from 'node:timers/promises';
+import { assert, describe, expect, it } from 'vitest';
+
+// Deno's Vitest fork pool crashes with a V8 HandleScope error when callback
+// registration tests run in the same child process after other getUserSharedBuffer
+// tests. Isolating them in a separate file gives them their own fork.
+describe('User Shared Buffer notify', () => {
+	describe('getUserSharedBuffer()', () => {
+		it('should notify callbacks', () =>
+			dbRunner(async ({ db }) => {
+				const sharedNumber = new Float64Array(1);
+				await new Promise<void>((resolve) => {
+					const sharedBuffer = db.getUserSharedBuffer('with-callback', sharedNumber.buffer, {
+						callback() {
+							// wait so notify() returns true
+							setTimeout(() => resolve(), 100);
+						},
+					});
+					expect(sharedBuffer.notify()).toBe(true);
+				});
+			}));
+
+		it.skipIf(!globalThis.gc)(
+			'should cleanup callbacks on GC',
+			() =>
+				dbRunner(async ({ db }) => {
+					const sharedNumber = new Float64Array(1);
+					let weakRef: WeakRef<ArrayBuffer> | undefined;
+
+					const encodedKey = db.store.encodeKey('with-callback2');
+					const key = Buffer.from(
+						encodedKey.subarray(encodedKey.start, encodedKey.end)
+					) as BufferWithDataView;
+
+					await new Promise<void>((resolve) => {
+						expect(db.listeners(key)).toBe(0);
+						const sharedBuffer = db.getUserSharedBuffer('with-callback2', sharedNumber.buffer, {
+							callback() {
+								// wait so notify() returns true
+								setImmediate(() => resolve());
+							},
+						});
+						weakRef = new WeakRef(sharedBuffer);
+						expect(sharedBuffer.notify()).toBe(true);
+						expect(db.listeners(key)).toBe(1);
+					});
+
+					// this can be flaky, especially when running all tests
+					globalThis.gc?.();
+					for (let i = 0; i < 20 && db.listeners(key) > 0; i++) {
+						globalThis.gc?.();
+						await delay(250);
+					}
+
+					assert(weakRef);
+					expect(weakRef.deref()).toBeUndefined();
+					const listenerCount = db.listeners(key);
+					if (listenerCount > 0) {
+						throw new Error(
+							`${listenerCount} listener${listenerCount === 1 ? '' : 's'} still present!`
+						);
+					}
+				}),
+			20000
+		);
+	});
+});

--- a/test/user-shared-buffer.test.ts
+++ b/test/user-shared-buffer.test.ts
@@ -1,9 +1,7 @@
-import type { BufferWithDataView } from '../src/encoding.js';
 import { withResolvers } from '../src/util.js';
-import { createWorkerBootstrapScript, dbRunner } from './lib/util.js';
-import { setTimeout as delay } from 'node:timers/promises';
+import { createWorkerBootstrapScript, dbRunner, terminateWorker } from './lib/util.js';
 import { Worker } from 'node:worker_threads';
-import { assert, describe, expect, it } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 describe('User Shared Buffer', () => {
 	describe('getUserSharedBuffer()', () => {
@@ -60,64 +58,6 @@ describe('User Shared Buffer', () => {
 				expect(incrementer2[0]).toBe(2n);
 			}));
 
-		it('should notify callbacks', () =>
-			dbRunner(async ({ db }) => {
-				const sharedNumber = new Float64Array(1);
-				await new Promise<void>((resolve) => {
-					const sharedBuffer = db.getUserSharedBuffer('with-callback', sharedNumber.buffer, {
-						callback() {
-							// wait so notify() returns true
-							setTimeout(() => resolve(), 100);
-						},
-					});
-					expect(sharedBuffer.notify()).toBe(true);
-				});
-			}));
-
-		it.skipIf(!globalThis.gc)(
-			'should cleanup callbacks on GC',
-			() =>
-				dbRunner(async ({ db }) => {
-					const sharedNumber = new Float64Array(1);
-					let weakRef: WeakRef<ArrayBuffer> | undefined;
-
-					const encodedKey = db.store.encodeKey('with-callback2');
-					const key = Buffer.from(
-						encodedKey.subarray(encodedKey.start, encodedKey.end)
-					) as BufferWithDataView;
-
-					await new Promise<void>((resolve) => {
-						expect(db.listeners(key)).toBe(0);
-						const sharedBuffer = db.getUserSharedBuffer('with-callback2', sharedNumber.buffer, {
-							callback() {
-								// wait so notify() returns true
-								setImmediate(() => resolve());
-							},
-						});
-						weakRef = new WeakRef(sharedBuffer);
-						expect(sharedBuffer.notify()).toBe(true);
-						expect(db.listeners(key)).toBe(1);
-					});
-
-					// this can be flaky, especially when running all tests
-					globalThis.gc?.();
-					for (let i = 0; i < 20 && db.listeners(key) > 0; i++) {
-						globalThis.gc?.();
-						await delay(250);
-					}
-
-					assert(weakRef);
-					expect(weakRef.deref()).toBeUndefined();
-					const listenerCount = db.listeners(key);
-					if (listenerCount > 0) {
-						throw new Error(
-							`${listenerCount} listener${listenerCount === 1 ? '' : 's'} still present!`
-						);
-					}
-				}),
-			20000
-		);
-
 		it(
 			'should share buffer across worker threads with same database',
 			() =>
@@ -161,23 +101,7 @@ describe('User Shared Buffer', () => {
 
 					resolver = withResolvers<void>();
 					worker.postMessage({ close: true });
-
-					if (process.versions.deno) {
-						// there is something buggy with Deno where calling `await delay(100)` freezes the
-						// process, but advancing a microtask seems to unfreeze it
-						await new Promise<void>((resolve) => {
-							const timer = setTimeout(() => {
-								worker.terminate();
-								resolve();
-							}, 100);
-
-							worker.on('exit', () => {
-								clearTimeout(timer);
-								resolve();
-							});
-						});
-					}
-
+					await terminateWorker(worker);
 					await resolver.promise;
 
 					expect(getNextId()).toBe(5n);

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -15,6 +15,8 @@ const rocksdbVersion = await import('./dist/index.mjs')
 	.catch(() => '?');
 console.log(`${runtime} (${machine}) rocksdb-js/${version} RocksDB/${rocksdbVersion}`);
 
+const isAlternateRuntime = !!(process.versions.bun || process.versions.deno);
+
 export default defineConfig({
 	test: {
 		allowOnly: true,
@@ -26,7 +28,10 @@ export default defineConfig({
 		globals: false,
 		hookTimeout: 30000,
 		include: ['test/**/*.test.ts'],
-		pool: process.versions.bun || process.versions.deno ? 'forks' : 'threads',
+		pool: isAlternateRuntime ? 'forks' : 'threads',
+		// Deno's node:worker_threads compat is flaky when native-backed tests run
+		// concurrently in the same fork; sequential execution avoids V8 HandleScope crashes.
+		sequence: isAlternateRuntime ? { concurrent: false } : undefined,
 		reporters: ['verbose'],
 		silent: false,
 		testTimeout: 30000,


### PR DESCRIPTION
## Summary

- Split `getUserSharedBuffer` callback/GC tests into `test/user-shared-buffer-notify.test.ts` so Deno's Vitest fork pool does not crash with a V8 HandleScope error after earlier shared-buffer tests in the same child process
- Run Bun/Deno tests sequentially (`sequence.concurrent: false`) to avoid concurrent native DB access in a single fork
- Add shared `terminateWorker()` helper and use it in all worker-thread tests (including `thread-id.test.ts`, which was leaking workers)

## Purpose

Deno CI on Linux/macOS was failing intermittently with `Worker exited unexpectedly` and `Timeout terminating forks worker for test/user-shared-buffer.test.ts` even when individual tests passed.

## Review focus

- Whether splitting the notify tests is an acceptable long-term workaround vs. fixing Deno/Vitest fork behavior or native callback teardown
- `terminateWorker()` force-terminates on Deno/Bun after 100ms — confirm that matches prior ad-hoc behavior and is applied everywhere workers are used in tests

Generated by Claude (Composer).

Made with [Cursor](https://cursor.com)