### PR TITLE
Add JSON-escape helper and ListenerData::fromStrings factory

### DIFF
--- a/README.md
+++ b/README.md
@@ -668,12 +668,25 @@ complete, use the `'aftercommit'` event.
 ## Event API
 
 `rocksdb-js` provides a EventEmitter-like API that lets you asynchronously notify events to one or
-more synchronous listener callbacks. Events are scoped by database path.
+more synchronous listener callbacks. There are two types of events:
+
+- Per-database events: scoped by database path.
+- Process-global events: not scoped by database path.
 
 Unlike `EventEmitter`, events are emitted asynchronously, but in the same order that the listeners
 were added.
 
 ```typescript
+// Process-global events
+RocksDatabase.on('log.warn', console.warn);
+
+RocksDatabase.on('foo', (...args) => {
+	console.log(args);
+});
+RocksDatabase.notify('foo', 'bar');
+RocksDatabase.off('foo', callback);
+
+// Per-database events
 const callback = (name) => console.log(`Hi from ${name}`);
 db.addListener('foo', callback);
 db.notify('foo');
@@ -1102,6 +1115,18 @@ for (const entry of rangeIter) {
 
 Returns the size of the given transaction log sequence file in bytes. Omit the sequence number to
 get the total size of all the transaction log sequence files for this log.
+
+### Transaction Log Initialization
+
+When a database is opened, `rocksdb-js` will automatically discover the transaction log files. If
+a corrupt transaction log file is detected, the `log.warn` event is emitted on the global
+`RocksDatabase` instance. This should be wired up prior to opening the database.
+
+```typescript
+RocksDatabase.on('log.warn', console.warn);
+
+const db = RocksDatabase.open('path/to/db');
+```
 
 ### Transaction Log Parser
 

--- a/binding.gyp
+++ b/binding.gyp
@@ -181,6 +181,7 @@
 				'src/binding/core/platform.cpp',
 				'src/binding/transaction_log/transaction_log_file.cpp',
 				'src/binding/transaction_log/transaction_log_recovery.cpp',
+				'test/native/event_emitter_stub.cc',
 				'test/native/rocksdb_version_test.cc',
 				'test/native/encoding_test.cc',
 				'test/native/json_test.cc',

--- a/binding.gyp
+++ b/binding.gyp
@@ -183,6 +183,7 @@
 				'src/binding/transaction_log/transaction_log_recovery.cpp',
 				'test/native/rocksdb_version_test.cc',
 				'test/native/encoding_test.cc',
+				'test/native/json_test.cc',
 				'test/native/transaction_log_writev_test.cc',
 				'test/native/transaction_log_recovery_test.cc',
 			],

--- a/src/binding/core/json.h
+++ b/src/binding/core/json.h
@@ -20,7 +20,8 @@ namespace rocksdb_js {
 inline void appendJsonString(std::string& out, std::string_view s) {
 	out.reserve(out.size() + s.size() + 2);
 	out += '"';
-	for (unsigned char c : s) {
+	for (char ch : s) {
+		const unsigned char c = static_cast<unsigned char>(ch);
 		switch (c) {
 			case '"':  out += "\\\""; break;
 			case '\\': out += "\\\\"; break;

--- a/src/binding/core/json.h
+++ b/src/binding/core/json.h
@@ -1,0 +1,57 @@
+#ifndef __CORE_JSON_H__
+#define __CORE_JSON_H__
+
+#include <cstdio>
+#include <string>
+#include <string_view>
+
+namespace rocksdb_js {
+
+/**
+ * Appends a JSON string literal (including surrounding double quotes) for
+ * `s` to `out`, escaping per RFC 8259: `"`, `\`, and control characters
+ * 0x00–0x1F. Bytes >= 0x20 are passed through verbatim, which means a
+ * valid UTF-8 input produces a valid UTF-8 JSON literal without
+ * re-encoding multi-byte sequences as `\uXXXX`.
+ *
+ * Inline so it can be used both from the N-API layer and from native
+ * GoogleTest binaries that don't link the N-API code.
+ */
+inline void appendJsonString(std::string& out, std::string_view s) {
+	out.reserve(out.size() + s.size() + 2);
+	out += '"';
+	for (unsigned char c : s) {
+		switch (c) {
+			case '"':  out += "\\\""; break;
+			case '\\': out += "\\\\"; break;
+			case '\b': out += "\\b";  break;
+			case '\f': out += "\\f";  break;
+			case '\n': out += "\\n";  break;
+			case '\r': out += "\\r";  break;
+			case '\t': out += "\\t";  break;
+			default:
+				if (c < 0x20) {
+					char buf[7];
+					std::snprintf(buf, sizeof(buf), "\\u%04x", c);
+					out.append(buf, 6);
+				} else {
+					out += static_cast<char>(c);
+				}
+		}
+	}
+	out += '"';
+}
+
+/**
+ * Convenience wrapper around `appendJsonString` that returns a freshly
+ * built JSON string literal.
+ */
+inline std::string jsonString(std::string_view s) {
+	std::string out;
+	appendJsonString(out, s);
+	return out;
+}
+
+} // namespace rocksdb_js
+
+#endif

--- a/src/binding/database/db_handle.cpp
+++ b/src/binding/database/db_handle.cpp
@@ -1,4 +1,3 @@
-#include <algorithm>
 #include "database/db_handle.h"
 #include "database/db_descriptor.h"
 #include "database/db_registry.h"
@@ -260,19 +259,7 @@ napi_value DBHandle::useLog(napi_env env, napi_value jsDatabase, std::string& na
 	NAPI_STATUS_THROWS(::napi_create_reference(env, instance, 0, &ref));
 	this->logRefs.emplace(name, ref);
 
-	// Notify that a new transaction log was created
-	// Create JSON string with log name: ["logName"]
-	std::string jsonArgs;
-	jsonArgs.reserve(name.size() + 4);
-	jsonArgs += "[\"";
-	for (char c : name) {
-		if (c == '"') jsonArgs  += '\\';
-		jsonArgs += c;
-	}
-	jsonArgs += "\"]";
-	ListenerData* data = new ListenerData(jsonArgs.size());
-	std::copy(jsonArgs.begin(), jsonArgs.end(), data->args.begin());
-	this->descriptor->notify("new-transaction-log", data);
+	this->descriptor->notify("new-transaction-log", ListenerData::fromStrings({ name }));
 
 	return instance;
 }

--- a/src/binding/napi/event_emitter.cpp
+++ b/src/binding/napi/event_emitter.cpp
@@ -1,10 +1,33 @@
 #include "napi/event_emitter.h"
 #include <algorithm>
 #include "core/debug.h"
+#include "core/json.h"
 #include "napi/helpers.h"
 #include "napi/macros.h"
 
 namespace rocksdb_js {
+
+ListenerData* ListenerData::fromStrings(std::initializer_list<std::string_view> args) {
+	std::string payload;
+	size_t reserve = 2; // '[' + ']'
+	for (std::string_view arg : args) {
+		reserve += arg.size() + 3; // quotes + comma; escapes may grow this
+	}
+	payload.reserve(reserve);
+
+	payload += '[';
+	bool first = true;
+	for (std::string_view arg : args) {
+		if (!first) payload += ',';
+		first = false;
+		appendJsonString(payload, arg);
+	}
+	payload += ']';
+
+	auto* data = new ListenerData();
+	data->args = std::move(payload);
+	return data;
+}
 
 /**
  * Threadsafe-function finalizer. Node-API guarantees this runs on the JS

--- a/src/binding/napi/event_emitter.cpp
+++ b/src/binding/napi/event_emitter.cpp
@@ -1,33 +1,10 @@
 #include "napi/event_emitter.h"
 #include <algorithm>
 #include "core/debug.h"
-#include "core/json.h"
 #include "napi/helpers.h"
 #include "napi/macros.h"
 
 namespace rocksdb_js {
-
-ListenerData* ListenerData::fromStrings(std::initializer_list<std::string_view> args) {
-	std::string payload;
-	size_t reserve = 2; // '[' + ']'
-	for (std::string_view arg : args) {
-		reserve += arg.size() + 3; // quotes + comma; escapes may grow this
-	}
-	payload.reserve(reserve);
-
-	payload += '[';
-	bool first = true;
-	for (std::string_view arg : args) {
-		if (!first) payload += ',';
-		first = false;
-		appendJsonString(payload, arg);
-	}
-	payload += ']';
-
-	auto* data = new ListenerData();
-	data->args = std::move(payload);
-	return data;
-}
 
 /**
  * Threadsafe-function finalizer. Node-API guarantees this runs on the JS

--- a/src/binding/napi/event_emitter.h
+++ b/src/binding/napi/event_emitter.h
@@ -2,9 +2,11 @@
 #define __NAPI_EVENT_EMITTER_H__
 
 #include <atomic>
+#include <initializer_list>
 #include <memory>
 #include <mutex>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 #include <vector>
 #include "napi/binding.h"
@@ -17,8 +19,23 @@ namespace rocksdb_js {
 struct ListenerData final {
 	std::string args;
 
+	ListenerData() = default;
 	ListenerData(size_t size) : args(size, '\0') {}
 	ListenerData(const ListenerData& other) : args(other.args) {}
+
+	/**
+	 * Builds a ListenerData payload from one or more pre-stringified args,
+	 * JSON-escaped and wrapped in a JSON array (the shape the JS listener
+	 * trampoline expects). Use this from native call sites that need to
+	 * surface text — typically a single message — to a JS listener.
+	 *
+	 * Each arg is encoded as a JSON string via `appendJsonString` so paths
+	 * containing `"`, `\`, or control characters round-trip safely.
+	 *
+	 * Returns a heap-allocated ListenerData; ownership transfers to the
+	 * recipient (`EventEmitter::notify` / `emitGlobalEvent`).
+	 */
+	static ListenerData* fromStrings(std::initializer_list<std::string_view> args);
 };
 
 /**

--- a/src/binding/napi/event_emitter.h
+++ b/src/binding/napi/event_emitter.h
@@ -9,6 +9,7 @@
 #include <string_view>
 #include <unordered_map>
 #include <vector>
+#include "core/json.h"
 #include "napi/binding.h"
 
 namespace rocksdb_js {
@@ -32,10 +33,35 @@ struct ListenerData final {
 	 * Each arg is encoded as a JSON string via `appendJsonString` so paths
 	 * containing `"`, `\`, or control characters round-trip safely.
 	 *
+	 * Defined inline so files that need only this factory (e.g. recovery
+	 * code in the native GoogleTest binary, which doesn't link the rest of
+	 * the N-API event-emitter machinery) get the implementation without
+	 * pulling in event_emitter.cpp.
+	 *
 	 * Returns a heap-allocated ListenerData; ownership transfers to the
 	 * recipient (`EventEmitter::notify` / `emitGlobalEvent`).
 	 */
-	static ListenerData* fromStrings(std::initializer_list<std::string_view> args);
+	static ListenerData* fromStrings(std::initializer_list<std::string_view> args) {
+		std::string payload;
+		size_t reserve = 2; // '[' + ']'
+		for (std::string_view arg : args) {
+			reserve += arg.size() + 3; // quotes + comma; escapes may grow this
+		}
+		payload.reserve(reserve);
+
+		payload += '[';
+		bool first = true;
+		for (std::string_view arg : args) {
+			if (!first) payload += ',';
+			first = false;
+			appendJsonString(payload, arg);
+		}
+		payload += ']';
+
+		auto* data = new ListenerData();
+		data->args = std::move(payload);
+		return data;
+	}
 };
 
 /**

--- a/src/binding/transaction_log/transaction_log_file.cpp
+++ b/src/binding/transaction_log/transaction_log_file.cpp
@@ -1,11 +1,8 @@
 #include <cmath>
-#include <cstdio>
 #include <sstream>
 #include <system_error>
 #include <vector>
-#ifndef ROCKSDB_JS_NATIVE_TESTS
-	#include "napi/global_events.h"
-#endif
+#include "napi/global_events.h"
 #include "transaction_log_entry.h"
 #include "transaction_log_file.h"
 #include "transaction_log_recovery.h"
@@ -164,10 +161,6 @@ void TransactionLogFile::recoverTail() {
 			DEBUG_LOG("%p TransactionLogFile::recoverTail Mid-file corruption at offset %u in %s (size=%u), leaving intact\n",
 				this, scan.validEnd, this->path.string().c_str(), fileSize);
 
-#ifndef ROCKSDB_JS_NATIVE_TESTS
-			// Surface to an operator via the global "log.warn" event. Skipped
-			// in native GoogleTest builds so this TU links without the N-API
-			// event-emitter machinery (recovery itself is the unit under test).
 			std::ostringstream msg;
 			msg << "Transaction log " << this->path.string()
 				<< " has a framing break at offset " << std::hex << scan.validEnd << std::dec
@@ -176,7 +169,6 @@ void TransactionLogFile::recoverTail() {
 					"Reads past this point will fail until the file is repaired.";
 
 			emitGlobalEvent("log.warn", ListenerData::fromStrings({ msg.str() }));
-#endif
 
 			return;
 		}

--- a/src/binding/transaction_log/transaction_log_file.cpp
+++ b/src/binding/transaction_log/transaction_log_file.cpp
@@ -167,7 +167,6 @@ void TransactionLogFile::recoverTail() {
 				<< " with " << (fileSize - scan.validEnd)
 				<< " byte(s) of further data; leaving it intact to avoid discarding committed entries. "
 					"Reads past this point will fail until the file is repaired.";
-
 			emitGlobalEvent("log.warn", ListenerData::fromStrings({ msg.str() }));
 
 			return;
@@ -184,10 +183,12 @@ void TransactionLogFile::recoverTail() {
 				if (this->lastFlushedSize > scan.validEnd) {
 					this->lastFlushedSize = scan.validEnd;
 				}
-				::fprintf(stderr,
-					"[rocksdb-js] transaction log %s had a torn tail; dropped %u partial byte(s) back to the last valid "
-					"entry (new size=%u).\n",
-					this->path.string().c_str(), fileSize - scan.validEnd, scan.validEnd);
+
+				std::ostringstream msg;
+				msg << "Transaction log " << this->path.string()
+					<< " had a torn tail; dropped " << (fileSize - scan.validEnd)
+					<< " partial byte(s) back to the last valid entry (new size=" << scan.validEnd << ").";
+				emitGlobalEvent("log.warn", ListenerData::fromStrings({ msg.str() }));
 			} else {
 				DEBUG_LOG("%p TransactionLogFile::recoverTail Truncate failed (or unsupported on this platform) for %s\n",
 					this, this->path.string().c_str());

--- a/src/binding/transaction_log/transaction_log_file.cpp
+++ b/src/binding/transaction_log/transaction_log_file.cpp
@@ -167,6 +167,7 @@ void TransactionLogFile::recoverTail() {
 				<< " with " << (fileSize - scan.validEnd)
 				<< " byte(s) of further data; leaving it intact to avoid discarding committed entries. "
 					"Reads past this point will fail until the file is repaired.";
+			DEBUG_LOG("%p TransactionLogFile::recoverTail WARNING: %s\n", this, msg.str().c_str());
 			emitGlobalEvent("log.warn", ListenerData::fromStrings({ msg.str() }));
 
 			return;
@@ -188,6 +189,7 @@ void TransactionLogFile::recoverTail() {
 				msg << "Transaction log " << this->path.string()
 					<< " had a torn tail; dropped " << (fileSize - scan.validEnd)
 					<< " partial byte(s) back to the last valid entry (new size=" << scan.validEnd << ").";
+				DEBUG_LOG("%p TransactionLogFile::recoverTail WARNING: %s\n", this, msg.str().c_str());
 				emitGlobalEvent("log.warn", ListenerData::fromStrings({ msg.str() }));
 			} else {
 				DEBUG_LOG("%p TransactionLogFile::recoverTail Truncate failed (or unsupported on this platform) for %s\n",

--- a/src/binding/transaction_log/transaction_log_file.cpp
+++ b/src/binding/transaction_log/transaction_log_file.cpp
@@ -1,7 +1,11 @@
 #include <cmath>
 #include <cstdio>
+#include <sstream>
 #include <system_error>
 #include <vector>
+#ifndef ROCKSDB_JS_NATIVE_TESTS
+	#include "napi/global_events.h"
+#endif
 #include "transaction_log_entry.h"
 #include "transaction_log_file.h"
 #include "transaction_log_recovery.h"
@@ -152,19 +156,30 @@ void TransactionLogFile::recoverTail() {
 		case RecoveryScan::Kind::Clean:
 			return;
 
-		case RecoveryScan::Kind::MidFileCorruption:
+		case RecoveryScan::Kind::MidFileCorruption: {
 			// Leave the file intact: entries are still framed after the break, so
 			// truncating would discard committed/replicated transactions. Surface
 			// it so an operator can repair the file; the reader's per-entry bounds
 			// checks refuse to return the broken frame.
 			DEBUG_LOG("%p TransactionLogFile::recoverTail Mid-file corruption at offset %u in %s (size=%u), leaving intact\n",
 				this, scan.validEnd, this->path.string().c_str(), fileSize);
-			::fprintf(stderr,
-				"[rocksdb-js] WARNING: transaction log %s has a framing break at offset %x with %u byte(s) of further "
-				"data; leaving it intact to avoid discarding committed entries. Reads past this point will fail until "
-				"the file is repaired.\n",
-				this->path.string().c_str(), scan.validEnd, fileSize - scan.validEnd);
+
+#ifndef ROCKSDB_JS_NATIVE_TESTS
+			// Surface to an operator via the global "log.warn" event. Skipped
+			// in native GoogleTest builds so this TU links without the N-API
+			// event-emitter machinery (recovery itself is the unit under test).
+			std::ostringstream msg;
+			msg << "Transaction log " << this->path.string()
+				<< " has a framing break at offset " << std::hex << scan.validEnd << std::dec
+				<< " with " << (fileSize - scan.validEnd)
+				<< " byte(s) of further data; leaving it intact to avoid discarding committed entries. "
+					"Reads past this point will fail until the file is repaired.";
+
+			emitGlobalEvent("log.warn", ListenerData::fromStrings({ msg.str() }));
+#endif
+
 			return;
+		}
 
 		case RecoveryScan::Kind::TruncateTail:
 			if (scan.validEnd >= fileSize) {

--- a/test/native/event_emitter_stub.cc
+++ b/test/native/event_emitter_stub.cc
@@ -1,0 +1,19 @@
+// Stub bodies for the slice of EventEmitter that low-level files
+// (transaction_log_file.cpp) transitively reference via emitGlobalEvent.
+// The native GoogleTest binary doesn't link the Node-API runtime, so the
+// real event_emitter.cpp — which calls napi_* — can't be included. These
+// stubs let recovery code emit warnings unchanged; the emission is a
+// no-op in test builds since there are no JS listeners to dispatch to.
+
+#include "napi/event_emitter.h"
+
+namespace rocksdb_js {
+
+bool EventEmitter::notify(const std::string& /*key*/, ListenerData* data) {
+	delete data;
+	return false;
+}
+
+void EventEmitter::releaseAll() {}
+
+} // namespace rocksdb_js

--- a/test/native/json_test.cc
+++ b/test/native/json_test.cc
@@ -1,0 +1,55 @@
+#include <gtest/gtest.h>
+#include <string>
+#include "core/json.h"
+
+using rocksdb_js::appendJsonString;
+using rocksdb_js::jsonString;
+
+TEST(Json, EmptyString) {
+	EXPECT_EQ(jsonString(""), "\"\"");
+}
+
+TEST(Json, PlainAscii) {
+	EXPECT_EQ(jsonString("hello world"), "\"hello world\"");
+}
+
+TEST(Json, EscapesDoubleQuote) {
+	EXPECT_EQ(jsonString("a\"b"), "\"a\\\"b\"");
+}
+
+TEST(Json, EscapesBackslash) {
+	// Mirrors a Windows path that previously broke the ad-hoc escaper:
+	// C:\foo\bar.log
+	EXPECT_EQ(jsonString("C:\\foo\\bar.log"), "\"C:\\\\foo\\\\bar.log\"");
+}
+
+TEST(Json, EscapesNamedControlChars) {
+	EXPECT_EQ(jsonString("\b\f\n\r\t"), "\"\\b\\f\\n\\r\\t\"");
+}
+
+TEST(Json, EscapesOtherControlCharsAsUnicode) {
+	// 0x01 has no named escape and must be emitted as .
+	EXPECT_EQ(jsonString(std::string("\x01", 1)), "\"\\u0001\"");
+	// 0x1f is the upper bound of the control range.
+	EXPECT_EQ(jsonString(std::string("\x1f", 1)), "\"\\u001f\"");
+}
+
+TEST(Json, PassesThroughHighBytesVerbatim) {
+	// UTF-8 multi-byte sequences (>= 0x80) round-trip without re-encoding.
+	// "ñ" is 0xC3 0xB1.
+	const std::string input = "\xC3\xB1";
+	const std::string expected = "\"\xC3\xB1\"";
+	EXPECT_EQ(jsonString(input), expected);
+}
+
+TEST(Json, AppendPreservesExistingOutput) {
+	std::string out = "prefix:";
+	appendJsonString(out, "x");
+	EXPECT_EQ(out, "prefix:\"x\"");
+}
+
+TEST(Json, EscapeCombination) {
+	// Mix of all escape categories in one input.
+	const std::string input = std::string("a\"b\\c\nd\x01" "e", 9);
+	EXPECT_EQ(jsonString(input), "\"a\\\"b\\\\c\\nd\\u0001e\"");
+}


### PR DESCRIPTION
## Summary
Two native call sites (`new-transaction-log` event in `db_handle.cpp`, and the new mid-file-corruption warning carried in from this branch's base in `transaction_log_file.cpp`) were each building JSON-array listener payloads inline. The escaping was buggy in both — `db_handle.cpp` only handled `"`, and the new `transaction_log_file.cpp` emission did no escaping at all, so a Windows path or a name with `\` or any control char would yield malformed JSON that the listener trampoline can't parse.

Centralized into:
- `core/json.h` — header-only `appendJsonString` / `jsonString`, RFC 8259-compliant.
- `ListenerData::fromStrings(initializer_list<string_view>)` — wraps escape + array assembly + the new/move boilerplate. Defined inline so files that only need this factory (e.g. recovery code in the native GoogleTest binary) get the implementation without linking the rest of `event_emitter.cpp`.

Both call sites collapse to one line.

## Where to look
- **`test/native/event_emitter_stub.cc`** — `transaction_log_file.cpp` is also linked into the GoogleTest binary, which has no N-API runtime. The stub supplies bodies for the two EventEmitter member symbols pulled in transitively via `emitGlobalEvent` (`EventEmitter::notify` and `releaseAll()` from the destructor). `notify` is a no-op that still takes ownership of the payload, matching the production contract. Production and test now run the same recovery path.
- **Open Codex finding (not addressed):** event name `log.warn` doesn't match the documented namespaced-key convention (`AGENTS.md` calls for `transactionLog:warning` for internal events). The name was set in the base branch's WIP, not by this refactor — flagging in case it should be renamed before either PR lands.
- **Lifetime of `string_view`s in `fromStrings({ msg.str() })`** — the `std::string` temporary lives to end-of-full-expression, which outlives the call. Safe but worth a glance.

## Testing
- New native GTest (`test/native/json_test.cc`) covers empty / plain ASCII / `"` / `\` / named control chars / `\u00XX` escapes / UTF-8 pass-through / append behavior / mixed escapes (9 cases).
- Existing `transaction-log.test.ts` `'new-transaction-log'` event test exercises the factory end-to-end.
- All 30 native GTests, 474 Vitest tests, `pnpm check` (type + lint + fmt) green.

🤖 Generated with Claude Opus 4.7 (1M context) via Claude Code