### PR TITLE
Strip the 'v' from the published version

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -297,7 +297,7 @@ jobs:
                     },
                     {
                       "type": "mrkdwn",
-                      "text": ":github: <https://github.com/HarperFast/rocksdb-js/releases/tag/v${{ github.event.release.tag_name }}|GitHub Release>"
+                      "text": ":github: <https://github.com/HarperFast/rocksdb-js/releases/tag/v${{ needs.preflight.outputs.version }}|GitHub Release>"
                     }
                   ]
                 }
@@ -312,8 +312,8 @@ jobs:
           token: ${{ secrets.GH_TOKEN }}
           client-payload: |
             {
-              "url": "https://github.com/HarperFast/rocksdb-js/releases/tag/v${{ github.event.release.tag_name }}",
-              "version": "${{ github.event.release.tag_name }}"
+              "url": "https://github.com/HarperFast/rocksdb-js/releases/tag/v${{ needs.preflight.outputs.version }}",
+              "version": "${{ needs.preflight.outputs.version }}"
             }
 
   on-publish-failure:


### PR DESCRIPTION
I noticed the npm published notifications have an extra 'v' because it's using the tag name instead of the scrubbed version.