### PR TITLE
Backport fix/evict-dropped-cf-on-reopen to v1.5.x (for 1.5.1)

### DIFF
--- a/src/binding/database/database.cpp
+++ b/src/binding/database/database.cpp
@@ -205,11 +205,16 @@ napi_value Database::Columns(napi_env env, napi_callback_info info) {
 	NAPI_METHOD();
 	UNWRAP_DB_HANDLE_AND_OPEN();
 
-	const auto& columns = (*dbHandle)->descriptor->columns;
 	std::vector<std::string> columnNames;
-	columnNames.reserve(columns.size());
-	for (const auto& [name, _column] : columns) {
-		columnNames.push_back(name);
+	{
+		// Snapshot under the columns mutex; a concurrent drop on another
+		// thread erases from this map.
+		std::lock_guard<std::mutex> columnsLock((*dbHandle)->descriptor->columnsMutex);
+		const auto& columns = (*dbHandle)->descriptor->columns;
+		columnNames.reserve(columns.size());
+		for (const auto& [name, _column] : columns) {
+			columnNames.push_back(name);
+		}
 	}
 	std::sort(columnNames.begin(), columnNames.end());
 
@@ -447,7 +452,11 @@ napi_value Database::Drop(napi_env env, napi_callback_info info) {
 		return nullptr;
 	}
 
-	(*dbHandle)->descriptor->tryUnregisterColumnFamily((*dbHandle)->getColumnFamilyName());
+	// The column family is gone from RocksDB; remove its by-name registry
+	// entry so a later open with the same name creates a fresh column family
+	// instead of reusing this dangling handle (which poisons write batches
+	// with "Invalid column family specified in write batch").
+	(*dbHandle)->descriptor->unregisterColumnFamily((*dbHandle)->getColumnFamilyName());
 
 	NAPI_STATUS_THROWS_ERROR(::napi_call_function(
 		env, global, resolve, 0, nullptr, nullptr
@@ -478,7 +487,11 @@ napi_value Database::DropSync(napi_env env, napi_callback_info info) {
 	DEBUG_LOG("%p Database::DropSync dropping database: %s\n", dbHandle->get(), (*dbHandle)->path.c_str());
 	ROCKSDB_STATUS_THROWS_ERROR_LIKE((*dbHandle)->descriptor->db->DropColumnFamily((*dbHandle)->getColumnFamilyHandle()), "Drop failed");
 
-	(*dbHandle)->descriptor->tryUnregisterColumnFamily((*dbHandle)->getColumnFamilyName());
+	// The column family is gone from RocksDB; remove its by-name registry
+	// entry so a later open with the same name creates a fresh column family
+	// instead of reusing this dangling handle (which poisons write batches
+	// with "Invalid column family specified in write batch").
+	(*dbHandle)->descriptor->unregisterColumnFamily((*dbHandle)->getColumnFamilyName());
 
 	DEBUG_LOG("%p Database::DropSync dropped database\n", dbHandle->get());
 	NAPI_RETURN_UNDEFINED();

--- a/src/binding/database/db_descriptor.cpp
+++ b/src/binding/database/db_descriptor.cpp
@@ -164,7 +164,17 @@ void DBDescriptor::close() {
 	// Trigger manual compaction on all column families to reclaim space from
 	// tombstones before closing
 	if (!this->readOnly && DBSettings::getInstance().getCompactOnClose()) {
-		for (const auto& [name, columnDesc] : this->columns) {
+		// Snapshot under the columns mutex; a concurrent drop can erase from
+		// the map while we compact.
+		std::vector<std::shared_ptr<ColumnFamilyDescriptor>> pinnedColumns;
+		{
+			std::lock_guard<std::mutex> columnsLock(this->columnsMutex);
+			pinnedColumns.reserve(this->columns.size());
+			for (const auto& [name, columnDesc] : this->columns) {
+				pinnedColumns.push_back(columnDesc);
+			}
+		}
+		for (const auto& columnDesc : pinnedColumns) {
 			if (columnDesc && columnDesc->column) {
 				this->compactRange(columnDesc->column.get(), nullptr, nullptr);
 			}
@@ -202,7 +212,10 @@ void DBDescriptor::close() {
 	TransactionLogStoreRegistry::Unregister(this->path);
 
 	this->transactions.clear();
-	this->columns.clear();
+	{
+		std::lock_guard<std::mutex> columnsLock(this->columnsMutex);
+		this->columns.clear();
+	}
 
 	this->events.releaseAll();
 
@@ -843,39 +856,21 @@ uint32_t DBDescriptor::transactionGetNextId() {
 }
 
 /**
- * Attempts to unregister a column family from the descriptor. This will only
- * remove the column family from the columns map if there is at most one
- * DBHandle still referencing it (the one performing the drop).
+ * Removes a dropped column family from the columns map so a later open-by-name
+ * creates a fresh column family instead of reusing the dangling dropped
+ * handle. DBHandles still holding the descriptor keep it alive via their
+ * shared_ptr and can continue reading until they close; only the by-name
+ * lookup is removed.
  */
-bool DBDescriptor::tryUnregisterColumnFamily(const std::string& columnName) {
-	auto it = this->columns.find(columnName);
-	if (it == this->columns.end()) {
-		DEBUG_LOG("%p DBDescriptor::tryUnregisterColumnFamily column \"%s\" not found\n",
+void DBDescriptor::unregisterColumnFamily(const std::string& columnName) {
+	std::lock_guard<std::mutex> lock(this->columnsMutex);
+	if (this->columns.erase(columnName)) {
+		DEBUG_LOG("%p DBDescriptor::unregisterColumnFamily unregistered column \"%s\"\n",
 			this, columnName.c_str());
-		return false;
-	}
-
-	// Check the reference count on the ColumnFamilyDescriptor shared_ptr.
-	// References are held by:
-	// - 1: the columns map entry
-	// - 1: each DBHandle that has this column family open
-	// So if use_count <= 2, only the map and the calling DBHandle hold references.
-	long refCount = it->second.use_count();
-
-	DEBUG_LOG("%p DBDescriptor::tryUnregisterColumnFamily column \"%s\" has %ld references\n",
-		this, columnName.c_str(), refCount);
-
-	// Only unregister if there's at most 2 references (map + the DBHandle doing the drop)
-	if (refCount <= 2) {
-		this->columns.erase(it);
-		DEBUG_LOG("%p DBDescriptor::tryUnregisterColumnFamily unregistered column \"%s\"\n",
+	} else {
+		DEBUG_LOG("%p DBDescriptor::unregisterColumnFamily column \"%s\" not found\n",
 			this, columnName.c_str());
-		return true;
 	}
-
-	DEBUG_LOG("%p DBDescriptor::tryUnregisterColumnFamily column \"%s\" still has %ld other references, not unregistering\n",
-		this, columnName.c_str(), refCount - 2);
-	return false;
 }
 
 /**
@@ -1449,10 +1444,21 @@ rocksdb::Status DBDescriptor::flush() {
 		return rocksdb::Status::OK();
 	}
 
-	// Convert columns map to vector of ColumnFamilyHandle*
+	// Snapshot the column family descriptors under the columns mutex. flush()
+	// can run on a libuv worker thread while the JS thread drops a column
+	// family (which erases from the map); the shared_ptr copies also pin the
+	// handles so they cannot be destroyed mid-Flush.
+	std::vector<std::shared_ptr<ColumnFamilyDescriptor>> pinnedColumns;
+	{
+		std::lock_guard<std::mutex> lock(this->columnsMutex);
+		pinnedColumns.reserve(this->columns.size());
+		for (const auto& [name, columnDescriptor] : this->columns) {
+			pinnedColumns.push_back(columnDescriptor);
+		}
+	}
 	std::vector<rocksdb::ColumnFamilyHandle*> columnHandles;
-	columnHandles.reserve(this->columns.size());
-	for (const auto& [name, columnDescriptor] : this->columns) {
+	columnHandles.reserve(pinnedColumns.size());
+	for (const auto& columnDescriptor : pinnedColumns) {
 		columnHandles.push_back(columnDescriptor->column.get());
 	}
 	// Perform flush

--- a/src/binding/database/db_descriptor.h
+++ b/src/binding/database/db_descriptor.h
@@ -84,6 +84,17 @@ struct DBDescriptor final : public std::enable_shared_from_this<DBDescriptor> {
 	std::unordered_map<std::string, std::shared_ptr<ColumnFamilyDescriptor>> columns;
 
 	/**
+	 * Mutex to protect the columns map. Column families can be unregistered on
+	 * drop (see `unregisterColumnFamily`) while other threads iterate the map:
+	 * the JS thread via the `columns` getter or `DBRegistry::OpenDB`, libuv
+	 * worker threads via `flush()`, and a closing thread via `close()`. Lock
+	 * ordering: when both are held, `DBRegistry::databasesMutex` is acquired
+	 * BEFORE `columnsMutex`; `columnsMutex` is never held while acquiring the
+	 * registry mutex.
+	 */
+	std::mutex columnsMutex;
+
+	/**
 	 * The RocksDB statistics instance.
 	 */
 	std::shared_ptr<rocksdb::Statistics> statistics;
@@ -234,15 +245,15 @@ public:
 	uint32_t transactionGetNextId();
 
 	/**
-	 * Attempts to unregister a column family from the descriptor. This will
-	 * only remove the column family from the columns map if there is at most
-	 * one DBHandle still referencing it (the one performing the drop).
+	 * Removes a dropped column family from the columns map (under
+	 * `columnsMutex`) so a later open-by-name creates a fresh column family
+	 * instead of reusing the dangling dropped handle. DBHandles still holding
+	 * the descriptor keep it alive via their shared_ptr; only the by-name
+	 * lookup is removed.
 	 *
-	 * @param columnName The name of the column family to unregister.
-	 * @returns true if the column family was unregistered, false if other
-	 *          DBHandles are still referencing it.
+	 * @param columnName The name of the dropped column family.
 	 */
-	bool tryUnregisterColumnFamily(const std::string& columnName);
+	void unregisterColumnFamily(const std::string& columnName);
 
 	/**
 	 * Creates a new user shared buffer or returns an existing one.

--- a/src/binding/database/db_registry.cpp
+++ b/src/binding/database/db_registry.cpp
@@ -237,7 +237,11 @@ std::unique_ptr<DBHandleParams> DBRegistry::OpenDB(const std::string& path, cons
 		DEBUG_LOG("%p DBRegistry::OpenDB Database already open \"%s\"\n", instance.get(), path.c_str());
 		DEBUG_LOG("%p DBRegistry::OpenDB Checking for column family \"%s\"\n", instance.get(), name.c_str());
 
-		// manually copy the columns because we don't know which ones are valid
+		// manually copy the columns because we don't know which ones are valid.
+		// Hold the descriptor's columns mutex across the copy-check-insert so a
+		// concurrent drop (which erases its entry via unregisterColumnFamily)
+		// cannot interleave and let us reuse a just-dropped column family.
+		std::lock_guard<std::mutex> columnsLock(entry.descriptor->columnsMutex);
 		bool columnExists = false;
 		for (auto& it : entry.descriptor->columns) {
 			columns[it.first] = it.second;

--- a/test/drop.test.ts
+++ b/test/drop.test.ts
@@ -1,3 +1,4 @@
+import { RocksDatabase } from '../src/index.js';
 import { dbRunner } from './lib/util.js';
 import { describe, expect, it } from 'vitest';
 
@@ -54,55 +55,52 @@ describe('Drop', () => {
 			expect(db.getSync('key')).toBeUndefined();
 		}));
 
-	it('should drop a column family with two database instances', () =>
+	// Regression test for the "ghost table" bug: a drop must free the column
+	// family name immediately, even while other instances still hold the
+	// dropped column family open. Before the fix, the dropped entry stayed in
+	// the registry's by-name map whenever any other handle referenced it, so a
+	// reopen-by-name reused the dangling handle and every write failed with
+	// "Invalid column family specified in write batch" until a full process
+	// restart.
+	it('should free the column family name immediately on drop, even with another instance holding it', () =>
 		dbRunner(
 			{ dbOptions: [{ name: 'test' }, { name: 'test' }] },
-			async ({ db: db1 }, { db: db2 }) => {
+			async ({ db: db1, dbPath }, { db: db2 }) => {
 				db1.putSync('key', 'value');
 				db2.putSync('key2', 'value2');
-				expect(db1.getSync('key')).toBe('value');
-				expect(db2.getSync('key2')).toBe('value2');
 				expect(db1.columns).toEqual(['default', 'test']);
 				expect(db2.columns).toEqual(['default', 'test']);
+
 				await db1.drop();
-				expect(db1.columns).toEqual(['default', 'test']);
-				expect(db2.columns).toEqual(['default', 'test']);
-				expect(db1.getSync('key')).toBe('value');
+
+				// the name is freed immediately: the registry no longer lists it
+				expect(db1.columns).toEqual(['default']);
+				expect(db2.columns).toEqual(['default']);
+
+				// an instance still holding the dropped column family can read it
+				// until it closes
+				expect(db2.getSync('key')).toBe('value');
 				expect(db2.getSync('key2')).toBe('value2');
 
-				// close db1, db2 will keep column family alive
-				db1.close();
-				db1.open();
-				expect(db1.getSync('key')).toBe('value');
-				expect(db2.getSync('key2')).toBe('value2');
-				expect(db1.columns).toEqual(['default', 'test']);
-				expect(db2.columns).toEqual(['default', 'test']);
+				// reopening by the same name creates a fresh, WRITABLE column
+				// family instead of reusing the dropped handle
+				const db3 = RocksDatabase.open(dbPath, { name: 'test' });
+				try {
+					db3.putSync('key3', 'value3');
+					expect(db3.getSync('key3')).toBe('value3');
+					// the fresh column family does not see the dropped data
+					expect(db3.getSync('key')).toBeUndefined();
+					expect(db3.columns).toEqual(['default', 'test']);
+				} finally {
+					db3.close();
+				}
 
-				// close db1 and reopen it, then do the same to db2, keeping column family alive
-				db1.close();
-				expect(db2.columns).toEqual(['default', 'test']);
-				db1.open();
-				expect(db1.columns).toEqual(['default', 'test']);
-				expect(db2.columns).toEqual(['default', 'test']);
-				db2.close();
-				expect(db1.columns).toEqual(['default', 'test']);
-				db2.open();
-				expect(db1.columns).toEqual(['default', 'test']);
-				expect(db2.columns).toEqual(['default', 'test']);
-
-				expect(db1.getSync('key')).toBe('value');
-				expect(db2.getSync('key2')).toBe('value2');
-
-				// close both databases, column family should be deleted
-				db1.close();
-				db2.close();
-				db1.open();
-				expect(db1.columns).toEqual(['default', 'test']);
-				db2.open();
-				expect(db1.columns).toEqual(['default', 'test']);
-				expect(db2.columns).toEqual(['default', 'test']);
-				expect(db1.getSync('key')).toBeUndefined();
-				expect(db2.getSync('key2')).toBeUndefined();
+				// writes through the dropped handle fail. NOTE: this must stay the
+				// LAST assertion - the failed write contaminates the env's shared
+				// write path, so writes through OTHER handles in this database fail
+				// afterward too (the same poison the eviction fix prevents callers
+				// from triggering accidentally via reopen-by-name)
+				expect(() => db2.putSync('key4', 'value4')).toThrow();
 			}
 		));
 });


### PR DESCRIPTION
## Summary

Conflict-free cherry-pick of #647 onto `v1.5.x`: free a column family name immediately on drop so same-name recreates get a fresh column family instead of the dangling dropped handle. Fixes Harper's ghost-table failures.

Replaces #648 per @cb1kenobi: no further 1.4 releases now that 1.5 is out. harper-pro 5.0.x pins `^1.4.2`, which a **1.5.1** release satisfies, so the delivery path to existing 5.0.x deployments is unchanged (harper-pro patch release resolves it at build).

## Validation

- Cherry-pick applied with zero conflicts (same call sites as main and 1.4.x).
- Local build clean on this line; drop suite passes (6/6) including the new multi-handle regression test.
- The identical change was e2e-validated against live harper-pro 5.0.27 on a 2-node Fabric repro cluster via the 1.4.2 backport build (see #647 and #648 for details): drop + same-name recreate + insert works, no env poisoning, no wedged creates, clean drops stay dropped across restart.

See #647 for the full root-cause description and the drop-semantics discussion.

Note: release is tag-driven; no package.json bump here, release owner tags v1.5.1.

Generated by an AI agent (Claude).

🤖 Generated with [Claude Code](https://claude.com/claude-code)