### PR TITLE
Bound transaction-log reader limit by mapped buffer length

### DIFF
--- a/src/transaction-log-reader.ts
+++ b/src/transaction-log-reader.ts
@@ -173,12 +173,16 @@ Object.defineProperty(TransactionLog.prototype, 'query', {
 
 					// Corruption bound: a committed read can't legitimately extend past
 					// the committed `size` (a true entry boundary); an uncommitted read is
-					// bounded only by the physically mapped buffer. A torn/corrupt entry
+					// bounded only by the physically mapped buffer. In both cases the bound
+					// is also clamped to `logBuffer.length` — if committed `size` over-reports
+					// the mapped buffer (e.g. a truncated/torn file), an unclamped `size`
+					// would let `position` advance past the buffer and `subarray` silently
+					// return a truncated frame instead of throwing. A torn/corrupt entry
 					// can declare a length far past this bound — without the checks below,
 					// `position` runs past the buffer, `subarray` hands back a misframed
 					// (garbage) transaction, and the advance-to-next-log path can
 					// dereference an undefined buffer. Fail loudly with a bounded error.
-					const limit = readUncommitted ? logBuffer!.length : size;
+					const limit = readUncommitted ? logBuffer!.length : Math.min(size, logBuffer!.length);
 					if (position + TRANSACTION_LOG_ENTRY_HEADER_SIZE > limit) {
 						throw new RangeError(
 							`Corrupt transaction log: truncated entry header at position ${position.toString(16)} of log ${

--- a/test/transaction-log.test.ts
+++ b/test/transaction-log.test.ts
@@ -1454,6 +1454,58 @@ describe('Transaction Log', () => {
 				(log as { _currentLogBuffer?: unknown })._currentLogBuffer = undefined;
 				expect(Array.from(log.query({ start: 0 })).length).toBe(3);
 			}));
+
+		it('query() throws a bounded RangeError when committed size over-reports the mapped buffer (#623)', () =>
+			dbRunner(async ({ db }) => {
+				const log = db.useLog('foo');
+				const value = Buffer.alloc(10, 'a');
+				for (let i = 0; i < 3; i++) {
+					await db.transaction(async (txn) => {
+						log.addEntry(value, txn.id);
+					});
+				}
+				// prime the query path so _lastCommittedPosition / _logBuffers init
+				expect(Array.from(log.query({ start: 0 })).length).toBe(3);
+
+				// Extract the committed size (low 32 bits of the position word). The last
+				// entry's header is fully present and well-formed; only the underlying
+				// buffer is short. This models a torn/truncated file (or page-rounded mmap
+				// shrink) where committed `size` legitimately exceeds the physical buffer.
+				const committedWord = new Uint32Array(
+					new Float64Array([log._lastCommittedPosition![0]]).buffer
+				);
+				const committedSize = committedWord[0];
+
+				// Return a buffer truncated mid-way through the final entry's data: the
+				// frame's declared length still fits within `committedSize`, but reading it
+				// would run past the physical buffer. Without bounding `limit` by the buffer
+				// length, `subarray` would silently hand back a truncated (misframed) entry.
+				const real = log._getMemoryMapOfFile(1)!;
+				const truncatedLength = committedSize - 5;
+				const copyBuffer = Buffer.from(new ArrayBuffer(truncatedLength));
+				real.copy(copyBuffer, 0, 0, truncatedLength);
+
+				log._logBuffers.clear();
+				(log as { _currentLogBuffer?: unknown })._currentLogBuffer = undefined;
+				const realDescriptor = Object.getOwnPropertyDescriptor(
+					Object.getPrototypeOf(log),
+					'_getMemoryMapOfFile'
+				)!;
+				Object.defineProperty(log, '_getMemoryMapOfFile', {
+					value: () => copyBuffer,
+					configurable: true,
+					writable: true,
+				});
+				try {
+					expect(() => Array.from(log.query({ start: 0 }))).toThrow(/overruns the log/);
+				} finally {
+					Object.defineProperty(log, '_getMemoryMapOfFile', realDescriptor);
+				}
+				// once the real mmap is restored, the valid data must still be readable
+				log._logBuffers.clear();
+				(log as { _currentLogBuffer?: unknown })._currentLogBuffer = undefined;
+				expect(Array.from(log.query({ start: 0 })).length).toBe(3);
+			}));
 	});
 
 	describe('crash recovery (truncate-on-open)', () => {


### PR DESCRIPTION
## Summary

Bounds the committed-read `limit` in the transaction-log reader by the physical buffer length to close a silent-truncation gap. Fixes #623.

## Purpose

In [src/transaction-log-reader.ts](src/transaction-log-reader.ts#L181), the committed-read bound was `limit = size` (the committed position). If committed `size` over-reports the physically mapped buffer — e.g. a truncated or torn log file — `position` could advance past the buffer end, and `logBuffer.subarray(entryStart, position)` silently returns a truncated, misframed transaction instead of throwing. The fix clamps the bound to `Math.min(size, logBuffer.length)` so any overrun trips the existing `RangeError` guard.

## Where to look

- **The clamp is a no-op in normal operation.** The native mmap (`getMemoryMap` in [transaction_log_file_posix.cpp](src/binding/transaction_log/transaction_log_file_posix.cpp#L133)) sizes the mapped region to `fileSize` and zero-pads beyond the committed extent, so `logBuffer.length >= size` normally. The clamp only engages when the buffer is physically shorter than the reported `size` (the corruption case), so there is no regression risk for legitimate reads.
- The regression test maps a buffer truncated mid-final-entry while committed `size` still reports the full extent; verified to **fail without the fix** (silent truncation) and **pass with it** (bounded `RangeError`).

## Review notes

- Codex cross-model review: no actionable issues.
- The Gemini (`agy`) reviewer was non-functional in this environment (returned empty output even for a trivial prompt), so the second cross-model review could not be completed. Flagging for the human reviewer.

Generated by an LLM (Claude Opus 4.8).