### PR TITLE
Add opt-in entry counts to purgeLogs()

### DIFF
--- a/src/binding/transaction_log/transaction_log_file.cpp
+++ b/src/binding/transaction_log/transaction_log_file.cpp
@@ -1,4 +1,6 @@
 #include <cmath>
+#include <fstream>
+#include <limits>
 #include <sstream>
 #include <system_error>
 #include <vector>
@@ -204,6 +206,56 @@ void TransactionLogFile::recoverTail() {
 					this, this->path.string().c_str());
 			}
 			return;
+	}
+}
+
+uint32_t TransactionLogFile::countEntries() const {
+	// Counting must never abort a purge, so swallow every failure (I/O errors and
+	// a std::bad_alloc from the whole-file buffer below) and report 0.
+	try {
+		std::error_code ec;
+		auto onDiskSize = std::filesystem::file_size(this->path, ec);
+		if (ec || onDiskSize <= TRANSACTION_LOG_FILE_HEADER_SIZE) {
+			// missing, empty, or header-only: no entries
+			return 0;
+		}
+		if (onDiskSize > std::numeric_limits<uint32_t>::max()) {
+			// transaction log files are bounded well under 4 GiB; refuse an absurd size
+			DEBUG_LOG("%p TransactionLogFile::countEntries File too large to count: %s (size=%llu)\n",
+				this, this->path.string().c_str(), static_cast<unsigned long long>(onDiskSize));
+			return 0;
+		}
+
+		auto fileSize = static_cast<uint32_t>(onDiskSize);
+		std::vector<char> buffer(fileSize);
+
+		// Read through a fresh handle rather than this->fd: old purgeable files are
+		// never opened (only the current sequence file is), and the read must work
+		// regardless. POSIX/Windows both share read access, so this is safe even when
+		// the file is concurrently open.
+		std::ifstream stream(this->path, std::ios::binary);
+		if (!stream) {
+			DEBUG_LOG("%p TransactionLogFile::countEntries Failed to open file for counting: %s\n",
+				this, this->path.string().c_str());
+			return 0;
+		}
+		stream.read(buffer.data(), fileSize);
+		auto bytesRead = stream.gcount();
+		if (bytesRead < 0) {
+			return 0;
+		}
+		if (static_cast<uint32_t>(bytesRead) != fileSize) {
+			// short read (e.g. the file shrank); count only what we actually read
+			DEBUG_LOG("%p TransactionLogFile::countEntries Short read while counting: %s (read=%lld, size=%u)\n",
+				this, this->path.string().c_str(), static_cast<long long>(bytesRead), fileSize);
+			fileSize = static_cast<uint32_t>(bytesRead);
+		}
+
+		return countTransactionLogEntries(buffer.data(), fileSize);
+	} catch (...) {
+		DEBUG_LOG("%p TransactionLogFile::countEntries Failed to count entries: %s\n",
+			this, this->path.string().c_str());
+		return 0;
 	}
 }
 

--- a/src/binding/transaction_log/transaction_log_file.h
+++ b/src/binding/transaction_log/transaction_log_file.h
@@ -221,6 +221,17 @@ struct TransactionLogFile final {
 	bool removeFile();
 
 	/**
+	 * Counts the committed entry frames in this log file by reading its on-disk
+	 * image and walking the v1 framing. Used by purge to report how many entries
+	 * each removed file held; counting is extra work, so it runs only when the
+	 * caller opts in. Cold path (purge only). Never throws — returns 0 if the
+	 * file is missing, unreadable, or malformed (a purge must not be aborted by a
+	 * counting failure). Reads through a fresh handle so it works whether or not
+	 * this file is currently open (POSIX uses pread; Windows shares read access).
+	 */
+	uint32_t countEntries() const;
+
+	/**
 	 * Writes a batch of transaction log entries to the log file.
 	 *
 	 * @param batch The batch of entries to write with state tracking.

--- a/src/binding/transaction_log/transaction_log_recovery.cpp
+++ b/src/binding/transaction_log/transaction_log_recovery.cpp
@@ -92,4 +92,28 @@ RecoveryScan scanTransactionLogForRecovery(const char* data, uint32_t fileSize) 
 	}
 }
 
+uint32_t countTransactionLogEntries(const char* data, uint32_t fileSize) {
+	if (fileSize <= TRANSACTION_LOG_FILE_HEADER_SIZE) {
+		return 0;
+	}
+
+	uint32_t count = 0;
+	uint32_t pos = TRANSACTION_LOG_FILE_HEADER_SIZE;
+	while (static_cast<uint64_t>(pos) + TRANSACTION_LOG_ENTRY_HEADER_SIZE <= fileSize) {
+		if (readDoubleBE(data + pos) == 0) {
+			// zero padding marks the end of entries (matches the reader/parser)
+			break;
+		}
+		uint32_t length = readUint32BE(data + pos + 8);
+		if (length == 0 ||
+			static_cast<uint64_t>(pos) + TRANSACTION_LOG_ENTRY_HEADER_SIZE + length > fileSize) {
+			// broken/torn frame; stop at the last well-formed entry
+			break;
+		}
+		++count;
+		pos += TRANSACTION_LOG_ENTRY_HEADER_SIZE + length;
+	}
+	return count;
+}
+
 } // namespace rocksdb_js

--- a/src/binding/transaction_log/transaction_log_recovery.h
+++ b/src/binding/transaction_log/transaction_log_recovery.h
@@ -50,6 +50,19 @@ struct RecoveryScan final {
  */
 RecoveryScan scanTransactionLogForRecovery(const char* data, uint32_t fileSize);
 
+/**
+ * Counts the well-formed v1 entry frames in an in-memory transaction log image.
+ * Pure (no I/O) so it can be unit-tested standalone, and shares the framing walk
+ * with scanTransactionLogForRecovery(). The file header is assumed already
+ * validated by the caller; counting begins at the first entry and stops at the
+ * first zero-timestamp marker, EOF, or a broken/torn frame — yielding the same
+ * entry count parseTransactionLog() reports for a clean file.
+ *
+ * @param data     Pointer to the full file image.
+ * @param fileSize Number of bytes in `data`.
+ */
+uint32_t countTransactionLogEntries(const char* data, uint32_t fileSize);
+
 } // namespace rocksdb_js
 
 #endif

--- a/src/binding/transaction_log/transaction_log_store.cpp
+++ b/src/binding/transaction_log/transaction_log_store.cpp
@@ -427,13 +427,13 @@ void TransactionLogStore::collectStats(TransactionLogStoreStats& out) {
 	}
 }
 
-void TransactionLogStore::purge(std::function<void(const std::filesystem::path&)> visitor, const bool all, const uint64_t before) {
+void TransactionLogStore::purge(std::function<void(const std::filesystem::path&, uint32_t entryCount)> visitor, const bool all, const uint64_t before, const bool countEntries) {
 	std::lock_guard<std::mutex> lock(this->writeMutex);
 	std::lock_guard<std::mutex> dataSetsLock(this->dataSetsMutex);
-	this->doPurge(visitor, all, before);
+	this->doPurge(visitor, all, before, countEntries);
 }
 
-void TransactionLogStore::doPurge(std::function<void(const std::filesystem::path&)> visitor, const bool all, const uint64_t before) {
+void TransactionLogStore::doPurge(std::function<void(const std::filesystem::path&, uint32_t entryCount)> visitor, const bool all, const uint64_t before, const bool countEntries) {
 	if (this->sequenceFiles.empty()) {
 		return;
 	}
@@ -495,6 +495,10 @@ void TransactionLogStore::doPurge(std::function<void(const std::filesystem::path
 			continue;
 		}
 
+		// count the entries before removing the file (counting is opt-in extra
+		// work; the file is gone by the time the visitor runs)
+		uint32_t entryCount = (visitor && countEntries) ? logFile->countEntries() : 0;
+
 		// delete the log file
 		uint32_t removedSize = logFile->size.load(std::memory_order_relaxed);
 		auto removed = logFile->removeFile();
@@ -504,7 +508,7 @@ void TransactionLogStore::doPurge(std::function<void(const std::filesystem::path
 		this->filesPurged.fetch_add(1, std::memory_order_relaxed);
 		this->bytesPurged.fetch_add(removedSize, std::memory_order_relaxed);
 		if (visitor) {
-			visitor(logFile->path);
+			visitor(logFile->path, entryCount);
 		}
 
 		// collect sequence number for removal

--- a/src/binding/transaction_log/transaction_log_store.h
+++ b/src/binding/transaction_log/transaction_log_store.h
@@ -435,9 +435,10 @@ struct TransactionLogStore final {
 	 * than the specified timestamp. If `all` is true, it deletes all transaction log files.
 	 */
 	void purge(
-		std::function<void(const std::filesystem::path&)> visitor,
+		std::function<void(const std::filesystem::path&, uint32_t entryCount)> visitor,
 		const bool all,
-		const uint64_t before
+		const uint64_t before,
+		const bool countEntries = false
 	);
 
 	/**
@@ -484,9 +485,10 @@ private:
 	std::shared_ptr<TransactionLogFile> getLogFile(const uint32_t sequenceNumber);
 
 	void doPurge(
-		std::function<void(const std::filesystem::path&)> visitor = nullptr,
+		std::function<void(const std::filesystem::path&, uint32_t entryCount)> visitor = nullptr,
 		const bool all = false,
-		const uint64_t before = 0
+		const uint64_t before = 0,
+		const bool countEntries = false
 	);
 
 	/**

--- a/src/binding/transaction_log/transaction_log_store_registry.cpp
+++ b/src/binding/transaction_log/transaction_log_store_registry.cpp
@@ -300,6 +300,9 @@ napi_value TransactionLogStoreRegistry::PurgeStores(napi_env env, const std::str
 	bool destroy = false;
 	NAPI_STATUS_THROWS(rocksdb_js::getProperty(env, options, "destroy", destroy));
 
+	bool includeEntryCounts = false;
+	NAPI_STATUS_THROWS(rocksdb_js::getProperty(env, options, "includeEntryCounts", includeEntryCounts));
+
 	std::string name;
 	NAPI_STATUS_THROWS(rocksdb_js::getProperty(env, options, "name", name));
 
@@ -334,12 +337,23 @@ napi_value TransactionLogStoreRegistry::PurgeStores(napi_env env, const std::str
 
 	// Phase 2: Process stores WITHOUT holding storesMutex
 	for (auto& store : storesToPurge) {
-		store->purge([&](const std::filesystem::path& filePath) -> void {
-			napi_value logFileValue;
+		store->purge([&](const std::filesystem::path& filePath, uint32_t entryCount) -> void {
 			auto path = filePath.string();
-			NAPI_STATUS_THROWS_VOID(::napi_create_string_utf8(env, path.c_str(), path.length(), &logFileValue));
-			NAPI_STATUS_THROWS_VOID(::napi_set_element(env, removed, i++, logFileValue));
-		}, destroy, before);
+			napi_value pathValue;
+			NAPI_STATUS_THROWS_VOID(::napi_create_string_utf8(env, path.c_str(), path.length(), &pathValue));
+
+			napi_value element = pathValue;
+			if (includeEntryCounts) {
+				// opt-in shape: { path: string, entries: number }
+				NAPI_STATUS_THROWS_VOID(::napi_create_object(env, &element));
+				NAPI_STATUS_THROWS_VOID(::napi_set_named_property(env, element, "path", pathValue));
+				napi_value entriesValue;
+				NAPI_STATUS_THROWS_VOID(::napi_create_uint32(env, entryCount, &entriesValue));
+				NAPI_STATUS_THROWS_VOID(::napi_set_named_property(env, element, "entries", entriesValue));
+			}
+
+			NAPI_STATUS_THROWS_VOID(::napi_set_element(env, removed, i++, element));
+		}, destroy, before, includeEntryCounts);
 
 		if (destroy) {
 			store->tryClose();

--- a/src/database.ts
+++ b/src/database.ts
@@ -7,6 +7,7 @@ import {
 	globalListenerCount,
 	globalNotify,
 	removeGlobalListener,
+	type PurgedLog,
 	type PurgeLogsOptions,
 	type RocksDatabaseConfig,
 	type NativeTransactionOptions,
@@ -672,8 +673,15 @@ export class RocksDatabase extends DBI<DBITransactional> {
 
 	/**
 	 * Purges transaction logs.
+	 *
+	 * By default returns the paths of the deleted log files. Pass
+	 * `includeEntryCounts: true` to instead return, for each deleted file, its
+	 * path and the number of entries it held (`{ path, entries }`).
 	 */
-	purgeLogs(options?: PurgeLogsOptions): string[] {
+	purgeLogs(options: PurgeLogsOptions & { includeEntryCounts: true }): PurgedLog[];
+	purgeLogs(options?: PurgeLogsOptions & { includeEntryCounts?: false }): string[];
+	purgeLogs(options?: PurgeLogsOptions): string[] | PurgedLog[];
+	purgeLogs(options?: PurgeLogsOptions): string[] | PurgedLog[] {
 		return this.store.db.purgeLogs(options);
 	}
 

--- a/src/load-binding.ts
+++ b/src/load-binding.ts
@@ -223,7 +223,22 @@ type RejectCallback = (err: Error) => void;
 
 export type UserSharedBufferCallback = () => void;
 
-export type PurgeLogsOptions = { before?: number; destroy?: boolean; name?: string };
+export type PurgeLogsOptions = {
+	before?: number;
+	destroy?: boolean;
+	/**
+	 * When `true`, count the entries in each purged log file (extra work) and
+	 * return `PurgedLog[]` instead of the default `string[]` of file paths.
+	 */
+	includeEntryCounts?: boolean;
+	name?: string;
+};
+
+/**
+ * A purged transaction log file and the number of entries it held, returned by
+ * `purgeLogs()` when `includeEntryCounts` is `true`.
+ */
+export type PurgedLog = { path: string; entries: number };
 
 export type NativeDatabase = {
 	new (): NativeDatabase;
@@ -279,7 +294,9 @@ export type NativeDatabase = {
 	opened: boolean;
 	open(path: string, options?: NativeDatabaseOptions): void;
 	populateVersion(keyLengthOrKeyBuffer: number | Buffer, version: number): void;
-	purgeLogs(options?: PurgeLogsOptions): string[];
+	purgeLogs(options: PurgeLogsOptions & { includeEntryCounts: true }): PurgedLog[];
+	purgeLogs(options?: PurgeLogsOptions & { includeEntryCounts?: false }): string[];
+	purgeLogs(options?: PurgeLogsOptions): string[] | PurgedLog[];
 	putSync(key: BufferWithDataView, value: any, txnId?: number): void;
 	removeListener(event: string | BufferWithDataView, callback: () => void): boolean;
 	removeSync(key: BufferWithDataView, txnId?: number): void;

--- a/test/native/transaction_log_recovery_test.cc
+++ b/test/native/transaction_log_recovery_test.cc
@@ -9,6 +9,7 @@
 #include "transaction_log/transaction_log_file.h"
 #include "transaction_log/transaction_log_recovery.h"
 
+using rocksdb_js::countTransactionLogEntries;
 using rocksdb_js::RecoveryScan;
 using rocksdb_js::scanTransactionLogForRecovery;
 
@@ -173,4 +174,43 @@ TEST(TransactionLogRecovery, ZeroLengthFrameAtTailTruncates) {
 	auto scan = scanTransactionLogForRecovery(img.data(), img.size());
 	EXPECT_EQ(scan.kind, RecoveryScan::Kind::TruncateTail);
 	EXPECT_EQ(scan.validEnd, tornStart);
+}
+
+TEST(TransactionLogCount, HeaderOnlyHasNoEntries) {
+	LogImage img; // just the 13-byte header
+	EXPECT_EQ(countTransactionLogEntries(img.data(), img.size()), 0u);
+}
+
+TEST(TransactionLogCount, CountsEntriesEndingOnBoundary) {
+	LogImage img;
+	img.entry(10).entry(20).entry(30);
+	EXPECT_EQ(countTransactionLogEntries(img.data(), img.size()), 3u);
+}
+
+TEST(TransactionLogCount, StopsAtZeroPaddedTail) {
+	LogImage img;
+	img.entry(10).entry(20);
+	img.zeros(64); // trailing zero padding must not be counted as entries
+	EXPECT_EQ(countTransactionLogEntries(img.data(), img.size()), 2u);
+}
+
+TEST(TransactionLogCount, StopsAtTornTail) {
+	LogImage img;
+	img.entry(10).entry(20);
+	// header claims 5000 bytes of data but only 12 are present before EOF
+	img.entryRaw(/*declaredLength=*/5000, /*actualDataLen=*/12);
+	EXPECT_EQ(countTransactionLogEntries(img.data(), img.size()), 2u);
+}
+
+TEST(TransactionLogCount, StopsAtPartialHeader) {
+	LogImage img;
+	img.entry(10).entry(20);
+	img.raw({ 0x42, 0x79, 0x05 }); // fewer than a full entry header remains
+	EXPECT_EQ(countTransactionLogEntries(img.data(), img.size()), 2u);
+}
+
+TEST(TransactionLogCount, CountsLargeEntryExceedingRotationSize) {
+	LogImage img;
+	img.entry(10).entry(64 * 1024).entry(20);
+	EXPECT_EQ(countTransactionLogEntries(img.data(), img.size()), 3u);
 }

--- a/test/transaction-log.test.ts
+++ b/test/transaction-log.test.ts
@@ -1601,6 +1601,68 @@ describe('Transaction Log', () => {
 	});
 
 	describe('purgeLogs', () => {
+		// Build a transaction log file image with a valid header followed by
+		// `entryCount` well-formed v1 entry frames so the native counter has real
+		// framing to walk.
+		const buildLogFile = (entryCount: number, dataLen = 10): Buffer => {
+			const header = Buffer.alloc(TRANSACTION_LOG_FILE_HEADER_SIZE);
+			header.writeUInt32BE(TRANSACTION_LOG_TOKEN, 0);
+			header.writeUInt8(1, 4);
+			header.writeDoubleBE(Date.now(), 5);
+
+			const parts: Buffer[] = [header];
+			for (let i = 0; i < entryCount; i++) {
+				const entry = Buffer.alloc(TRANSACTION_LOG_ENTRY_HEADER_SIZE + dataLen);
+				entry.writeDoubleBE(Date.now(), 0); // entry timestamp (non-zero)
+				entry.writeUInt32BE(dataLen, 8); // payload length
+				entry.writeUInt8(i === entryCount - 1 ? 0x01 : 0x00, 12); // last-entry flag on the final frame
+				entry.fill(0xab, TRANSACTION_LOG_ENTRY_HEADER_SIZE);
+				parts.push(entry);
+			}
+			return Buffer.concat(parts);
+		};
+
+		it('should return entry counts when includeEntryCounts is true', () =>
+			dbRunner({ skipOpen: true }, async ({ db, dbPath }) => {
+				const logDirectory = join(dbPath, 'transaction_logs', 'foo');
+				const logFile = join(logDirectory, '1.txnlog');
+				await mkdir(logDirectory, { recursive: true });
+				await writeFile(logFile, buildLogFile(3));
+				await writeFile(join(logDirectory, 'txn.state'), Buffer.from([0, 0, 0, 0, 2, 0, 0, 0]));
+
+				db.open();
+				expect(db.purgeLogs({ destroy: true, includeEntryCounts: true })).toEqual([
+					{ path: logFile, entries: 3 },
+				]);
+				expect(existsSync(logFile)).toBe(false);
+			}));
+
+		it('should report zero entries for a header-only log file', () =>
+			dbRunner({ skipOpen: true }, async ({ db, dbPath }) => {
+				const logDirectory = join(dbPath, 'transaction_logs', 'foo');
+				const logFile = join(logDirectory, '1.txnlog');
+				await mkdir(logDirectory, { recursive: true });
+				await writeFile(logFile, buildLogFile(0));
+				await writeFile(join(logDirectory, 'txn.state'), Buffer.from([0, 0, 0, 0, 2, 0, 0, 0]));
+
+				db.open();
+				expect(db.purgeLogs({ destroy: true, includeEntryCounts: true })).toEqual([
+					{ path: logFile, entries: 0 },
+				]);
+			}));
+
+		it('should return string paths by default when includeEntryCounts is omitted', () =>
+			dbRunner({ skipOpen: true }, async ({ db, dbPath }) => {
+				const logDirectory = join(dbPath, 'transaction_logs', 'foo');
+				const logFile = join(logDirectory, '1.txnlog');
+				await mkdir(logDirectory, { recursive: true });
+				await writeFile(logFile, buildLogFile(2));
+				await writeFile(join(logDirectory, 'txn.state'), Buffer.from([0, 0, 0, 0, 2, 0, 0, 0]));
+
+				db.open();
+				expect(db.purgeLogs({ destroy: true })).toEqual([logFile]);
+			}));
+
 		it('should purge all transaction log files', () =>
 			dbRunner({ skipOpen: true }, async ({ db, dbPath }) => {
 				const logDirectory = join(dbPath, 'transaction_logs', 'foo');


### PR DESCRIPTION
## Summary

`purgeLogs()` returns the paths of the transaction log files it deleted but gives no indication of how many entries each file held. This adds an **opt-in** `includeEntryCounts` option:

- **omitted / `false`** (default): return shape is unchanged — `string[]` of deleted file paths.
- **`true`**: returns `Array<{ path: string; entries: number }>`, where `entries` is the number of v1 entry frames the deleted file held, counted in C++.

Opt-in by design: the count requires reading each file before it is removed, so callers that don't need it pay nothing, and existing `string[]` consumers are not broken.

## Purpose

Callers purging logs want to know how much was discarded (entry counts), not just which files. Computing the count in C++ avoids re-reading/parsing the files in JS.

## Where to look

- **`src/binding/transaction_log/transaction_log_recovery.{h,cpp}`** — new pure `countTransactionLogEntries()` that walks the v1 framing (timestamp/length/flags), stopping at the first zero-timestamp marker, EOF, or a broken/torn frame — i.e. the same entry set `parseTransactionLog()` reports. Unit-tested standalone (GTest).
- **`transaction_log_file.{h,cpp}`** — `TransactionLogFile::countEntries()` reads the file's on-disk image through a *fresh* handle (old purgeable files are never opened; POSIX `pread` / Windows `FILE_SHARE_READ` make a concurrent read safe) and is wrapped to **never throw** (incl. `std::bad_alloc` from the whole-file buffer) so a counting failure can't abort a purge.
- **`transaction_log_store.{h,cpp}`** — the purge visitor signature gains an `entryCount`, and a `countEntries` flag is threaded through `purge()`/`doPurge()`. Counting happens *before* `removeFile()` and only when both a visitor and the flag are present. The no-visitor `close()`/on-load retention purge paths are unaffected (signature change is compiler-enforced across all three callers).
- **`transaction_log_store_registry.cpp`** — reads the `includeEntryCounts` option and builds either string elements or `{ path, entries }` objects.
- **`src/load-binding.ts`, `src/database.ts`** — `PurgeLogsOptions.includeEntryCounts`, a `PurgedLog` type, and overloads so the return type narrows to `string[]` or `PurgedLog[]` (plus a general overload so a non-literal `boolean` still type-checks).

## Notes for the reviewer

- **Entry semantics:** `entries` counts framed records (one per `addEntry`), matching `parseTransactionLog().entries.length` — a multi-entry transaction contributes each of its frames. Confirm that's the count you'd expect.
- **Cross-model review:** Codex reviewed and surfaced two items (TS overload gap for a `boolean` variable; `std::bad_alloc` could escape `countEntries`) — both fixed in this PR. The Gemini leg could not run in my environment (the `agy` CLI returns empty headlessly and `gemini` isn't installed), so a second cross-model pass is still worth a human eye.

## Testing

- Native GTest: 6 new `TransactionLogCount` cases (header-only, clean, zero-pad tail, torn tail, partial header, large entry).
- Vitest: 3 new `purgeLogs` cases (entry counts when opted in, zero for header-only, unchanged `string[]` by default). Full suite green (548 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: Claude Opus 4.8)