### PR TITLE
Document purgeLogs() includeEntryCounts option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1120,7 +1120,9 @@ Returns an array of log store names.
 const names = db.listLogs();
 ```
 
-### `db.purgeLogs(options?): string[] | { path: string; entries: number }[]`
+### `db.purgeLogs(options?): string[]`
+
+### `db.purgeLogs(options): { path: string; entries: number }[]`
 
 Deletes transaction log files older than the `transactionLogRetention` (defaults to 3 days).
 
@@ -1133,9 +1135,11 @@ Deletes transaction log files older than the `transactionLogRetention` (defaults
     each file before it is removed, so it is only performed when this option is enabled.
   - `name?: string` The name of a store to limit the purging to.
 
-By default, returns an array with the full path of each log file deleted. When `includeEntryCounts`
-is `true`, returns an array of objects, each with the `path` of the deleted log file and the number
-of `entries` it held.
+The method is overloaded so the return type follows `includeEntryCounts`: by default (omitted or
+`false`) it returns `string[]` — the full path of each log file deleted; when `includeEntryCounts` is
+`true` it returns `{ path: string; entries: number }[]`, each entry being the `path` of the deleted
+log file and the number of `entries` it held. Because of the overloads, the object-array form is
+returned directly when `includeEntryCounts: true` is passed as a literal, with no casting required.
 
 ```typescript
 const removed = db.purgeLogs();

--- a/README.md
+++ b/README.md
@@ -1120,7 +1120,7 @@ Returns an array of log store names.
 const names = db.listLogs();
 ```
 
-### `db.purgeLogs(options?): string[]`
+### `db.purgeLogs(options?): string[] | { path: string; entries: number }[]`
 
 Deletes transaction log files older than the `transactionLogRetention` (defaults to 3 days).
 
@@ -1128,13 +1128,24 @@ Deletes transaction log files older than the `transactionLogRetention` (defaults
   - `before?: number` Remove all transaction log files older than the specified timestamp.
   - `destroy?: boolean` When `true`, deletes transaction log stores including all log sequence files
     on disk.
+  - `includeEntryCounts?: boolean` When `true`, counts the entries in each deleted log file and
+    returns an array of `{ path, entries }` objects instead of an array of file paths. Counting reads
+    each file before it is removed, so it is only performed when this option is enabled.
   - `name?: string` The name of a store to limit the purging to.
 
-Returns an array with the full path of each log file deleted.
+By default, returns an array with the full path of each log file deleted. When `includeEntryCounts`
+is `true`, returns an array of objects, each with the `path` of the deleted log file and the number
+of `entries` it held.
 
 ```typescript
 const removed = db.purgeLogs();
 console.log(`Removed ${removed.length} log files`);
+
+// Include the entry count for each deleted log file:
+const purged = db.purgeLogs({ includeEntryCounts: true });
+for (const { path, entries } of purged) {
+	console.log(`Removed ${path} (${entries} entries)`);
+}
 ```
 
 ### `db.useLog(name): TransactionLog`

--- a/README.md
+++ b/README.md
@@ -1122,7 +1122,7 @@ const names = db.listLogs();
 
 ### `db.purgeLogs(options?): string[]`
 
-### `db.purgeLogs(options): { path: string; entries: number }[]`
+### `db.purgeLogs({ includeEntryCounts: true, ...options }): { path: string; entries: number }[]`
 
 Deletes transaction log files older than the `transactionLogRetention` (defaults to 3 days).
 


### PR DESCRIPTION
## Summary

The `includeEntryCounts` option for `db.purgeLogs()` (added in #661) was never documented in the README. This documents it.

- Updates the `db.purgeLogs()` signature to reflect the conditional return type (`string[] | { path, entries }[]`).
- Adds the `includeEntryCounts?: boolean` option, noting it only does the extra counting work when enabled.
- Documents the return shape and adds a short usage example.

Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: Claude Opus 4.8)