### PR TITLE
Fix TransactionHandle::close() double-free when descriptor close races async-commit callback (harper#1370)

### DIFF
--- a/src/binding/transaction/transaction_handle.cpp
+++ b/src/binding/transaction/transaction_handle.cpp
@@ -210,9 +210,12 @@ void TransactionHandle::close() {
 	this->waitForAsyncWorkCompletion();
 
 	// Test seam: widen the PATH A vs PATH B race window (see txnCloseTestDelayMs).
+	// This window is real in production (PATH B fires after waitForAsyncWorkCompletion
+	// unblocks); the seam makes it wide enough to reproduce deterministically.
 	// Noop in production.
-	if (txnCloseTestDelayMs() > 0) {
-		std::this_thread::sleep_for(std::chrono::milliseconds(txnCloseTestDelayMs()));
+	const int testDelayMs = txnCloseTestDelayMs();
+	if (testDelayMs > 0) {
+		std::this_thread::sleep_for(std::chrono::milliseconds(testDelayMs));
 	}
 
 	// if the transaction was aborted (either via an error, explicit abort, or was pending), we need

--- a/src/binding/transaction/transaction_handle.cpp
+++ b/src/binding/transaction/transaction_handle.cpp
@@ -1,4 +1,7 @@
+#include <chrono>
+#include <cstdlib>
 #include <sstream>
+#include <thread>
 #include "database/database.h"
 #include "database/db_descriptor.h"
 #include "database/db_settings.h"
@@ -7,6 +10,21 @@
 #include "napi/macros.h"
 
 namespace rocksdb_js {
+
+/**
+ * Read-once test seam: returns milliseconds to sleep after
+ * waitForAsyncWorkCompletion() in close(), widening the window between PATH A
+ * (descriptor close on env M) and PATH B (commit complete callback on env W)
+ * so the close-vs-commit double-free race (HarperFast/harper#1370) reproduces
+ * deterministically. Zero in production (env var not set).
+ */
+static int txnCloseTestDelayMs() {
+	static const int delayMs = [] {
+		const char* value = ::getenv("ROCKSDB_JS_TXN_CLOSE_DELAY_MS");
+		return value ? ::atoi(value) : 0;
+	}();
+	return delayMs;
+}
 
 /**
  * Creates a new RocksDB transaction, enables snapshots, and sets the
@@ -25,7 +43,8 @@ TransactionHandle::TransactionHandle(
 	coordinatedRetry(false),
 	state(TransactionState::Pending),
 	txn(nullptr),
-	committedPosition(0, 0) {
+	committedPosition(0, 0),
+	envThreadId(std::this_thread::get_id()) {
 	this->resetTransaction();
 	this->id = this->dbHandle->descriptor->transactionGetNextId();
 
@@ -161,8 +180,16 @@ void TransactionHandle::releaseIntent() {
 /**
  * Release the transaction. This is called after successful commit, after
  * the transaction has been aborted, or when the transaction is destroyed.
+ *
+ * The `closed` atomic gate ensures this runs at most once even when called
+ * from multiple threads concurrently (e.g. DBDescriptor::close() on env M's
+ * JS thread racing the async commit's complete callback on env W's JS thread).
  */
 void TransactionHandle::close() {
+	if (this->closed.exchange(true)) {
+		return;
+	}
+
 	if (this->dbHandle && this->dbHandle->descriptor) {
 		this->dbHandle->descriptor->transactionRemove(shared_from_this());
 	}
@@ -181,6 +208,12 @@ void TransactionHandle::close() {
 
 	// wait for all async work to complete before closing
 	this->waitForAsyncWorkCompletion();
+
+	// Test seam: widen the PATH A vs PATH B race window (see txnCloseTestDelayMs).
+	// Noop in production.
+	if (txnCloseTestDelayMs() > 0) {
+		std::this_thread::sleep_for(std::chrono::milliseconds(txnCloseTestDelayMs()));
+	}
 
 	// if the transaction was aborted (either via an error, explicit abort, or was pending), we need
 	// to remove the committed position from the log store
@@ -219,9 +252,17 @@ void TransactionHandle::close() {
 	this->txn = nullptr;
 
 	if (this->jsDatabaseRef != nullptr) {
-		DEBUG_LOG("%p TransactionHandle::close Cleaning up reference to database\n", this);
-		NAPI_STATUS_THROWS_ERROR_VOID(::napi_delete_reference(this->env, this->jsDatabaseRef), "Failed to delete reference to database");
-		DEBUG_LOG("%p TransactionHandle::close Reference to database deleted successfully\n", this);
+		if (std::this_thread::get_id() == this->envThreadId) {
+			// On the owning JS thread — safe to call napi_delete_reference.
+			DEBUG_LOG("%p TransactionHandle::close Cleaning up reference to database\n", this);
+			NAPI_STATUS_THROWS_ERROR_VOID(::napi_delete_reference(this->env, this->jsDatabaseRef), "Failed to delete reference to database");
+			DEBUG_LOG("%p TransactionHandle::close Reference to database deleted successfully\n", this);
+		} else {
+			// Wrong thread (close() called from a different env's JS thread, e.g.
+			// DBDescriptor::close() PATH A). napi_delete_reference is not thread-safe
+			// across envs; skip and let Node clean up the weak ref on env teardown.
+			DEBUG_LOG("%p TransactionHandle::close Skipping napi_delete_reference (wrong thread)\n", this);
+		}
 		this->jsDatabaseRef = nullptr;
 	} else {
 		DEBUG_LOG("%p TransactionHandle::close jsDatabaseRef is already null\n", this);

--- a/src/binding/transaction/transaction_handle.h
+++ b/src/binding/transaction/transaction_handle.h
@@ -3,6 +3,7 @@
 
 #include <memory>
 #include <mutex>
+#include <thread>
 #include <unordered_map>
 #include <vector>
 #include "database/db_handle.h"
@@ -100,6 +101,28 @@ struct TransactionHandle final : Closable, AsyncWorkHandle, std::enable_shared_f
 	 * The RocksDB transaction.
 	 */
 	rocksdb::Transaction* txn;
+
+	/**
+	 * One-shot close gate: set to true by the first close() caller. Subsequent
+	 * callers from any thread return immediately. Mirrors DBDescriptor::closing.
+	 *
+	 * Without this, DBDescriptor::close() (on env M's JS thread) and the async
+	 * commit's complete callback (on env W's JS thread) can both pass the
+	 * `!this->txn` check before either executes `delete this->txn`, causing a
+	 * double-free through ~OptimisticTransaction → ~PointLockTracker
+	 * (HarperFast/harper#1370, close-vs-commit variant).
+	 */
+	std::atomic<bool> closed{false};
+
+	/**
+	 * The thread ID of the JS thread that owns `env` (set at construction time).
+	 * Used in close() to guard napi_delete_reference: calling it from a thread
+	 * other than the owning JS thread is undefined behaviour and will crash.
+	 * When close() is invoked from a different env's JS thread (PATH A, the
+	 * DBDescriptor::close() path), the deletion is skipped and the ref is left
+	 * for Node to clean up on env teardown.
+	 */
+	std::thread::id envThreadId;
 
 	/**
 	 * A batch of log entries to write to the transaction log. It can only be

--- a/test/fixtures/fork-close-commit-uaf.mts
+++ b/test/fixtures/fork-close-commit-uaf.mts
@@ -1,0 +1,117 @@
+/**
+ * Isolated repro for the TransactionHandle::close() double-free when
+ * DBDescriptor::close() (env M's JS thread) and the async commit's complete
+ * callback (env W's JS thread) both call close() concurrently
+ * (HarperFast/harper#1370, close-vs-commit variant).
+ *
+ * Scenario per round:
+ * 1. M opens the DB path (descriptor refcount = 1).
+ * 2. M signals W "nextRound"; W opens the same path (refcount = 2).
+ * 3. W queues an async commit, then immediately closes W's handle (refcount → 1).
+ *    T->dbHandle->descriptor is now null; PATH B's transactionRemove is skipped.
+ * 4. W signals M "committing"; M closes M's handle (refcount → 0) →
+ *    DBDescriptor::close() → T->close() on M's JS thread (PATH A).
+ * 5. PATH A calls waitForAsyncWorkCompletion(), unblocking when the execute
+ *    handler signals, then sleeps for ROCKSDB_JS_TXN_CLOSE_DELAY_MS ms (seam).
+ * 6. During that sleep the commit's complete callback fires on W's JS thread
+ *    (PATH B) and also calls T->close().
+ *
+ * Before the fix, both paths pass the `!this->txn` guard and both execute
+ * `delete this->txn` → double-free through ~OptimisticTransaction →
+ * ~PointLockTracker → SIGABRT.  After the fix, the `closed` atomic gate lets
+ * only the first caller through; the second returns immediately.
+ *
+ * Round coordination: W only opens the DB after M sends "nextRound", and M
+ * only triggers the next round after sending "readyForNext" to W once M's
+ * descriptor has been fully closed and the registry entry erased. This prevents
+ * W from reopening the DB before M's close commits to the registry, which would
+ * trigger the pre-existing DBRegistry race (HarperFast/rocksdb-js PR #664).
+ *
+ * Exit 0 = survived; a crash exits via signal / non-zero.
+ */
+import { RocksDatabase } from '../../src/index.js';
+import { createWorkerBootstrapScript } from '../lib/util.js';
+import { mkdirSync } from 'node:fs';
+import { Worker } from 'node:worker_threads';
+
+const dbPath = process.argv[2];
+
+if (!dbPath) {
+	console.error('Usage: fork-close-commit-uaf.mts <dbPath>');
+	process.exit(1);
+}
+
+mkdirSync(dbPath, { recursive: true });
+
+// More rounds = more PATH-A/PATH-B overlap windows.
+const ROUNDS = 60;
+
+function spawnWorker(): Promise<Worker> {
+	return new Promise((resolve, reject) => {
+		const worker = new Worker(
+			createWorkerBootstrapScript('./test/workers/txn-close-commit-worker.mts'),
+			{ eval: true, workerData: { path: dbPath } }
+		);
+		worker.once('message', (event: { ready?: boolean }) => {
+			if (event.ready) resolve(worker);
+		});
+		worker.once('error', reject);
+	});
+}
+
+function waitForMessage(
+	worker: Worker,
+	predicate: (msg: Record<string, unknown>) => boolean
+): Promise<void> {
+	return new Promise((resolve) => {
+		const handler = (msg: Record<string, unknown>) => {
+			if (predicate(msg)) {
+				worker.off('message', handler);
+				resolve();
+			}
+		};
+		worker.on('message', handler);
+	});
+}
+
+async function run(): Promise<void> {
+	const worker = await spawnWorker();
+
+	for (let round = 0; round < ROUNDS; round++) {
+		// Open M's anchor handle so the descriptor refcount is 2 when W opens.
+		const db = RocksDatabase.open(dbPath);
+
+		// Tell W to start this round: W opens the DB and begins a commit.
+		worker.postMessage({ nextRound: true });
+
+		// Wait for W to close its handle and signal us.
+		await waitForMessage(worker, (msg) => Boolean(msg.committing));
+
+		// Closing M's handle drops the last descriptor ref → descriptor->close()
+		// → T->close() PATH A → waitForAsyncWorkCompletion + test-seam sleep.
+		db.close();
+
+		// Wait for W's complete callback to finish the round.
+		await waitForMessage(worker, (msg) => Boolean(msg.done));
+
+		// The descriptor is now fully closed and erased from the registry.
+		// Signal W that it may open a fresh DB handle for the next round.
+		// (Not sent on the last round — W gets "stop" instead.)
+	}
+
+	// Stop the worker cleanly.
+	await new Promise<void>((resolve) => {
+		waitForMessage(worker, (msg) => Boolean(msg.stopped)).then(resolve);
+		worker.postMessage({ stop: true });
+	});
+	await worker.terminate();
+}
+
+try {
+	await run();
+	console.log('SUCCESS');
+	process.exit(0);
+} catch (error) {
+	console.error('FAILED', error);
+	process.exit(1);
+}

--- a/test/txn-close-commit-uaf.test.ts
+++ b/test/txn-close-commit-uaf.test.ts
@@ -1,0 +1,57 @@
+import { generateDBPath } from './lib/util.js';
+import { spawn } from 'node:child_process';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const fixturePath = join(__dirname, 'fixtures', 'fork-close-commit-uaf.mts');
+
+/**
+ * Runs the repro fixture in a child process so a SIGABRT (the harper#1370
+ * crash) surfaces as a signal/non-zero exit instead of taking down vitest.
+ * The ROCKSDB_JS_TXN_CLOSE_DELAY_MS seam widens the window between
+ * waitForAsyncWorkCompletion() returning (PATH A) and the commit's complete
+ * callback (PATH B) so the race reproduces deterministically.
+ */
+async function expectSurvives(iterations = 3): Promise<void> {
+	for (let i = 0; i < iterations; i++) {
+		const { code, signal } = await spawnRepro(generateDBPath());
+		expect(signal, `iteration=${i}`).toBeNull();
+		expect(code, `iteration=${i}`).toBe(0);
+	}
+}
+
+function spawnRepro(
+	dbPath: string
+): Promise<{ code: number | null; signal: NodeJS.Signals | null }> {
+	return new Promise((resolve, reject) => {
+		const args =
+			process.versions.bun || process.versions.deno
+				? [fixturePath, dbPath]
+				: ['node_modules/tsx/dist/cli.mjs', fixturePath, dbPath];
+
+		const child = spawn(process.execPath, args, {
+			env: { ...process.env, ROCKSDB_JS_TXN_CLOSE_DELAY_MS: '25' },
+		});
+
+		let stderr = '';
+		child.stderr?.on('data', (chunk) => {
+			stderr += chunk.toString();
+		});
+
+		child.on('close', (code, signal) => {
+			if (code !== 0 || signal) {
+				console.error(`Repro child stderr:\n${stderr}`);
+			}
+			resolve({ code, signal });
+		});
+		child.on('error', reject);
+	});
+}
+
+describe('TransactionHandle::close() vs async-commit complete callback', () => {
+	it(
+		'should survive DBDescriptor::close() racing the commit complete callback (harper#1370)',
+		() => expectSurvives(),
+		60_000
+	);
+});

--- a/test/workers/txn-close-commit-worker.mts
+++ b/test/workers/txn-close-commit-worker.mts
@@ -1,0 +1,60 @@
+import { RocksDatabase } from '../../src/index.js';
+import { parentPort, workerData } from 'node:worker_threads';
+
+// W opens a FRESH handle each round (signaled by M via "nextRound") so the
+// DBDescriptor refcount is always 2 when the commit starts (M holds the other
+// ref). After W closes its handle the refcount drops to 1; when M then closes
+// its handle the refcount hits 0 and triggers DBDescriptor::close() →
+// T->close() on M's JS thread (PATH A). The async commit's complete callback
+// fires T->close() on W's JS thread (PATH B). Without the closed-gate fix both
+// paths race to delete this->txn (HarperFast/harper#1370, close-vs-commit).
+//
+// Round coordination ("nextRound" / "committing" / "done"):
+//
+//   M ──nextRound──► W opens DB, starts commit, closes handle
+//   M ◄─committing── W
+//   M closes its handle (triggers descriptor->close() / PATH A)
+//   W awaits commit (PATH B fires in complete callback)
+//   W ──done──────► M
+//   (M loops: opens fresh DB handle, then sends nextRound for the next round)
+//
+// The explicit handshake prevents W from reopening the DB before M's close has
+// fully erased the registry entry, which would trigger the pre-existing
+// DBRegistry race (HarperFast/rocksdb-js PR #664, not the bug under test).
+
+let counter = 0;
+
+parentPort?.on('message', async (message: { stop?: boolean; nextRound?: boolean }) => {
+	if (message.stop) {
+		parentPort?.postMessage({ stopped: true });
+		return;
+	}
+
+	if (!message.nextRound) return;
+
+	try {
+		// Fresh handle: shares descriptor with M's handle (refcount = 2)
+		const db = RocksDatabase.open(workerData.path);
+
+		// Queue the async commit on the threadpool
+		const commitPromise = db.transaction((txn) => {
+			txn.put('committer', counter++);
+		});
+
+		// Drop W's descriptor ref (refcount → 1, descriptor still alive via M)
+		// T->dbHandle->descriptor is now null; PATH B's transactionRemove is skipped
+		db.close();
+
+		// Signal M: W's handle is closed; M closing now triggers descriptor->close()
+		parentPort?.postMessage({ committing: true });
+
+		// PATH B: complete callback fires on this thread once execute finishes
+		await commitPromise;
+	} catch {
+		// Expected — descriptor may be closing when the commit resolves
+	}
+
+	parentPort?.postMessage({ done: true });
+});
+
+parentPort?.postMessage({ ready: true });


### PR DESCRIPTION
## Summary

Fixes the close-vs-commit double-free reported in HarperFast/harper#1370. When a DB descriptor is closed by one env's JS thread (PATH A: `DBDescriptor::close()` → `T->close()`) while the same transaction's async commit complete callback fires on another env's JS thread (PATH B), both paths could pass the original `!this->txn` guard and both execute `delete this->txn`, causing a double-free through `~OptimisticTransaction → ~PointLockTracker → SIGABRT`.

**Two fixes:**

1. **One-shot `closed` gate** (`std::atomic<bool> closed{false}`): `closed.exchange(true)` at the start of `close()`. The first caller proceeds; the second returns immediately. Prevents both PATH A and PATH B from reaching `delete this->txn`.

2. **Cross-env `napi_delete_reference` guard** (`std::thread::id envThreadId`): stored at construction time (W's JS thread). When `close()` is invoked from a different env's JS thread (PATH A, M's thread), `napi_delete_reference` is skipped — calling it cross-env is UB and crashes. The ref is a weak ref (refcount=0) and is cleaned up by Node on env teardown.

Also adds a `ROCKSDB_JS_TXN_CLOSE_DELAY_MS` test seam (read-once static, zero-cost in production) that widens the PATH A / PATH B overlap window after `waitForAsyncWorkCompletion()` returns, and a deterministic 60-round regression test.

## Relationship to PR #664

No file overlap with PR #664 (`DBRegistry::CloseDB` raw-pointer race). Different bugs, different layers. The regression test's round-coordination design avoids the DBRegistry race (W only opens its handle after M already holds one), so both bugs can coexist without interfering with each other.

## Areas deserving attention

- **`envThreadId` guard**: the transaction is constructed on W's JS thread, so `envThreadId = W's thread ID`. PATH A runs on M's JS thread. The IDs differ → `napi_delete_reference` is correctly skipped when PATH A wins the gate. This path is exercised deterministically by the test (whenever PATH A wins).
- **`waitForAsyncWorkCompletion()` unblocking point**: unblocks when `signalExecuteCompleted()` is called at the end of the execute lambda — before the complete callback fires. The production window between these two events is real; the seam just widens it.

Cross-model review (quick, Gemini leg unavailable): no blockers found. Significant concerns were all correctness confirmations; two minor suggestions addressed (test seam comment clarified, `txnCloseTestDelayMs()` read once per call site).

*Generated by Claude Opus 4.8*