### PR TITLE
Enforce write-once WAL across IsBusy commit retry (#668)

### DIFF
--- a/src/binding/transaction/transaction.cpp
+++ b/src/binding/transaction/transaction.cpp
@@ -425,7 +425,12 @@ napi_value Transaction::Commit(napi_env env, napi_callback_info info) {
 					napi_value error;
 					ROCKSDB_CREATE_ERROR_LIKE_VOID(error, state->status, "Transaction commit failed");
 					napi_value hasLogValue;
-					napi_status status = ::napi_get_boolean(env, state->hasLog, &hasLogValue);
+					// #668: writeBatch is skipped on an IsBusy retry once the WAL batch is durable
+					// (committedPosition set), so state->hasLog is false this attempt. Fall back to
+					// committedPosition so the retry-on-busy heuristic still treats this as logged.
+					bool hasLog = state->hasLog ||
+						(state->handle && state->handle->committedPosition.logSequenceNumber > 0);
+					napi_status status = ::napi_get_boolean(env, hasLog, &hasLogValue);
 					if (status == napi_ok) {
 						::napi_set_named_property(env, error, "hasLog", hasLogValue);
 					}
@@ -518,7 +523,10 @@ napi_value Transaction::CommitSync(napi_env env, napi_callback_info info) {
 		napi_value error;
 		ROCKSDB_CREATE_ERROR_LIKE_VOID(error, status, "Transaction commit failed");
 		napi_value hasLogValue;
-		NAPI_STATUS_THROWS(::napi_get_boolean(env, hasLog, &hasLogValue));
+		// #668: writeBatch is skipped on an IsBusy retry (WAL already durable), so fall
+		// back to committedPosition so the caller keeps treating this as a logged txn.
+		NAPI_STATUS_THROWS(::napi_get_boolean(env,
+			hasLog || (*txnHandle)->committedPosition.logSequenceNumber > 0, &hasLogValue));
 		NAPI_STATUS_THROWS(::napi_set_named_property(env, error, "hasLog", hasLogValue));
 		NAPI_STATUS_THROWS(::napi_throw(env, error));
 	}

--- a/src/binding/transaction/transaction_handle.cpp
+++ b/src/binding/transaction/transaction_handle.cpp
@@ -101,6 +101,23 @@ void TransactionHandle::addLogEntry(std::unique_ptr<TransactionLogEntry> entry) 
 	DEBUG_LOG("%p TransactionHandle::addLogEntry Adding log entry to store \"%s\" for transaction %u (size=%zu)\n",
 		this, entry->store->name.c_str(), this->id, entry->size);
 
+	// #668 (defense in depth): the write-ahead log is write-once per transaction. If
+	// committedPosition is already set, this transaction's batch was durably written by a
+	// prior commit attempt (committedPosition survives resetTransaction). A commit that
+	// returned IsBusy is retried by re-running the transaction body to re-drive the RocksDB
+	// commit; re-staging the log here would write the records a second time at a new
+	// position, orphaning the original (commitFinished is gated on !IsBusy, so the original
+	// is never finalized) and pinning the committed-read watermark at it forever — silent
+	// committed-read truncation (HarperFast/harper-pro#426). Higher layers are expected to
+	// suppress the re-log on retry (e.g. harper's DatabaseTransaction.isRetry), but enforce
+	// write-once here too so a stray re-stage from any caller cannot corrupt the watermark.
+	if (this->committedPosition.logSequenceNumber > 0) {
+		DEBUG_LOG("%p TransactionHandle::addLogEntry Skipping re-stage on retry for transaction %u "
+			"(WAL already written at seq %u)\n",
+			this, this->id, this->committedPosition.logSequenceNumber);
+		return;
+	}
+
 	// check if this transaction is already bound to a different log store
 	auto currentBoundStore = this->boundLogStore.lock();
 	if (currentBoundStore) {

--- a/test/transaction-log-isbusy-retry.test.ts
+++ b/test/transaction-log-isbusy-retry.test.ts
@@ -1,0 +1,79 @@
+// Regression test for HarperFast/rocksdb-js#668.
+//
+// The write-ahead log is written once per transaction; an IsBusy commit retry
+// re-runs the transaction body to re-drive the RocksDB commit, but must not
+// rewrite the WAL. Before the fix, the retry re-staged the log entries, so
+// writeBatch() ran a second time and wrote the records again at a fresh
+// position. The first copy was orphaned (commitFinished is gated on !IsBusy, so
+// it was never finalized), which pinned the committed-read watermark at it
+// forever and silently truncated committed reads (HarperFast/harper-pro#426).
+//
+// This test forces exactly one IsBusy retry on a logged transaction via the
+// db.transaction() retry loop and asserts the log holds a single copy of the
+// record (not one per attempt) and that the committed read still sees it.
+
+import { constants } from '../src/load-binding.js';
+import { dbRunner, generateDBPath } from './lib/util.js';
+import { readdir, stat } from 'node:fs/promises';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const { TRANSACTION_LOG_FILE_HEADER_SIZE, TRANSACTION_LOG_ENTRY_HEADER_SIZE } = constants;
+
+async function transactionLogBytes(logDir: string): Promise<number> {
+	let size = 0;
+	for (const file of await readdir(logDir).catch(() => [])) {
+		const info = await stat(join(logDir, file)).catch(() => undefined);
+		if (info?.isFile()) {
+			size += info.size;
+		}
+	}
+	return size;
+}
+
+describe('#668 IsBusy retry does not rewrite the WAL', () => {
+	it('writes the log entry once across an IsBusy retry and keeps committed reads intact', () =>
+		dbRunner({ dbOptions: [{ path: generateDBPath() }] }, async ({ db, dbPath }) => {
+			const key = 'k';
+			const payload = Buffer.alloc(128, 'z');
+			const log = db.useLog('repl');
+
+			let attempts = 0;
+			await db.put(key, 'initial');
+
+			await db.transaction(
+				async (txn, attempt) => {
+					attempts = attempt;
+					// Establish the snapshot before injecting the conflict.
+					await txn.get(key);
+					// Inject an external write only on the first attempt so attempt 1
+					// hits an optimistic conflict (IsBusy) and the retry then commits.
+					if (attempt === 1) {
+						await db.put(key, 'conflict');
+					}
+					await txn.put(key, 'committed');
+					log.addEntry(payload, txn.id);
+				},
+				{ retryOnBusy: true, maxRetries: 5 }
+			);
+
+			// The retry must actually have happened, otherwise the test proves nothing.
+			expect(attempts).toBeGreaterThanOrEqual(2);
+
+			// The transaction ultimately committed its value.
+			expect(await db.get(key)).toBe('committed');
+
+			// The WAL holds exactly one copy of the record — not one per attempt.
+			const logDir = join(dbPath, 'transaction_logs', 'repl');
+			const bytes = await transactionLogBytes(logDir);
+			expect(bytes).toBe(
+				TRANSACTION_LOG_FILE_HEADER_SIZE + TRANSACTION_LOG_ENTRY_HEADER_SIZE + payload.length
+			);
+
+			// And a committed read from the start reaches it — the watermark advanced to head
+			// rather than being pinned short of it (the #668 failure mode would truncate here).
+			const entries = [...db.useLog('repl').query({ start: 0 })];
+			expect(entries.length).toBe(1);
+			expect(Buffer.from(entries[0].data).equals(payload)).toBe(true);
+		}));
+});


### PR DESCRIPTION
## What this does

The write-ahead log is **write-once per transaction**, but if a logged transaction's `addEntry` is re-staged across an IsBusy commit retry, `writeBatch()` runs a second time and allocates a fresh position **B**; the first position **A** is never finalized (`commitFinished` is gated on `!IsBusy`) and never aborted, so it is orphaned. Since `lastCommittedPosition` is the `front()` of `uncommittedTransactionPositions`, the orphaned **A** becomes a permanent floor and every later committed read truncates at it — silent committed-read truncation.

This PR enforces write-once at the rocksdb-js boundary, in `TransactionHandle::addLogEntry`: if `committedPosition` is already set (the batch was durably written by a prior attempt — `committedPosition` survives `resetTransaction`), skip re-staging. The retry re-drives only the RocksDB commit; `writeBatch` is not called again, and the original position is finalized by `commitFinished` on success. The IsBusy error's `hasLog` flag also falls back to `committedPosition` (since `writeBatch` — which sets the per-attempt `hasLog` — is skipped on the retry) so the retry-on-busy heuristic keeps treating the transaction as logged.

## ⚠️ Scope: this is engine defense-in-depth — NOT a confirmed fix for harper-pro#426

Earlier revisions of this PR claimed this resolves the harper-pro#426 replication-backlog data loss. **That claim is withdrawn pending a direct mechanism trace.** Current understanding:

- Harper already enforces write-once at its own layer: `DatabaseTransaction` sets `transaction.isRetry` on retry and `RocksTransactionLogStore.put` skips `addEntry` when set (harper `db375241f`, present in 5.0.31 / 5.1.0). With `isRetry` working, the IsBusy-retry path **does not orphan** — the suppressed retry leaves `logEntryBatch` null, so `writeBatch` is skipped (`transaction.cpp:228`), `committedPosition` stays A, and `commitFinished(A)` fires on success (`:254`). No double-write.
- A double-write (and thus the watermark pin) therefore requires `addEntry` to run **twice** — i.e. harper's `isRetry` suppression to fail on some path. That gap has **not** been located (static trace of single-write, batched, sourceApply, and next-chain paths all set `isRetry`); investigation continues with direct position-lifecycle instrumentation of the `backlog-recovery` repro.
- The #426 captures confirm the *symptom* (committed read truncates at a fixed watermark; backlog physically past it) but never instrumented the orphaning *trigger*. No retry-exhaustion / non-retryable-commit / `ERR_BUSY` signatures appear in any capture.

**What this PR is good for regardless:** rocksdb-js's own `db.transaction()` retry loop re-runs the callback with no `isRetry`-style suppression, so any direct rocksdb-js consumer that logs inside a transaction hitting IsBusy *would* double-write and orphan. This guard closes that engine-level path so a stray re-stage from **any** caller can no longer corrupt the watermark. It is independently correct and worth landing on those grounds — but it should not be cited as the #426 fix until the harper-layer mechanism is pinned.

## Test

`test/transaction-log-isbusy-retry.test.ts` forces exactly one IsBusy retry on a logged transaction (via `db.transaction()` with an injected one-shot conflict) and asserts the WAL holds a **single** copy of the record and that a committed read from the start reaches it.

Verified as a real regression test by neutralizing the guard and rebuilding: the log file then contains **two** entries (295 vs 154 bytes) and the assertion fails. With the guard, one entry. Full native GoogleTest suite (51) and the existing `transactions` / `transaction-log` suites pass (the one pre-existing red — `transaction log visibility … until successfully committed` — fails identically on `main` without these changes; it's a timing/teardown-race test, not a regression here).

🤖 Updated by Claude (Opus 4.8) on behalf of Kris.
