### PR TITLE
Guard against null transaction handle in Commit complete callback

### DIFF
--- a/src/binding/transaction/transaction.cpp
+++ b/src/binding/transaction/transaction.cpp
@@ -326,7 +326,7 @@ napi_value Transaction::Commit(napi_env env, napi_callback_info info) {
 			TransactionCommitState* state = reinterpret_cast<TransactionCommitState*>(data);
 
 			DEBUG_LOG("%p Transaction::Commit Complete callback entered (status=%d, txnId=%d)\n",
-				state->handle.get(), status, state->handle->id);
+				state->handle.get(), status, state->handle ? state->handle->id : 0);
 
 			state->deleteAsyncWork();
 
@@ -338,7 +338,7 @@ napi_value Transaction::Commit(napi_env env, napi_callback_info info) {
 						state->handle->close();
 						DEBUG_LOG("%p Transaction::Commit Complete closed (txnId=%u)\n", state->handle.get(), state->handle->id);
 					} else {
-						DEBUG_LOG("%p Transaction::Commit Complete, but handle is null! (txnId=%u)\n", state->handle.get(), state->handle->id);
+						DEBUG_LOG("%p Transaction::Commit Complete, but handle is null!\n", state->handle.get());
 					}
 
 					state->callResolve();
@@ -419,7 +419,7 @@ napi_value Transaction::Commit(napi_env env, napi_callback_info info) {
 					// Guard: keep Aborted if close() already set it (DB closing
 					// during commit) — don't let Transaction::Abort call Rollback()
 					// on a null txn.
-					if (state->handle->state == TransactionState::Committing) {
+					if (state->handle && state->handle->state == TransactionState::Committing) {
 						state->handle->state = TransactionState::Pending;
 					}
 					napi_value error;

--- a/src/binding/transaction/transaction_handle.cpp
+++ b/src/binding/transaction/transaction_handle.cpp
@@ -43,8 +43,8 @@ TransactionHandle::TransactionHandle(
 	coordinatedRetry(false),
 	state(TransactionState::Pending),
 	txn(nullptr),
-	committedPosition(0, 0),
-	envThreadId(std::this_thread::get_id()) {
+	envThreadId(std::this_thread::get_id()),
+	committedPosition(0, 0) {
 	this->resetTransaction();
 	this->id = this->dbHandle->descriptor->transactionGetNextId();
 


### PR DESCRIPTION
## Summary

While reviewing `Transaction::Commit`, we noticed the complete callback was inconsistent about guarding `state->handle`. The ok path and the IsBusy path already null-checked it, but:

- the **normal error path** dereferenced `state->handle->state` unconditionally
- two `DEBUG_LOG` calls dereferenced `state->handle->id` without a guard — including the `else` branch whose entire purpose is to handle the null case (it would have null-deref'd the moment it ran)

`state->handle` is **never actually null in practice** today — it's a strong `shared_ptr<TransactionHandle>` copy, constructed non-null (`UNWRAP_TRANSACTION_HANDLE` guarantees it) and never reassigned/reset, so the strong ref keeps the object alive for the whole async-work lifetime. These guards are therefore defensive: the goal is that a null handle should never be able to crash the process, rather than asserting on it.

## Changes

- `transaction.cpp`: guard the error-path `state->handle->state` check (matches the existing ok/IsBusy guards)
- `transaction.cpp`: make the entry-log `txnId` null-safe
- `transaction.cpp`: drop the null-deref `->id` from the "handle is null!" log
- `transaction_handle.cpp`: fix the field-init-order warning (`envThreadId` / `committedPosition`) surfaced by the debug build

## Impact

The `DEBUG_LOG` changes only affect debug builds (`DEBUG_LOG` is a no-op in production), so this is not a production crash fix — it makes the whole complete callback uniformly null-tolerant and silences a compiler warning.

## Testing

- `pnpm build:binding:debug` compiles cleanly (no warnings in the touched files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)