### PR TITLE
Add `createCheckpoint()` to expose RocksDB's Checkpoint API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1400,10 +1400,10 @@ result the operation is near-instant on the same filesystem and as costly as a f
 filesystems. The memtable is flushed so the checkpoint includes the latest writes even when the
 WAL is disabled.
 
-`targetPath` must not already exist (RocksDB creates it) and its parent directory must exist.
-The call rejects with the RocksDB status message on failure (e.g. the target already exists, the
-parent is missing, or the disk is full). The caller is responsible for opening the checkpoint and
-for eventually deleting the directory.
+Parent directories are created as needed. `targetPath` itself must not already exist — RocksDB
+creates the checkpoint directory — and the call rejects with `Create checkpoint failed: target
+path exists` if it does (other failures, such as a full disk, surface the RocksDB status message).
+The caller is responsible for opening the checkpoint and for eventually deleting the directory.
 
 ```typescript
 const db = RocksDatabase.open('/path/to/database');

--- a/README.md
+++ b/README.md
@@ -1385,6 +1385,34 @@ import { versions } from '@harperfast/rocksdb-js';
 console.log(versions); // { "rocksdb": "10.10.1", "rocksdb-js": "0.1.2" }
 ```
 
+## Checkpoints
+
+### `db.createCheckpoint(targetPath: string): Promise<void>`
+
+Creates a [checkpoint](https://github.com/facebook/rocksdb/wiki/Checkpoints) — a point-in-time,
+fully independent copy of the entire database (all column families) at `targetPath` — and resolves
+once written. Unlike a backup, a checkpoint is a normal, writable database: open it as a new
+`RocksDatabase` and it diverges independently from the source.
+
+SST and blob files are **hard-linked** when `targetPath` is on the **same filesystem** as the
+database, and **copied** otherwise; other files (such as the `MANIFEST`) are always copied. As a
+result the operation is near-instant on the same filesystem and as costly as a full copy across
+filesystems. The memtable is flushed so the checkpoint includes the latest writes even when the
+WAL is disabled.
+
+`targetPath` must not already exist (RocksDB creates it) and its parent directory must exist.
+The call rejects with the RocksDB status message on failure (e.g. the target already exists, the
+parent is missing, or the disk is full). The caller is responsible for opening the checkpoint and
+for eventually deleting the directory.
+
+```typescript
+const db = RocksDatabase.open('/path/to/database');
+await db.createCheckpoint('/path/to/checkpoint');
+
+// The checkpoint is a normal, writable database.
+const branch = RocksDatabase.open('/path/to/checkpoint');
+```
+
 ## Backups
 
 Backups use RocksDB's `BackupEngine` to capture consistent, incremental, checksum-verified

--- a/binding.gyp
+++ b/binding.gyp
@@ -47,6 +47,7 @@
 				'src/binding/napi/global_events.cpp',
 				'src/binding/napi/helpers.cpp',
 				'src/binding/database/backup.cpp',
+				'src/binding/database/checkpoint.cpp',
 				'src/binding/database/database.cpp',
 				'src/binding/database/database_events.cpp',
 				'src/binding/database/db_descriptor.cpp',

--- a/src/binding/database/checkpoint.cpp
+++ b/src/binding/database/checkpoint.cpp
@@ -1,0 +1,189 @@
+#include "database/database.h"
+#include "database/db_handle.h"
+#include "napi/async.h"
+#include "napi/helpers.h"
+#include "napi/macros.h"
+#include "rocksdb/status.h"
+#include "rocksdb/utilities/checkpoint.h"
+#include <memory>
+#include <string>
+
+namespace rocksdb_js {
+
+/**
+ * State for the `Database::CreateCheckpoint` async work. Holds a live `DBHandle`
+ * and its own reference to the descriptor (captured on the JS thread) so the
+ * underlying `rocksdb::DB` stays alive for the entire checkpoint even if
+ * `close()` is called concurrently — `close()` resets the handle's descriptor
+ * after a bounded wait, so relying on `handle->descriptor` from the worker
+ * thread is unsafe. This mirrors `AsyncBackupState`.
+ *
+ * The checkpoint also registers in the descriptor's `operationsInFlight`
+ * counter (see `Database::CreateCheckpoint`). Unlike `close()`, the
+ * `destroy()` / `shutdown()` / `PurgeAll()` teardown paths call
+ * `DBDescriptor::finishClose()` directly without waiting on the async-work
+ * tracker, and `finishClose()` resets `descriptor->db`. Registering in
+ * `operationsInFlight` makes `finishClose()` wait for the copy to finish
+ * before tearing down the database, so the worker never dereferences a
+ * freed `rocksdb::DB`.
+ *
+ * Note: like backup, pinning the descriptor defers the registry purge if a
+ * caller closes the database before the checkpoint settles. That shared
+ * lifecycle wrinkle is tracked separately (HarperFast/rocksdb-js#672); this
+ * method intentionally matches the existing backup behavior rather than
+ * diverging.
+ */
+struct AsyncCheckpointState final : BaseAsyncState<std::shared_ptr<DBHandle>> {
+	std::shared_ptr<DBDescriptor> descriptor;
+	std::string targetPath;
+
+	AsyncCheckpointState(
+		napi_env env,
+		std::shared_ptr<DBHandle> handle,
+		std::shared_ptr<DBDescriptor> descriptor,
+		std::string targetPath
+	) :
+		BaseAsyncState<std::shared_ptr<DBHandle>>(env, handle),
+		descriptor(std::move(descriptor)),
+		targetPath(std::move(targetPath)) {}
+};
+
+/**
+ * RAII release for a descriptor `operationsInFlight` claim made on the JS
+ * thread. Decrements the counter (and wakes a waiting `finishClose()`) on any
+ * early return, unless the claim was handed off to the async worker — which
+ * then owns the matching decrement at the end of its execute callback.
+ */
+struct CheckpointInFlightClaim {
+	DBDescriptor* descriptor;
+	const bool& handedOff;
+
+	~CheckpointInFlightClaim() {
+		if (!handedOff && --descriptor->operationsInFlight == 0 && descriptor->isClosing()) {
+			descriptor->operationsInFlight.notify_all();
+		}
+	}
+};
+
+/**
+ * Creates a hardlinked, point-in-time, fully independent copy of the open
+ * database at `targetPath` using RocksDB's `Checkpoint` API. The target path
+ * must not already exist (RocksDB creates it). Resolves with `undefined`.
+ *
+ * Signature: `createCheckpoint(resolve, reject, targetPath)`
+ *
+ * @example
+ * ```typescript
+ * await db.createCheckpoint('/path/to/checkpoint');
+ * ```
+ */
+napi_value Database::CreateCheckpoint(napi_env env, napi_callback_info info) {
+	NAPI_METHOD_ARGV(3);
+	UNWRAP_DB_HANDLE_AND_OPEN();
+
+	napi_value resolve = argv[0];
+	napi_value reject = argv[1];
+
+	NAPI_GET_STRING(argv[2], targetPath, "Checkpoint target path must be a string");
+
+	// Claim an in-flight operation on the descriptor BEFORE queuing so the
+	// destroy()/shutdown()/PurgeAll() teardown paths — which call
+	// DBDescriptor::finishClose() directly, bypassing the async-work tracker, and
+	// reset descriptor->db — wait for this copy first. Incrementing before
+	// checking isClosing() mirrors OperationGuard: close() publishes the closing
+	// flag (beginClose()) before finishClose() waits on this counter, so if we
+	// still observe isClosing() after our increment the teardown may already be
+	// past its wait and about to free the DB — bail rather than start the copy.
+	auto descriptor = (*dbHandle)->descriptor;
+	++descriptor->operationsInFlight;
+
+	// Releases the claim on any early return below; cleared once the worker takes
+	// ownership of the decrement (at the end of execute) after a successful queue.
+	bool handedOff = false;
+	CheckpointInFlightClaim claim{descriptor.get(), handedOff};
+
+	if (descriptor->isClosing()) {
+		::napi_throw_error(env, nullptr, "Database is closing");
+		NAPI_RETURN_UNDEFINED();
+	}
+
+	auto state = new AsyncCheckpointState(
+		env,
+		*dbHandle,
+		descriptor,
+		std::move(targetPath)
+	);
+
+	NAPI_STATUS_THROWS(::napi_create_reference(env, resolve, 1, &state->resolveRef));
+	NAPI_STATUS_THROWS(::napi_create_reference(env, reject, 1, &state->rejectRef));
+
+	napi_value name;
+	NAPI_STATUS_THROWS(::napi_create_string_utf8(env, "database.createCheckpoint", NAPI_AUTO_LENGTH, &name));
+
+	NAPI_STATUS_THROWS(::napi_create_async_work(
+		env,
+		nullptr,
+		name,
+		[](napi_env, void* data) { // execute
+			auto state = reinterpret_cast<AsyncCheckpointState*>(data);
+			// state->descriptor keeps the rocksdb::DB alive for the whole copy, so
+			// it is safe to use even if close() runs concurrently. isCancelled()
+			// lets us skip starting a checkpoint once close() has been requested.
+			if (!state->descriptor || !state->handle || state->handle->isCancelled()) {
+				state->status = rocksdb::Status::Aborted("Database closed during checkpoint operation");
+			} else {
+				rocksdb::Checkpoint* checkpoint = nullptr;
+				rocksdb::Status s = rocksdb::Checkpoint::Create(state->descriptor->db.get(), &checkpoint);
+				if (s.ok()) {
+					std::unique_ptr<rocksdb::Checkpoint> guard(checkpoint);
+					// log_size_for_flush = 0 (default) always flushes the memtable so
+					// the checkpoint contains up-to-date data even when the WAL is
+					// disabled.
+					s = checkpoint->CreateCheckpoint(state->targetPath);
+				}
+				state->status = s;
+			}
+			// Release the in-flight claim made on the JS thread (the worker owns
+			// this decrement once the work was queued). Wake any finishClose()
+			// waiting for this copy before it tears down descriptor->db. Mirrors
+			// OperationGuard's destructor.
+			if (--state->descriptor->operationsInFlight == 0 && state->descriptor->isClosing()) {
+				state->descriptor->operationsInFlight.notify_all();
+			}
+			state->signalExecuteCompleted();
+		},
+		[](napi_env env, napi_status status, void* data) { // complete
+			auto state = reinterpret_cast<AsyncCheckpointState*>(data);
+			state->deleteAsyncWork();
+			if (status != napi_cancelled) {
+				if (state->status.ok()) {
+					napi_value undefined;
+					NAPI_STATUS_THROWS_VOID(::napi_get_undefined(env, &undefined));
+					state->callResolve(undefined);
+				} else {
+					napi_value error;
+					rocksdb_js::createRocksDBError(env, state->status, "Create checkpoint failed", error);
+					state->callReject(error);
+				}
+			}
+			delete state;
+		},
+		state,
+		&state->asyncWork
+	));
+
+	(*dbHandle)->registerAsyncWork();
+
+	// On a queue failure the claim above rolls the counter back (execute never
+	// runs); the state leak on this rare N-API failure path matches the existing
+	// async methods (e.g. Database::Backup).
+	NAPI_STATUS_THROWS(::napi_queue_async_work(env, state->asyncWork));
+
+	// The worker now owns the in-flight decrement (end of execute); stop the
+	// claim from releasing it here.
+	handedOff = true;
+
+	NAPI_RETURN_UNDEFINED();
+}
+
+} // namespace rocksdb_js

--- a/src/binding/database/checkpoint.cpp
+++ b/src/binding/database/checkpoint.cpp
@@ -126,10 +126,13 @@ napi_value Database::CreateCheckpoint(napi_env env, napi_callback_info info) {
 		name,
 		[](napi_env, void* data) { // execute
 			auto state = reinterpret_cast<AsyncCheckpointState*>(data);
-			// state->descriptor keeps the rocksdb::DB alive for the whole copy, so
-			// it is safe to use even if close() runs concurrently. isCancelled()
-			// lets us skip starting a checkpoint once close() has been requested.
-			if (!state->descriptor || !state->handle || state->handle->isCancelled()) {
+			// state->descriptor is a strong reference held for the whole copy, so it
+			// is always valid here; the operationsInFlight registration keeps
+			// finishClose() from resetting descriptor->db until this work completes,
+			// so the database stays valid even if close() runs concurrently.
+			// isCancelled() lets us skip starting a checkpoint once close() has been
+			// requested.
+			if (!state->handle || state->handle->isCancelled()) {
 				state->status = rocksdb::Status::Aborted("Database closed during checkpoint operation");
 			} else {
 				rocksdb::Checkpoint* checkpoint = nullptr;

--- a/src/binding/database/database.cpp
+++ b/src/binding/database/database.cpp
@@ -1671,6 +1671,7 @@ void Database::Init(napi_env env, napi_value exports) {
 		{ "columns", nullptr, nullptr, Columns, nullptr, nullptr, napi_default, nullptr },
 		{ "compact", nullptr, Compact, nullptr, nullptr, nullptr, napi_default, nullptr },
 		{ "compactSync", nullptr, CompactSync, nullptr, nullptr, nullptr, napi_default, nullptr },
+		{ "createCheckpoint", nullptr, CreateCheckpoint, nullptr, nullptr, nullptr, napi_default, nullptr },
 		{ "destroy", nullptr, Destroy, nullptr, nullptr, nullptr, napi_default, nullptr },
 		{ "drop", nullptr, Drop, nullptr, nullptr, nullptr, napi_default, nullptr },
 		{ "dropSync", nullptr, DropSync, nullptr, nullptr, nullptr, napi_default, nullptr },

--- a/src/binding/database/database.h
+++ b/src/binding/database/database.h
@@ -245,6 +245,7 @@ struct Database final {
 	static napi_value DropSync(napi_env env, napi_callback_info info);
 	static napi_value Compact(napi_env env, napi_callback_info info);
 	static napi_value CompactSync(napi_env env, napi_callback_info info);
+	static napi_value CreateCheckpoint(napi_env env, napi_callback_info info);
 	static napi_value Flush(napi_env env, napi_callback_info info);
 	static napi_value FlushSync(napi_env env, napi_callback_info info);
 	static napi_value Get(napi_env env, napi_callback_info info);

--- a/src/database.ts
+++ b/src/database.ts
@@ -183,8 +183,11 @@ export class RocksDatabase extends DBI<DBITransactional> {
 	 *
 	 * Unlike a backup, a checkpoint is a normal, writable sibling database: open
 	 * it with {@link RocksDatabase.open} and it diverges independently from the
-	 * source. SST files are hardlinked when the target is on the same filesystem,
-	 * so the operation is near-instant; only the memtable is flushed and copied.
+	 * source. SST and blob files are hardlinked when `targetPath` is on the same
+	 * filesystem as the database and copied otherwise (other files such as the
+	 * MANIFEST are always copied), so the operation is near-instant on the same
+	 * filesystem. The memtable is flushed so the checkpoint includes the latest
+	 * writes even when the WAL is disabled.
 	 *
 	 * `targetPath` must not already exist and its parent directory must exist —
 	 * RocksDB creates the checkpoint directory itself. The caller is responsible

--- a/src/database.ts
+++ b/src/database.ts
@@ -178,6 +178,30 @@ export class RocksDatabase extends DBI<DBITransactional> {
 	}
 
 	/**
+	 * Creates a hardlinked, point-in-time, fully independent copy of the entire
+	 * database (all column families) at `targetPath` and resolves once written.
+	 *
+	 * Unlike a backup, a checkpoint is a normal, writable sibling database: open
+	 * it with {@link RocksDatabase.open} and it diverges independently from the
+	 * source. SST files are hardlinked when the target is on the same filesystem,
+	 * so the operation is near-instant; only the memtable is flushed and copied.
+	 *
+	 * `targetPath` must not already exist and its parent directory must exist —
+	 * RocksDB creates the checkpoint directory itself. The caller is responsible
+	 * for eventual cleanup of the directory.
+	 *
+	 * @example
+	 * ```typescript
+	 * const db = RocksDatabase.open('/path/to/database');
+	 * await db.createCheckpoint('/path/to/checkpoint');
+	 * const branch = RocksDatabase.open('/path/to/checkpoint');
+	 * ```
+	 */
+	createCheckpoint(targetPath: string): Promise<void> {
+		return this.store.createCheckpoint(targetPath);
+	}
+
+	/**
 	 * Compacts the entire key range of the database synchronously.
 	 * This triggers manual compaction which removes tombstones and reclaims space.
 	 *

--- a/src/database.ts
+++ b/src/database.ts
@@ -31,6 +31,8 @@ import {
 	TransactionIsBusyError,
 } from './transaction.js';
 import { Encoder as MsgpackEncoder } from 'msgpackr';
+import { existsSync, mkdirSync } from 'node:fs';
+import { dirname } from 'node:path';
 import * as orderedBinary from 'ordered-binary';
 
 export type TransactionCallback<T> = (txn: Transaction, attempt: number) => T | PromiseLike<T>;
@@ -189,9 +191,10 @@ export class RocksDatabase extends DBI<DBITransactional> {
 	 * filesystem. The memtable is flushed so the checkpoint includes the latest
 	 * writes even when the WAL is disabled.
 	 *
-	 * `targetPath` must not already exist and its parent directory must exist —
-	 * RocksDB creates the checkpoint directory itself. The caller is responsible
-	 * for eventual cleanup of the directory.
+	 * Parent directories are created as needed. `targetPath` itself must not
+	 * already exist (RocksDB creates the checkpoint directory) and rejects with
+	 * `Create checkpoint failed: target path exists` if it does. The caller is
+	 * responsible for eventual cleanup of the directory.
 	 *
 	 * @example
 	 * ```typescript
@@ -201,9 +204,17 @@ export class RocksDatabase extends DBI<DBITransactional> {
 	 * ```
 	 */
 	createCheckpoint(targetPath: string): Promise<void> {
-		return new Promise((resolve, reject) =>
-			this.store.db.createCheckpoint(resolve, reject, targetPath)
-		);
+		return new Promise((resolve, reject) => {
+			if (existsSync(targetPath)) {
+				reject(new Error('Create checkpoint failed: target path exists'));
+				return;
+			}
+			// Create parent directories as needed (a throw here rejects the promise),
+			// then hand off to the native worker synchronously so it registers its
+			// in-flight operation before this call returns.
+			mkdirSync(dirname(targetPath), { recursive: true });
+			this.store.db.createCheckpoint(resolve, reject, targetPath);
+		});
 	}
 
 	/**

--- a/src/database.ts
+++ b/src/database.ts
@@ -198,7 +198,9 @@ export class RocksDatabase extends DBI<DBITransactional> {
 	 * ```
 	 */
 	createCheckpoint(targetPath: string): Promise<void> {
-		return this.store.createCheckpoint(targetPath);
+		return new Promise((resolve, reject) =>
+			this.store.db.createCheckpoint(resolve, reject, targetPath)
+		);
 	}
 
 	/**

--- a/src/load-binding.ts
+++ b/src/load-binding.ts
@@ -255,6 +255,11 @@ export type NativeDatabase = {
 	compact(resolve: ResolveCallback<void>, reject: RejectCallback, start?: Key, end?: Key): void;
 	compactSync(start?: Key, end?: Key): void;
 	columns: string[];
+	createCheckpoint(
+		resolve: ResolveCallback<void>,
+		reject: RejectCallback,
+		targetPath: string
+	): void;
 	destroy(): void;
 	drop(resolve: ResolveCallback<void>, reject: RejectCallback): void;
 	dropSync(): void;

--- a/src/store.ts
+++ b/src/store.ts
@@ -427,22 +427,6 @@ export class Store {
 	}
 
 	/**
-	 * Creates a hardlinked, point-in-time, fully independent copy of the entire
-	 * database at `targetPath` using RocksDB's checkpoint API and resolves once
-	 * written. `targetPath` must not already exist and its parent directory must
-	 * exist (RocksDB requires this). The caller is responsible for opening the
-	 * checkpoint as a new database and for eventual cleanup of the directory.
-	 *
-	 * @example
-	 * ```typescript
-	 * await db.createCheckpoint('/path/to/checkpoint');
-	 * ```
-	 */
-	createCheckpoint(targetPath: string): Promise<void> {
-		return new Promise((resolve, reject) => this.db.createCheckpoint(resolve, reject, targetPath));
-	}
-
-	/**
 	 * Compacts the entire key range of the database synchronously.
 	 * This triggers manual compaction which removes tombstones and reclaims space.
 	 *

--- a/src/store.ts
+++ b/src/store.ts
@@ -427,6 +427,22 @@ export class Store {
 	}
 
 	/**
+	 * Creates a hardlinked, point-in-time, fully independent copy of the entire
+	 * database at `targetPath` using RocksDB's checkpoint API and resolves once
+	 * written. `targetPath` must not already exist and its parent directory must
+	 * exist (RocksDB requires this). The caller is responsible for opening the
+	 * checkpoint as a new database and for eventual cleanup of the directory.
+	 *
+	 * @example
+	 * ```typescript
+	 * await db.createCheckpoint('/path/to/checkpoint');
+	 * ```
+	 */
+	createCheckpoint(targetPath: string): Promise<void> {
+		return new Promise((resolve, reject) => this.db.createCheckpoint(resolve, reject, targetPath));
+	}
+
+	/**
 	 * Compacts the entire key range of the database synchronously.
 	 * This triggers manual compaction which removes tombstones and reclaims space.
 	 *

--- a/test/checkpoint.test.ts
+++ b/test/checkpoint.test.ts
@@ -108,24 +108,36 @@ describe('Checkpoints', () => {
 			}
 		}));
 
-	it('should reject when the target path already exists', () =>
+	it('should reject with a simplified error when the target path already exists', () =>
 		dbRunner(async ({ db }) => {
 			await writeAll(db, 5);
 
 			const checkpointDir = tempDir();
 			mkdirSync(checkpointDir, { recursive: true });
 
-			await expect(db.createCheckpoint(checkpointDir)).rejects.toThrow();
+			await expect(db.createCheckpoint(checkpointDir)).rejects.toThrow(
+				'Create checkpoint failed: target path exists'
+			);
 		}));
 
-	it('should reject when the parent directory does not exist', () =>
+	it('should create missing parent directories', () =>
 		dbRunner(async ({ db }) => {
 			await writeAll(db, 5);
 
-			// Parent ("missing") is never created; RocksDB does not create parents.
+			// The "missing" parent does not exist; createCheckpoint creates it.
 			const checkpointDir = join(tempDir(), 'missing', 'checkpoint');
+			expect(existsSync(checkpointDir)).toBe(false);
 
-			await expect(db.createCheckpoint(checkpointDir)).rejects.toThrow();
+			await expect(db.createCheckpoint(checkpointDir)).resolves.toBeUndefined();
+			expect(existsSync(checkpointDir)).toBe(true);
+
+			const checkpoint = new RocksDatabase(checkpointDir);
+			checkpoint.open();
+			try {
+				expect(await checkpoint.get('key-0')).toBe('value-0');
+			} finally {
+				checkpoint.close();
+			}
 		}));
 
 	it('should not crash when closing during a checkpoint', () =>

--- a/test/checkpoint.test.ts
+++ b/test/checkpoint.test.ts
@@ -1,4 +1,4 @@
-import { RocksDatabase } from '../src/index.js';
+import { RocksDatabase, shutdown } from '../src/index.js';
 import { dbRunner, generateDBPath } from './lib/util.js';
 import { existsSync, mkdirSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
@@ -26,6 +26,13 @@ async function writeAll(db: RocksDatabase, count: number, prefix = 'value'): Pro
 
 describe('Checkpoints', () => {
 	afterEach(() => {
+		// The close()/destroy()-during-checkpoint tests can leave a descriptor
+		// pending registry purge (closing before an in-flight, descriptor-pinned
+		// checkpoint settles defers the purge — see #672), which keeps the source
+		// database open and its temp dir locked. That fails cleanup on Windows and
+		// crashes the Bun worker on exit. Purge the registry first so the locks are
+		// released before we remove the directories.
+		shutdown();
 		for (const dir of tempDirs) {
 			rmSync(dir, { force: true, recursive: true, maxRetries: 3, retryDelay: 500 });
 		}

--- a/test/checkpoint.test.ts
+++ b/test/checkpoint.test.ts
@@ -1,0 +1,168 @@
+import { RocksDatabase } from '../src/index.js';
+import { dbRunner, generateDBPath } from './lib/util.js';
+import { existsSync, mkdirSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const tempDirs: string[] = [];
+
+/**
+ * Returns a unique, not-yet-created temp directory path that is cleaned up
+ * after each test. Suitable as a checkpoint target (RocksDB requires the
+ * target to not already exist).
+ */
+function tempDir(): string {
+	const dir = generateDBPath();
+	tempDirs.push(dir);
+	return dir;
+}
+
+async function writeAll(db: RocksDatabase, count: number, prefix = 'value'): Promise<void> {
+	for (let i = 0; i < count; ++i) {
+		await db.put(`key-${i}`, `${prefix}-${i}`);
+	}
+	await db.flush();
+}
+
+describe('Checkpoints', () => {
+	afterEach(() => {
+		for (const dir of tempDirs) {
+			rmSync(dir, { force: true, recursive: true, maxRetries: 3, retryDelay: 500 });
+		}
+		tempDirs.length = 0;
+	});
+
+	it('should create a checkpoint that reads identically to the source', () =>
+		dbRunner(async ({ db }) => {
+			await writeAll(db, 100);
+
+			const checkpointDir = tempDir();
+			await expect(db.createCheckpoint(checkpointDir)).resolves.toBeUndefined();
+			expect(existsSync(checkpointDir)).toBe(true);
+
+			const checkpoint = new RocksDatabase(checkpointDir);
+			checkpoint.open();
+			try {
+				for (let i = 0; i < 100; ++i) {
+					expect(await checkpoint.get(`key-${i}`)).toBe(`value-${i}`);
+				}
+			} finally {
+				checkpoint.close();
+			}
+		}));
+
+	it('should produce an independent, writable database', () =>
+		dbRunner(async ({ db }) => {
+			await writeAll(db, 10);
+
+			const checkpointDir = tempDir();
+			await db.createCheckpoint(checkpointDir);
+
+			const checkpoint = new RocksDatabase(checkpointDir);
+			checkpoint.open();
+			try {
+				// Diverge both databases and assert they do not see each other's writes.
+				await db.put('only-source', 'source');
+				await checkpoint.put('only-checkpoint', 'checkpoint');
+				await db.put('key-0', 'source-updated');
+				await checkpoint.put('key-0', 'checkpoint-updated');
+
+				expect(await db.get('only-source')).toBe('source');
+				expect(await db.get('only-checkpoint')).toBeUndefined();
+				expect(await db.get('key-0')).toBe('source-updated');
+
+				expect(await checkpoint.get('only-checkpoint')).toBe('checkpoint');
+				expect(await checkpoint.get('only-source')).toBeUndefined();
+				expect(await checkpoint.get('key-0')).toBe('checkpoint-updated');
+			} finally {
+				checkpoint.close();
+			}
+		}));
+
+	it('should flush unflushed memtable data into the checkpoint', () =>
+		dbRunner({ dbOptions: [{ disableWAL: true }] }, async ({ db }) => {
+			// No explicit flush — createCheckpoint flushes the memtable by default,
+			// so this data must be present in the checkpoint even with the WAL off.
+			for (let i = 0; i < 25; ++i) {
+				await db.put(`key-${i}`, `value-${i}`);
+			}
+
+			const checkpointDir = tempDir();
+			await db.createCheckpoint(checkpointDir);
+
+			const checkpoint = new RocksDatabase(checkpointDir);
+			checkpoint.open();
+			try {
+				for (let i = 0; i < 25; ++i) {
+					expect(await checkpoint.get(`key-${i}`)).toBe(`value-${i}`);
+				}
+			} finally {
+				checkpoint.close();
+			}
+		}));
+
+	it('should reject when the target path already exists', () =>
+		dbRunner(async ({ db }) => {
+			await writeAll(db, 5);
+
+			const checkpointDir = tempDir();
+			mkdirSync(checkpointDir, { recursive: true });
+
+			await expect(db.createCheckpoint(checkpointDir)).rejects.toThrow();
+		}));
+
+	it('should reject when the parent directory does not exist', () =>
+		dbRunner(async ({ db }) => {
+			await writeAll(db, 5);
+
+			// Parent ("missing") is never created; RocksDB does not create parents.
+			const checkpointDir = join(tempDir(), 'missing', 'checkpoint');
+
+			await expect(db.createCheckpoint(checkpointDir)).rejects.toThrow();
+		}));
+
+	it('should not crash when closing during a checkpoint', () =>
+		dbRunner({ skipOpen: true }, async ({ db }) => {
+			db.open();
+			await writeAll(db, 200);
+
+			const checkpointDir = tempDir();
+			const checkpointPromise = db.createCheckpoint(checkpointDir);
+
+			// Close while the checkpoint is in flight. The descriptor is kept alive
+			// for the duration of the copy, so this must settle cleanly (resolve or
+			// reject) rather than crash.
+			db.close();
+
+			await expect(
+				checkpointPromise.then(
+					() => 'settled',
+					() => 'settled'
+				)
+			).resolves.toBe('settled');
+		}));
+
+	it('should not free the database under an in-flight checkpoint when destroy() races it', () =>
+		dbRunner({ skipOpen: true }, async ({ db }) => {
+			db.open();
+			await writeAll(db, 200);
+
+			const checkpointDir = tempDir();
+			const settled = db.createCheckpoint(checkpointDir).then(
+				() => 'settled',
+				() => 'settled'
+			);
+
+			// destroy() tears down via DBDescriptor::finishClose(), which (unlike
+			// close()) bypasses the async-work tracker. The checkpoint registers in
+			// operationsInFlight, so finishClose() waits for the copy to finish
+			// before resetting descriptor->db — the worker never touches a freed DB.
+			// The in-flight op still holds a descriptor reference, so destroy() throws
+			// rather than tearing the database down mid-copy.
+			expect(() => db.destroy()).toThrow();
+
+			// The checkpoint itself completed (finishClose waited for it), so the
+			// promise settles cleanly and nothing crashes.
+			await expect(settled).resolves.toBe('settled');
+		}));
+});

--- a/test/checkpoint.test.ts
+++ b/test/checkpoint.test.ts
@@ -47,8 +47,7 @@ describe('Checkpoints', () => {
 			await expect(db.createCheckpoint(checkpointDir)).resolves.toBeUndefined();
 			expect(existsSync(checkpointDir)).toBe(true);
 
-			const checkpoint = new RocksDatabase(checkpointDir);
-			checkpoint.open();
+			const checkpoint = RocksDatabase.open(checkpointDir);
 			try {
 				for (let i = 0; i < 100; ++i) {
 					expect(await checkpoint.get(`key-${i}`)).toBe(`value-${i}`);
@@ -65,8 +64,7 @@ describe('Checkpoints', () => {
 			const checkpointDir = tempDir();
 			await db.createCheckpoint(checkpointDir);
 
-			const checkpoint = new RocksDatabase(checkpointDir);
-			checkpoint.open();
+			const checkpoint = RocksDatabase.open(checkpointDir);
 			try {
 				// Diverge both databases and assert they do not see each other's writes.
 				await db.put('only-source', 'source');
@@ -86,9 +84,8 @@ describe('Checkpoints', () => {
 			}
 		}));
 
-	it('should survive the source database being destroyed', () =>
-		dbRunner({ skipOpen: true }, async ({ db, dbPath }) => {
-			db.open();
+	it('should survive the source database being destroyed with checkpoint closed', () =>
+		dbRunner(async ({ db, dbPath }) => {
 			await writeAll(db, 50);
 
 			const checkpointDir = tempDir();
@@ -101,8 +98,34 @@ describe('Checkpoints', () => {
 			// The checkpoint is independent: its SST files are hardlinks, so the
 			// data survives the source's deletion and it remains fully usable and
 			// writable.
-			const checkpoint = new RocksDatabase(checkpointDir);
-			checkpoint.open();
+			const checkpoint = RocksDatabase.open(checkpointDir);
+			try {
+				for (let i = 0; i < 50; ++i) {
+					expect(await checkpoint.get(`key-${i}`)).toBe(`value-${i}`);
+				}
+				await checkpoint.put('after-destroy', 'ok');
+				expect(await checkpoint.get('after-destroy')).toBe('ok');
+			} finally {
+				checkpoint.close();
+			}
+		}));
+
+	it('should survive the source database being destroyed with checkpoint opened', () =>
+		dbRunner(async ({ db, dbPath }) => {
+			await writeAll(db, 50);
+
+			const checkpointDir = tempDir();
+			await db.createCheckpoint(checkpointDir);
+
+			const checkpoint = RocksDatabase.open(checkpointDir);
+
+			// Destroy the source entirely — its directory is removed from disk.
+			db.destroy();
+			expect(existsSync(dbPath)).toBe(false);
+
+			// The checkpoint is independent: its SST files are hardlinks, so the
+			// data survives the source's deletion and it remains fully usable and
+			// writable.
 			try {
 				for (let i = 0; i < 50; ++i) {
 					expect(await checkpoint.get(`key-${i}`)).toBe(`value-${i}`);
@@ -125,8 +148,7 @@ describe('Checkpoints', () => {
 			const checkpointDir = tempDir();
 			await db.createCheckpoint(checkpointDir);
 
-			const checkpoint = new RocksDatabase(checkpointDir);
-			checkpoint.open();
+			const checkpoint = RocksDatabase.open(checkpointDir);
 			try {
 				for (let i = 0; i < 25; ++i) {
 					expect(await checkpoint.get(`key-${i}`)).toBe(`value-${i}`);
@@ -159,8 +181,7 @@ describe('Checkpoints', () => {
 			await expect(db.createCheckpoint(checkpointDir)).resolves.toBeUndefined();
 			expect(existsSync(checkpointDir)).toBe(true);
 
-			const checkpoint = new RocksDatabase(checkpointDir);
-			checkpoint.open();
+			const checkpoint = RocksDatabase.open(checkpointDir);
 			try {
 				expect(await checkpoint.get('key-0')).toBe('value-0');
 			} finally {
@@ -169,8 +190,7 @@ describe('Checkpoints', () => {
 		}));
 
 	it('should not crash when closing during a checkpoint', () =>
-		dbRunner({ skipOpen: true }, async ({ db }) => {
-			db.open();
+		dbRunner(async ({ db }) => {
 			await writeAll(db, 200);
 
 			const checkpointDir = tempDir();
@@ -190,8 +210,7 @@ describe('Checkpoints', () => {
 		}));
 
 	it('should not free the database under an in-flight checkpoint when destroy() races it', () =>
-		dbRunner({ skipOpen: true }, async ({ db }) => {
-			db.open();
+		dbRunner(async ({ db }) => {
 			await writeAll(db, 200);
 
 			const checkpointDir = tempDir();

--- a/test/checkpoint.test.ts
+++ b/test/checkpoint.test.ts
@@ -86,6 +86,34 @@ describe('Checkpoints', () => {
 			}
 		}));
 
+	it('should survive the source database being destroyed', () =>
+		dbRunner({ skipOpen: true }, async ({ db, dbPath }) => {
+			db.open();
+			await writeAll(db, 50);
+
+			const checkpointDir = tempDir();
+			await db.createCheckpoint(checkpointDir);
+
+			// Destroy the source entirely — its directory is removed from disk.
+			db.destroy();
+			expect(existsSync(dbPath)).toBe(false);
+
+			// The checkpoint is independent: its SST files are hardlinks, so the
+			// data survives the source's deletion and it remains fully usable and
+			// writable.
+			const checkpoint = new RocksDatabase(checkpointDir);
+			checkpoint.open();
+			try {
+				for (let i = 0; i < 50; ++i) {
+					expect(await checkpoint.get(`key-${i}`)).toBe(`value-${i}`);
+				}
+				await checkpoint.put('after-destroy', 'ok');
+				expect(await checkpoint.get('after-destroy')).toBe('ok');
+			} finally {
+				checkpoint.close();
+			}
+		}));
+
 	it('should flush unflushed memtable data into the checkpoint', () =>
 		dbRunner({ dbOptions: [{ disableWAL: true }] }, async ({ db }) => {
 			// No explicit flush — createCheckpoint flushes the memtable by default,


### PR DESCRIPTION
Closes #577.

## Summary

Adds `db.createCheckpoint(targetPath: string): Promise<void>` — a thin async wrapper over RocksDB's `Checkpoint::CreateCheckpoint`. It produces a near-instant, hardlinked, point-in-time, fully independent **writable** copy of the whole database (all column families), run off the main thread via an N-API async worker.

- SST/blob files are hardlinked when the target is on the same filesystem; only the memtable is flushed/copied.
- `log_size_for_flush = 0` (always flush) so the checkpoint is up-to-date even when the WAL is disabled.
- `targetPath` must not exist and its parent must exist — RocksDB creates the checkpoint dir. Failures (target exists, missing parent, ENOSPC, EACCES) surface as JS errors with the RocksDB status message.
- Caller opens the checkpoint as a normal `RocksDatabase` and owns cleanup.

Modeled on `Database::Backup`. New native file `src/binding/database/checkpoint.cpp`; TS surface threads `RocksDatabase.createCheckpoint` → `Store.createCheckpoint` → native.

## Where to look

The non-obvious part is **teardown synchronization** in `checkpoint.cpp`, hardened beyond `backup` after cross-model review:

- Like `backup`, the async state pins the `DBDescriptor` to keep `rocksdb::DB` alive during the copy.
- **Beyond backup**, it registers the copy in `descriptor->operationsInFlight`. `destroy()`/`shutdown()`/`PurgeAll()` tear down via `DBDescriptor::finishClose()` directly (bypassing the async-work tracker) and reset `descriptor->db`; registering makes `finishClose()` wait for the copy first, so the worker never dereferences a freed DB.
- The claim uses **increment-then-`isClosing()`** (mirroring `OperationGuard`) with an RAII `CheckpointInFlightClaim` that rolls the counter back on every early-return path, closing the TOCTOU where teardown could already be past its `operationsInFlight == 0` wait.

Please sanity-check that synchronization against `OperationGuard`/`ACQUIRE_OPERATIONS_LOCK` and `DBDescriptor::finishClose`.

## Deliberately out of scope (tracked in #672)

The descriptor-pin defers the registry purge if a caller `close()`s before the op settles — a pre-existing characteristic shared with `backup`. `backup` also lacks the `operationsInFlight` guard this PR adds to checkpoint. Both are tracked in #672 (proper fix needs registry purge-retry machinery + the Guard Malloc teardown harness) rather than expanded here, to keep this PR scoped to #577.

## Tests

`test/checkpoint.test.ts`: identical reads, write isolation, memtable-flush-with-WAL-off, target-exists & missing-parent rejection, close-during-checkpoint crash-safety, and a deterministic destroy-races-checkpoint test exercising the `operationsInFlight` guard.

---
🤖 Generated by Claude (Opus 4.8). Cross-model reviewed by Codex (clean) and Gemini.