### PR TITLE
ci: re-run failed Dependabot checks once fresh deps age out

### DIFF
--- a/.github/workflows/retry-dependabot.yml
+++ b/.github/workflows/retry-dependabot.yml
@@ -1,0 +1,72 @@
+name: Retry Dependabot Checks
+
+# Dependabot's `cooldown` only delays the *direct* dependency it bumps. When it
+# regenerates pnpm-lock.yaml, pnpm re-resolves transitive deps to their latest
+# versions, and any transitive dep published within pnpm's `minimumReleaseAge`
+# window (see pnpm-workspace.yaml) fails the supply-chain check at install time
+# — turning the whole PR red for reasons unrelated to the bump.
+#
+# Those deps always age past the cutoff within a day, so this workflow simply
+# re-runs the failed checks on open Dependabot PRs. It re-uses the exact same
+# committed lockfile (no `recreate`, which could pull in another fresh dep and
+# restart the clock); only time has passed, so the age check now passes.
+
+on:
+  schedule:
+    # Daily, after Dependabot's 05:15 UTC run. By 06:00 the previous day's deps
+    # have cleared the 24h cutoff; a PR opened today is retried tomorrow.
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+
+permissions:
+  actions: write
+  pull-requests: read
+
+concurrency:
+  cancel-in-progress: true
+  group: ${{ github.workflow }}
+
+jobs:
+  retry:
+    name: Retry failed Dependabot checks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Re-run failed checks on open Dependabot PRs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # Head SHAs of every open Dependabot PR.
+          shas=$(gh pr list \
+            --author 'app/dependabot' \
+            --state open \
+            --json headRefOid \
+            --jq '.[].headRefOid')
+
+          if [ -z "$shas" ]; then
+            echo "No open Dependabot PRs."
+            exit 0
+          fi
+
+          for sha in $shas; do
+            echo "::group::PR head $sha"
+            # Failed workflow runs for this commit.
+            runs=$(gh run list \
+              --commit "$sha" \
+              --status failure \
+              --json databaseId \
+              --jq '.[].databaseId')
+
+            if [ -z "$runs" ]; then
+              echo "No failed runs."
+            else
+              for run in $runs; do
+                echo "Re-running failed jobs in run $run"
+                gh run rerun "$run" --failed || echo "Could not re-run $run (may be too old or already running)"
+              done
+            fi
+            echo "::endgroup::"
+          done


### PR DESCRIPTION
## Problem

Dependabot PRs intermittently go fully red on the dependency **install** step, not in any test:

```
[ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION] 1 lockfile entries failed verification:
  nanoid@3.3.15 was published at ..., within the minimumReleaseAge cutoff (...)
```

Dependabot's `cooldown` (`.github/dependabot.yml`) only gates the **direct** dependency being bumped. When Dependabot regenerates `pnpm-lock.yaml`, pnpm re-resolves **transitive** deps to their latest versions, and any transitive dep published within pnpm's `minimumReleaseAge` window (`pnpm-workspace.yaml`) is rejected at install time. The two cooldowns operate on disjoint sets (direct vs. all deps), so tuning the Dependabot cooldown can't fix it — it's a structural mismatch, not a misconfiguration.

Example: [#671](https://github.com/HarperFast/rocksdb-js/pull/671) failed only because the transitive `nanoid@3.3.15` was ~19h old when CI ran.

## Fix

The offending transitive dep always clears the 24h cutoff within a day. This scheduled workflow re-runs the failed checks on open Dependabot PRs after they've aged out.

It deliberately **re-runs the existing runs** rather than issuing `@dependabot recreate`: re-running re-uses the exact same committed lockfile, so the only thing that changes is that time has passed and the age check now passes. `recreate` would re-resolve and could pull in *another* freshly-published transitive dep, restarting the 24h clock.

- Runs daily at 06:00 UTC (after Dependabot's 05:15 run) + `workflow_dispatch`.
- Lists open Dependabot PRs, finds failed workflow runs for each head SHA, and `gh run rerun --failed`.
- Minimal permissions: `actions: write`, `pull-requests: read`; uses the default `GITHUB_TOKEN`.

Supply-chain protection is unchanged — the `minimumReleaseAge` policy still runs and still blocks genuinely too-fresh deps; this only retries once they're old enough.

🤖 Generated with [Claude Code](https://claude.com/claude-code)