### PR TITLE
Correct findPositionByTimestamp docstring to match running-maxima semantics

### DIFF
--- a/src/binding/transaction_log/transaction_log_file.cpp
+++ b/src/binding/transaction_log/transaction_log_file.cpp
@@ -385,10 +385,16 @@ std::shared_ptr<MemoryMap> TransactionLogFile::getMemoryMap(uint32_t fileSize, b
 }
 
 /**
- * Find the position of a timestamp, specifically the position where there are no transactions with an earlier timestamp
- * @param timestamp - the timestamp to find the position of
+ * Find the start position for a forward scan of all transactions with timestamp >= the given one:
+ * the position of the first entry whose timestamp is >= `timestamp`, such that no entry BEFORE it
+ * has a timestamp >= `timestamp` (a tight lower bound to begin scanning). This is a running-maxima
+ * index, so it gives no UPPER bound — on an out-of-order log, entries with timestamp >= `timestamp`
+ * may still appear after the returned position, and an absent `timestamp` scans to end-of-log. The
+ * caller filters each entry and is responsible for any stop condition.
+ * @param timestamp - the timestamp to find the start position for
  * @param mapSize - the size of the memory map to search in
- * @return the position of the timestamp, or zero if comes before this logfile, or 0xFFFFFFFF if it comes after this logfile
+ * @return the position of the first entry >= timestamp, or zero if it precedes this log file's
+ *         header timestamp, or 0xFFFFFFFF if it follows every entry in this log file
  */
 uint32_t TransactionLogFile::findPositionByTimestamp(double timestamp, uint32_t mapSize, bool isCurrent, bool fileMutexHeld) {
 	DEBUG_LOG("%p TransactionLogFile::findPositionByTimestamp Finding position for timestamp=%f, mapSize=%u\n", this, timestamp, mapSize);


### PR DESCRIPTION
## Summary

Doc-only fix. Corrects the `findPositionByTimestamp` function docstring
(`src/binding/transaction_log/transaction_log_file.cpp`) to match what the code actually
computes. No behavior change.

## Why

The old docstring — *"the position where there are no transactions with an earlier timestamp"* —
reads like a suffix guarantee. The function actually builds a **running-maxima** index answered
with `lower_bound`: it returns the first entry with timestamp `>= t` such that no entry *before*
it is `>= t` — i.e. a tight **lower bound to START a forward scan**, with no upper bound. The
N-API wrapper docstring (`transaction_log.cpp`) and the inline comment in this same function
already state the correct semantics; only the function-level docstring was inverted.

## Notes

- The "no upper bound" property (an absent-timestamp `exactStart` query scans to end-of-log) is
  a real but separate, optional perf enhancement — tracked in #676, not addressed here.
- Trivial doc change; no tests/behavior affected.

_Generated with assistance from Claude (Opus 4.8)._
