### PR TITLE
Pin Deno CI to 2.8.3 after Vitest resolution regression

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -200,7 +200,8 @@ jobs:
       - name: Install Deno
         uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2.0.4
         with:
-          deno-version: latest
+          # 2.9.0 fails to resolve vitest's transitive @vitest/utils under pnpm's layout.
+          deno-version: 2.8.3
 
       - name: Setup dependencies
         uses: ./.github/actions/setup-deps


### PR DESCRIPTION
## Summary
- Pin the Deno CI job to 2.8.3 instead of `latest`.
- Deno 2.9.0 fails to resolve vitest's transitive `@vitest/utils` dependency under pnpm's nested `node_modules` layout, breaking `pnpm test:deno`.

## Test plan
- [ ] CI Deno job passes on ubuntu, macOS, and Windows with Deno 2.8.3
- [ ] Revert or bump the pin once Deno fixes nested npm resolution under pnpm


Made with [Cursor](https://cursor.com)