### PR TITLE
VerificationTable invalidation hardening: clear() sweep, non-txn write settle, snapshot TOCTOU, backdated-version gate

### DIFF
--- a/src/binding/core/verification_table.cpp
+++ b/src/binding/core/verification_table.cpp
@@ -255,6 +255,34 @@ void VerificationTable::unrefTracker(LockTracker* t) {
 	if (t->refcount.fetch_sub(1, std::memory_order_acq_rel) == 1) delete t;
 }
 
+void VerificationTable::settleAllSlots() {
+	if (!slots_) return;
+	size_t n = mask_ + 1;
+	for (size_t i = 0; i < n; ++i) {
+		uint64_t v = slots_[i].load(std::memory_order_acquire);
+		// Skip lock slots — the write-intent lifecycle (releaseWriteIntent)
+		// advances them to a fresh settled-empty when the last holder releases.
+		// A concurrent lockSlotForWrite uses an unconditional store (under
+		// writerMutex_) that can race with our CAS; if it wins, the slot is a
+		// lock that will advance further when committed/aborted — still correct.
+		if (vtIsLock(v)) continue;
+		// CAS non-lock (version or settled-empty) to a fresh generation. On CAS
+		// failure the current value is loaded into v; if it's now a lock we
+		// stop (handled above). If it's a different non-lock value (concurrent
+		// populate or another sweep) we retry once more to ensure advancement.
+		while (!vtIsLock(v)) {
+			if (slots_[i].compare_exchange_strong(
+					v,
+					vtEncodeSettled(vtNextSettleGen()),
+					std::memory_order_release,
+					std::memory_order_acquire)) {
+				break;
+			}
+			// v has been reloaded by the failed CAS; if now a lock, exit.
+		}
+	}
+}
+
 void VerificationTable::cancelForDB(uintptr_t dbPtr) {
 	if (!slots_) return;
 	std::lock_guard<std::mutex> lock(writerMutex_);

--- a/src/binding/core/verification_table.cpp
+++ b/src/binding/core/verification_table.cpp
@@ -258,6 +258,11 @@ void VerificationTable::unrefTracker(LockTracker* t) {
 void VerificationTable::settleAllSlots() {
 	if (!slots_) return;
 	size_t n = mask_ + 1;
+	// One fresh generation shared by every slot in this sweep: the CAS is
+	// per-slot, so uniqueness only matters versus values a reader may have
+	// previously observed in that slot — a just-minted generation satisfies
+	// that for all slots, and hoisting avoids n atomic fetch-adds.
+	const uint64_t settledValue = vtEncodeSettled(vtNextSettleGen());
 	for (size_t i = 0; i < n; ++i) {
 		uint64_t v = slots_[i].load(std::memory_order_acquire);
 		// Skip lock slots — the write-intent lifecycle (releaseWriteIntent)
@@ -266,19 +271,17 @@ void VerificationTable::settleAllSlots() {
 		// writerMutex_) that can race with our CAS; if it wins, the slot is a
 		// lock that will advance further when committed/aborted — still correct.
 		if (vtIsLock(v)) continue;
-		// CAS non-lock (version or settled-empty) to a fresh generation. On CAS
-		// failure the current value is loaded into v; if it's now a lock we
-		// stop (handled above). If it's a different non-lock value (concurrent
-		// populate or another sweep) we retry once more to ensure advancement.
+		// CAS non-lock (version or settled-empty) to the sweep generation,
+		// retrying until the CAS lands or the slot turns into a lock (each
+		// failed CAS reloads v; a lock exits via the loop condition).
 		while (!vtIsLock(v)) {
 			if (slots_[i].compare_exchange_strong(
 					v,
-					vtEncodeSettled(vtNextSettleGen()),
+					settledValue,
 					std::memory_order_release,
 					std::memory_order_acquire)) {
 				break;
 			}
-			// v has been reloaded by the failed CAS; if now a lock, exit.
 		}
 	}
 }

--- a/src/binding/core/verification_table.h
+++ b/src/binding/core/verification_table.h
@@ -211,6 +211,29 @@ public:
 	 */
 	void cancelForDB(uintptr_t dbPtr);
 
+	/**
+	 * Sweeps every non-lock slot in the table and advances it to a fresh
+	 * settled-empty generation. Called after a bulk-delete operation (clear)
+	 * to ensure that any pre-clear version cached in a slot can no longer be
+	 * re-published via a concurrent populate CAS. The sweep is coarse (it
+	 * covers all slots, not just those for the cleared store) because slot
+	 * identities are not tracked in version or settled-empty slots — only in
+	 * LockTracker, which belongs to lock slots that are intentionally skipped.
+	 *
+	 * Lock slots are skipped: the write-intent lifecycle already advances them
+	 * to a fresh settled-empty generation when the last holder releases. A
+	 * concurrent lockSlotForWrite may overwrite a slot we just settled via an
+	 * unconditional store (not a CAS) — this is safe because the subsequent
+	 * commit+releaseWriteIntent also advances to a new generation, blocking
+	 * any pre-clear populate that observed the slot value before the clear.
+	 *
+	 * Ordering: call AFTER the data-delete operations complete. Any stale
+	 * version that a concurrent reader published between delete-start and
+	 * sweep-start is overwritten by the sweep; after the sweep verifyVersion
+	 * with any pre-clear version returns false.
+	 */
+	void settleAllSlots();
+
 	// ---- Write-intent lifecycle (LockTracker management) ----
 	//
 	// These four methods own the full lifecycle of a slot's LockTracker and are

--- a/src/binding/database/database.cpp
+++ b/src/binding/database/database.cpp
@@ -474,6 +474,14 @@ napi_value Database::Drop(napi_env env, napi_callback_info info) {
 		// owns the unregister; the name may now point to a freshly-created
 		// family, so unregistering here would corrupt the registry.
 		(*dbHandle)->descriptor->unregisterColumnFamily((*dbHandle)->getColumnFamilyName());
+		// Dropping a column family bulk-deletes its data exactly like clear();
+		// sweep the VT so pre-drop versions can no longer verify FRESH (see
+		// DBHandle::clear). Only on the ok path — on already-dropped, the
+		// handle that performed the drop owns the sweep.
+		if ((*dbHandle)->enableVerificationTable) {
+			VerificationTable* vt = DBSettings::getInstance().getVerificationTableRaw();
+			if (vt) vt->settleAllSlots();
+		}
 	}
 
 	NAPI_STATUS_THROWS_ERROR(::napi_call_function(
@@ -520,6 +528,14 @@ napi_value Database::DropSync(napi_env env, napi_callback_info info) {
 		// owns the unregister; the name may now point to a freshly-created
 		// family, so unregistering here would corrupt the registry.
 		(*dbHandle)->descriptor->unregisterColumnFamily((*dbHandle)->getColumnFamilyName());
+		// Dropping a column family bulk-deletes its data exactly like clear();
+		// sweep the VT so pre-drop versions can no longer verify FRESH (see
+		// DBHandle::clear). Only on the ok path — on already-dropped, the
+		// handle that performed the drop owns the sweep.
+		if ((*dbHandle)->enableVerificationTable) {
+			VerificationTable* vt = DBSettings::getInstance().getVerificationTableRaw();
+			if (vt) vt->settleAllSlots();
+		}
 	}
 
 	DEBUG_LOG("%p Database::DropSync dropped database\n", dbHandle->get());

--- a/src/binding/database/database.cpp
+++ b/src/binding/database/database.cpp
@@ -1019,7 +1019,7 @@ napi_value Database::GetSync(napi_env env, napi_callback_info info) {
 
 	bool wantsPopulate = (flags & POPULATE_VERSION_FLAG) != 0;
 
-	// FIX C: For transactional reads, establish the snapshot BEFORE loading
+	// For transactional reads, establish the snapshot BEFORE loading
 	// the VT slot. If we loaded the slot first, a complete write cycle
 	// (lock → commit → settle) landing between the slot load and
 	// ensureSnapshot() would let us pass the FRESH check for V_old while
@@ -1489,7 +1489,7 @@ napi_value Database::PutSync(napi_env env, napi_callback_info info) {
 			*dbHandle
 		);
 	} else {
-		// FIX B: Lock the VT slot before the write and settle it after, so
+		// Lock the VT slot before the write and settle it after, so
 		// readers see a lock (not a stale version) during the write window.
 		// This mirrors the transactional path (putSync → lockVTSlot → commit →
 		// releaseWriteIntent). Without pre-locking, a reader that observes the
@@ -1558,7 +1558,7 @@ napi_value Database::RemoveSync(napi_env env, napi_callback_info info) {
 		}
 		status = txnHandle->removeSync(keySlice, *dbHandle);
 	} else {
-		// FIX B: Same lock-before-write, settle-after pattern as PutSync above.
+		// Same lock-before-write, settle-after pattern as PutSync above.
 		VerificationTable* vt = (*dbHandle)->enableVerificationTable
 			? DBSettings::getInstance().getVerificationTableRaw()
 			: nullptr;

--- a/src/binding/database/database.cpp
+++ b/src/binding/database/database.cpp
@@ -9,6 +9,7 @@
 #include "database/db_settings.h"
 #include "napi/macros.h"
 #include "transaction/transaction.h"
+#include "transaction/transaction_handle.h"
 #include "core/platform.h"
 #include "napi/helpers.h"
 #include "napi/async.h"
@@ -1002,10 +1003,32 @@ napi_value Database::GetSync(napi_env env, napi_callback_info info) {
 
 	bool wantsPopulate = (flags & POPULATE_VERSION_FLAG) != 0;
 
+	// FIX C: For transactional reads, establish the snapshot BEFORE loading
+	// the VT slot. If we loaded the slot first, a complete write cycle
+	// (lock → commit → settle) landing between the slot load and
+	// ensureSnapshot() would let us pass the FRESH check for V_old while
+	// pinning a snapshot that already sees V_new — a torn view. Establishing
+	// the snapshot first ensures the write cycle's lock is visible in the VT
+	// before our load, so any FRESH hit is consistent with the snapshot.
+	// For non-transactional reads (no txnId) there is no snapshot to establish,
+	// so the TOCTOU does not apply.
+	std::shared_ptr<TransactionHandle> txnHandle;
+	if (txnIdType == napi_number) {
+		uint32_t txnId;
+		NAPI_STATUS_THROWS(::napi_get_value_uint32(env, argv[2], &txnId));
+		txnHandle = (*dbHandle)->descriptor->transactionGet(txnId);
+		if (!txnHandle) {
+			std::string errorMsg = "Get sync failed: Transaction not found (txnId: " + std::to_string(txnId) + ")";
+			::napi_throw_error(env, nullptr, errorMsg.c_str());
+			NAPI_RETURN_UNDEFINED();
+		}
+		txnHandle->ensureSnapshot();
+	}
+
 	std::atomic<uint64_t>* vtSlot = nullptr;
-	// Slot value observed up front (before the read below). Reused for both the
-	// fast-path check and the post-read conditional CAS, so the populate only
-	// succeeds if nothing changed the slot across the read.
+	// Slot value observed up front (after snapshot is established). Reused for
+	// both the fast-path check and the post-read conditional CAS, so the
+	// populate only succeeds if nothing changed the slot across the read.
 	uint64_t vtObserved = 0;
 	if (hasExpectedVersion || wantsPopulate) {
 		vtSlot = vtSlotFor(*dbHandle, DBSettings::getInstance().getVerificationTable(), keySlice);
@@ -1013,22 +1036,8 @@ napi_value Database::GetSync(napi_env env, napi_callback_info info) {
 	}
 
 	// Fast path: caller-supplied version matches the table — return FRESH
-	// sentinel without touching RocksDB.
+	// sentinel without touching RocksDB. Snapshot already established above.
 	if (vtSlot != nullptr && hasExpectedVersion && vtObserved == expectedVersion) {
-		// When this read belongs to a transaction, still establish that
-		// transaction's snapshot even though the value is served from the VT.
-		// Optimistic conflict detection at commit time needs a read-time
-		// snapshot baseline; skipping it lets a read-modify-write whose read
-		// is served from the VT commit with no snapshot, so concurrent writes
-		// to the same key are not detected (lost updates).
-		if (txnIdType == napi_number) {
-			uint32_t txnId;
-			NAPI_STATUS_THROWS(::napi_get_value_uint32(env, argv[2], &txnId));
-			auto txnHandle = (*dbHandle)->descriptor->transactionGet(txnId);
-			if (txnHandle) {
-				txnHandle->ensureSnapshot();
-			}
-		}
 		napi_value result;
 		NAPI_STATUS_THROWS(::napi_create_int32(env, FRESH_VERSION_FLAG, &result));
 		return result;
@@ -1043,16 +1052,7 @@ napi_value Database::GetSync(napi_env env, napi_callback_info info) {
 	// Tracks the snapshot the read observed (nullptr ⇒ latest committed state),
 	// so the VT populate can tell whether the value just read is the latest.
 	const rocksdb::Snapshot* readSnapshot = nullptr;
-	if (txnIdType == napi_number) {
-		uint32_t txnId;
-		NAPI_STATUS_THROWS(::napi_get_value_uint32(env, argv[2], &txnId));
-
-		auto txnHandle = (*dbHandle)->descriptor->transactionGet(txnId);
-		if (!txnHandle) {
-			std::string errorMsg = "Get sync failed: Transaction not found (txnId: " + std::to_string(txnId) + ")";
-			::napi_throw_error(env, nullptr, errorMsg.c_str());
-			NAPI_RETURN_UNDEFINED();
-		}
+	if (txnHandle) {
 		status = txnHandle->getSync(keySlice, value, readOptions, *dbHandle);
 		readSnapshot = txnHandle->readSnapshot();
 	} else {
@@ -1473,6 +1473,23 @@ napi_value Database::PutSync(napi_env env, napi_callback_info info) {
 			*dbHandle
 		);
 	} else {
+		// FIX B: Lock the VT slot before the write and settle it after, so
+		// readers see a lock (not a stale version) during the write window.
+		// This mirrors the transactional path (putSync → lockVTSlot → commit →
+		// releaseWriteIntent). Without pre-locking, a reader that observes the
+		// old VT version just before the write and populates it just after the
+		// write completes (but before any settle) could publish a stale value.
+		VerificationTable* vt = (*dbHandle)->enableVerificationTable
+			? DBSettings::getInstance().getVerificationTableRaw()
+			: nullptr;
+		std::atomic<uint64_t>* vtSlot = nullptr;
+		LockTracker* vtTracker = nullptr;
+		if (vt) {
+			uintptr_t dbPtr = reinterpret_cast<uintptr_t>((*dbHandle)->descriptor.get());
+			uint32_t cfId = (*dbHandle)->getColumnFamilyHandle()->GetID();
+			vtSlot = vt->slotFor(dbPtr, cfId, keySlice);
+			vtTracker = vt->lockSlotForWrite(vtSlot, dbPtr);
+		}
 		rocksdb::WriteOptions writeOptions;
 		writeOptions.disableWAL = (*dbHandle)->disableWAL;
 		status = (*dbHandle)->descriptor->db->Put(
@@ -1481,6 +1498,9 @@ napi_value Database::PutSync(napi_env env, napi_callback_info info) {
 			keySlice,
 			valueSlice
 		);
+		if (vt && vtSlot) {
+			vt->releaseWriteIntent(vtSlot, vtTracker);
+		}
 	}
 
 	if (!status.ok()) {
@@ -1522,6 +1542,18 @@ napi_value Database::RemoveSync(napi_env env, napi_callback_info info) {
 		}
 		status = txnHandle->removeSync(keySlice, *dbHandle);
 	} else {
+		// FIX B: Same lock-before-write, settle-after pattern as PutSync above.
+		VerificationTable* vt = (*dbHandle)->enableVerificationTable
+			? DBSettings::getInstance().getVerificationTableRaw()
+			: nullptr;
+		std::atomic<uint64_t>* vtSlot = nullptr;
+		LockTracker* vtTracker = nullptr;
+		if (vt) {
+			uintptr_t dbPtr = reinterpret_cast<uintptr_t>((*dbHandle)->descriptor.get());
+			uint32_t cfId = (*dbHandle)->getColumnFamilyHandle()->GetID();
+			vtSlot = vt->slotFor(dbPtr, cfId, keySlice);
+			vtTracker = vt->lockSlotForWrite(vtSlot, dbPtr);
+		}
 		rocksdb::WriteOptions writeOptions;
 		writeOptions.disableWAL = (*dbHandle)->disableWAL;
 		status = (*dbHandle)->descriptor->db->Delete(
@@ -1529,6 +1561,9 @@ napi_value Database::RemoveSync(napi_env env, napi_callback_info info) {
 			(*dbHandle)->getColumnFamilyHandle(),
 			keySlice
 		);
+		if (vt && vtSlot) {
+			vt->releaseWriteIntent(vtSlot, vtTracker);
+		}
 	}
 
 	if (!status.ok()) {

--- a/src/binding/database/database.h
+++ b/src/binding/database/database.h
@@ -151,10 +151,15 @@ inline void vtPopulateIfSettled(
 		// Gate 2: sequence-number gate for backdated replicated versions.
 		// Only run when Gate 1 passes (there IS an open snapshot, but the
 		// version's timestamp predates it — exactly the backdated-write case).
+		// No `oldestSnapshotSeq != 0` guard: a snapshot taken on a fresh DB
+		// legitimately has sequence 0, and exempting it would let a backdated
+		// write at seq > 0 publish past it. hasOpenSnapshot already guarantees
+		// a snapshot exists; if GetIntProperty fails (property unsupported)
+		// the && short-circuit skips the gate.
 		uint64_t oldestSnapshotSeq = 0;
 		uint64_t latestSeq = db->GetLatestSequenceNumber();
 		if (db->GetIntProperty(cf, "rocksdb.oldest-snapshot-sequence", &oldestSnapshotSeq) &&
-		    oldestSnapshotSeq != 0 && oldestSnapshotSeq < latestSeq) {
+		    oldestSnapshotSeq < latestSeq) {
 			// Some snapshot was taken before the latest write. We cannot
 			// determine without the key's individual write sequence whether
 			// that snapshot sees this version, so we defer conservatively.

--- a/src/binding/database/database.h
+++ b/src/binding/database/database.h
@@ -117,7 +117,7 @@ inline void vtPopulateIfSettled(
 		if (version == 0 || vtIsLock(version)) return;
 	}
 
-	// FIX D: Two-gate snapshot check.
+	// Two-gate snapshot check.
 	//
 	// Gate 1 (wall-clock, pre-filter): suppresses publication when the version
 	// is forward-dated relative to the oldest open snapshot — the common case

--- a/src/binding/database/database.h
+++ b/src/binding/database/database.h
@@ -117,20 +117,47 @@ inline void vtPopulateIfSettled(
 		if (version == 0 || vtIsLock(version)) return;
 	}
 
+	// FIX D: Two-gate snapshot check.
+	//
+	// Gate 1 (wall-clock, pre-filter): suppresses publication when the version
+	// is forward-dated relative to the oldest open snapshot — the common case
+	// for locally-minted versions that race with a snapshot reader. Fast: a
+	// single GetIntProperty call.
+	//
+	// Gate 2 (sequence number): suppresses publication when any open snapshot
+	// predates the latest write in the DB. This catches backdated replicated /
+	// catch-up writes whose origin timestamp (Gate 1's comparand) lies BEFORE
+	// the oldest snapshot's creation time but whose local write sequence lies
+	// AFTER the snapshot's sequence — a case Gate 1 incorrectly passes. We
+	// capture the latest sequence at the point of population; if oldest-snapshot
+	// sequence < latest sequence, some snapshot does not see the latest write
+	// and we defer publication until the snapshot drains.
+	//
+	// Gate 2 is conservative in active systems (any open snapshot + any write
+	// after the snapshot blocks publication). In practice Harper transaction
+	// bodies are short-lived, so slots settle quickly between transactions.
+	// "rocksdb.oldest-snapshot-sequence" is available in the vendored RocksDB
+	// (confirmed in include/rocksdb/db.h kOldestSnapshotSequence).
 	uint64_t oldestSnapshotSec = 0;
-	// rocksdb.oldest-snapshot-time is the wall-clock unix-seconds creation time
-	// of the oldest live snapshot, or 0 when none are open.
-	if (db->GetIntProperty(cf, "rocksdb.oldest-snapshot-time", &oldestSnapshotSec) &&
-	    oldestSnapshotSec != 0) {
-		// `version` is the host-endian bit pattern of the float64 ms timestamp
-		// Harper writes at offset 0 of each record; reinterpret it to compare
-		// against the snapshot's wall-clock time. Conservative at second
-		// granularity: require the oldest snapshot to have been created at/after
-		// the latest version's millisecond, so every open snapshot already sees
-		// it (single accessible value). Otherwise leave the slot unpopulated.
+	bool hasOpenSnapshot = db->GetIntProperty(cf, "rocksdb.oldest-snapshot-time", &oldestSnapshotSec) &&
+	                       oldestSnapshotSec != 0;
+	if (hasOpenSnapshot) {
+		// Gate 1: forward-dated version.
 		double versionMs;
 		std::memcpy(&versionMs, &version, sizeof(double));
 		if (static_cast<double>(oldestSnapshotSec) * 1000.0 < versionMs) {
+			return;
+		}
+		// Gate 2: sequence-number gate for backdated replicated versions.
+		// Only run when Gate 1 passes (there IS an open snapshot, but the
+		// version's timestamp predates it — exactly the backdated-write case).
+		uint64_t oldestSnapshotSeq = 0;
+		uint64_t latestSeq = db->GetLatestSequenceNumber();
+		if (db->GetIntProperty(cf, "rocksdb.oldest-snapshot-sequence", &oldestSnapshotSeq) &&
+		    oldestSnapshotSeq != 0 && oldestSnapshotSeq < latestSeq) {
+			// Some snapshot was taken before the latest write. We cannot
+			// determine without the key's individual write sequence whether
+			// that snapshot sees this version, so we defer conservatively.
 			return;
 		}
 	}

--- a/src/binding/database/db_handle.cpp
+++ b/src/binding/database/db_handle.cpp
@@ -2,7 +2,9 @@
 #include "database/db_handle.h"
 #include "database/db_descriptor.h"
 #include "database/db_registry.h"
+#include "database/db_settings.h"
 #include "transaction_log/transaction_log_store_registry.h"
+#include "core/verification_table.h"
 
 namespace rocksdb_js {
 
@@ -96,7 +98,24 @@ rocksdb::Status DBHandle::clear() {
 		return status;
 	}
 	// it appears we do not need to call WaitForCompact for this to work
-	return rocksdb::DeleteFilesInRange(this->descriptor->db.get(), this->columnDescriptor->column.get(), nullptr, nullptr);
+	rocksdb::Status clearStatus = rocksdb::DeleteFilesInRange(
+		this->descriptor->db.get(), this->columnDescriptor->column.get(), nullptr, nullptr
+	);
+	// FIX A: After data is deleted, advance all non-lock VT slots to fresh
+	// settled-empty generations. This prevents stale pre-clear versions from
+	// being re-published via a concurrent populate CAS. The sweep is coarse
+	// (covers all slots in the process-global table) since slot provenance is
+	// not tracked for non-lock slots; the cost is spurious cache misses for
+	// other stores, which is acceptable given clear() is already a rare,
+	// expensive operation. Lock slots are skipped — the write-intent lifecycle
+	// handles them independently. We sweep regardless of clearStatus: if the
+	// delete partially succeeded, any keys that were removed must not remain
+	// cacheable via stale VT entries.
+	if (this->enableVerificationTable) {
+		VerificationTable* vt = DBSettings::getInstance().getVerificationTableRaw();
+		if (vt) vt->settleAllSlots();
+	}
+	return clearStatus;
 }
 
 /**

--- a/src/binding/database/db_handle.cpp
+++ b/src/binding/database/db_handle.cpp
@@ -101,7 +101,7 @@ rocksdb::Status DBHandle::clear() {
 	rocksdb::Status clearStatus = rocksdb::DeleteFilesInRange(
 		this->descriptor->db.get(), this->columnDescriptor->column.get(), nullptr, nullptr
 	);
-	// FIX A: After data is deleted, advance all non-lock VT slots to fresh
+	// After data is deleted, advance all non-lock VT slots to fresh
 	// settled-empty generations. This prevents stale pre-clear versions from
 	// being re-published via a concurrent populate CAS. The sweep is coarse
 	// (covers all slots in the process-global table) since slot provenance is

--- a/src/binding/transaction/transaction.cpp
+++ b/src/binding/transaction/transaction.cpp
@@ -650,9 +650,19 @@ napi_value Transaction::GetSync(napi_env env, napi_callback_info info) {
 
 	bool wantsPopulate = (flags & POPULATE_VERSION_FLAG) != 0;
 
+	// FIX C: Establish the transaction snapshot BEFORE loading the VT slot.
+	// If we loaded the slot first, a complete write cycle (lock → commit →
+	// settle) landing in the window between the slot load and the snapshot-set
+	// could let us observe V_old in the slot, pass the fast-path check, and
+	// then pin a snapshot that already sees V_new — a torn view where the VT
+	// says FRESH for V_old but the transaction's snapshot is post-V_new.
+	// Pinning the snapshot first ensures that the write cycle's lock clears
+	// the slot before our load, so a FRESH hit is consistent with the snapshot.
+	(*txnHandle)->ensureSnapshot();
+
 	std::atomic<uint64_t>* vtSlot = nullptr;
-	// Observe the slot before the read; reused for the fast-path check and the
-	// post-read conditional CAS.
+	// Observe the slot after the snapshot is established; reused for the
+	// fast-path check and the post-read conditional CAS.
 	uint64_t vtObserved = 0;
 	if (hasExpectedVersion || wantsPopulate) {
 		vtSlot = vtSlotFor((*txnHandle)->dbHandle, DBSettings::getInstance().getVerificationTableRaw(), keySlice);
@@ -661,10 +671,7 @@ napi_value Transaction::GetSync(napi_env env, napi_callback_info info) {
 
 	// VT fast-path: caller-supplied version matches the table → return FRESH
 	if (vtSlot && hasExpectedVersion && vtObserved == expectedVersion) {
-		// Serving from the VT still counts as a read within this transaction:
-		// establish the snapshot so optimistic conflict detection has a
-		// read-time baseline (see TransactionHandle::ensureSnapshot).
-		(*txnHandle)->ensureSnapshot();
+		// Snapshot already established above; no further action needed.
 		napi_value result;
 		NAPI_STATUS_THROWS(::napi_create_int32(env, FRESH_VERSION_FLAG, &result));
 		return result;

--- a/src/binding/transaction/transaction.cpp
+++ b/src/binding/transaction/transaction.cpp
@@ -650,7 +650,7 @@ napi_value Transaction::GetSync(napi_env env, napi_callback_info info) {
 
 	bool wantsPopulate = (flags & POPULATE_VERSION_FLAG) != 0;
 
-	// FIX C: Establish the transaction snapshot BEFORE loading the VT slot.
+	// Establish the transaction snapshot BEFORE loading the VT slot.
 	// If we loaded the slot first, a complete write cycle (lock → commit →
 	// settle) landing in the window between the slot load and the snapshot-set
 	// could let us observe V_old in the slot, pass the fast-path check, and

--- a/test/verification-table.test.ts
+++ b/test/verification-table.test.ts
@@ -210,5 +210,156 @@ describe('Verification Table', () => {
 				native.getSync(key, POPULATE_VERSION_FLAG, undefined, undefined);
 				expect(db.verifyVersion(key, futureVersion)).toBe(true);
 			}));
+
+		// FIX D: Sequence-number gate for backdated replicated versions.
+		// A version whose wall-clock timestamp predates the oldest open snapshot's
+		// creation time passes Gate 1 (the original wall-clock check), but if that
+		// version was written locally AFTER the snapshot was taken (i.e. its write
+		// sequence number > oldest_snapshot_seq), the snapshot cannot see it.
+		// Gate 2 (sequence-number check) blocks publication in that case.
+		//
+		// Note: rocksdb.oldest-snapshot-sequence returns 0 when no prior writes
+		// exist in the DB (sequence starts at 0). We write a sentinel key first
+		// so the snapshot is taken at sequence >= 1, making Gate 2 detectable.
+		it('suppresses seeding for backdated version written after the open snapshot (FIX D)', () =>
+			dbRunner({ dbOptions: [{ encoding: false, verificationTable: true }] }, async ({ db }) => {
+				const key = Buffer.from('backdated-key');
+				// A very old timestamp (2001-09-09) that pre-dates any plausible local
+				// snapshot creation time → Gate 1 passes for this version, even with
+				// a snapshot open right now.
+				const backdatedVersion = 1.0e12;
+
+				// Write a sentinel first so the DB has a non-zero write sequence.
+				// Without this, a snapshot taken on an empty DB gets seq=0 and
+				// rocksdb.oldest-snapshot-sequence returns 0 (Gate 2 cannot fire).
+				await db.put(Buffer.from('sentinel'), makeValue(1.5e12));
+
+				// Open a snapshot to pin the current DB sequence (S1 >= 1).
+				const snap = new Transaction(db.store);
+				snap.getBinarySync(Buffer.from('sentinel')); // forces SetSnapshot
+
+				try {
+					// Write the backdated version AFTER the snapshot is open (seq S2 > S1).
+					// This models a replicated write: origin timestamp is old but the local
+					// apply sequence is newer than the open snapshot.
+					await db.put(key, makeValue(backdatedVersion));
+
+					// Attempt to seed the VT. Gate 1 would pass (backdatedVersion << now).
+					// Gate 2 must block because oldest_snapshot_seq (S1) < latest_seq (S2).
+					const native = (db as any).store.db;
+					native.getSync(key, POPULATE_VERSION_FLAG, undefined, undefined);
+					expect(db.verifyVersion(key, backdatedVersion)).toBe(false);
+				} finally {
+					snap.abort();
+				}
+
+				// After snapshot drains, the sequence gate passes and the slot settles.
+				const native = (db as any).store.db;
+				native.getSync(key, POPULATE_VERSION_FLAG, undefined, undefined);
+				expect(db.verifyVersion(key, backdatedVersion)).toBe(true);
+			}));
+	});
+
+	// FIX A: clear() must invalidate the VT.
+	describe('VT invalidation on clear()', () => {
+		it('verifyVersion returns false after clearSync() on a VT-enabled store', () =>
+			dbRunner({ dbOptions: [{ encoding: false, verificationTable: true }] }, async ({ db }) => {
+				const key = Buffer.from('clear-me');
+				const version = 1.7e12;
+				await db.put(key, makeValue(version));
+
+				// Seed the VT slot with the version.
+				const native = (db as any).store.db;
+				native.getSync(key, POPULATE_VERSION_FLAG, undefined, undefined);
+				expect(db.verifyVersion(key, version)).toBe(true);
+
+				// Synchronous clear: VT sweep must follow the data delete.
+				db.clearSync();
+
+				// Slot should be advanced to settled-empty; stale version no longer fresh.
+				expect(db.verifyVersion(key, version)).toBe(false);
+			}));
+
+		it('verifyVersion returns false after async clear() on a VT-enabled store', () =>
+			dbRunner({ dbOptions: [{ encoding: false, verificationTable: true }] }, async ({ db }) => {
+				const key = Buffer.from('clear-me-async');
+				const version = 1.71e12;
+				await db.put(key, makeValue(version));
+
+				const native = (db as any).store.db;
+				native.getSync(key, POPULATE_VERSION_FLAG, undefined, undefined);
+				expect(db.verifyVersion(key, version)).toBe(true);
+
+				await db.clear();
+
+				expect(db.verifyVersion(key, version)).toBe(false);
+			}));
+
+		it('a stale expectedVersion read after clearSync does not return FRESH', () =>
+			dbRunner({ dbOptions: [{ encoding: false, verificationTable: true }] }, async ({ db }) => {
+				const key = Buffer.from('stale-after-clear');
+				const version = 1.72e12;
+				await db.put(key, makeValue(version));
+
+				const native = (db as any).store.db;
+				// Seed the slot.
+				native.getSync(key, POPULATE_VERSION_FLAG, undefined, undefined);
+				expect(db.verifyVersion(key, version)).toBe(true);
+
+				db.clearSync();
+
+				// A getSync with expectedVersion (the harper "check cache freshness" path)
+				// must fall through to a DB read (key not found), not return FRESH.
+				const result = native.getSync(key, 0, undefined, version);
+				expect(result).not.toBe(FRESH_VERSION_FLAG);
+				expect(result).toBeUndefined();
+			}));
+	});
+
+	// FIX B: non-transactional putSync/removeSync must invalidate the VT.
+	describe('VT invalidation on non-transactional putSync/removeSync', () => {
+		it('putSync advances the slot so a stale expectedVersion is no longer FRESH', () =>
+			dbRunner({ dbOptions: [{ encoding: false, verificationTable: true }] }, async ({ db }) => {
+				const key = Buffer.from('non-txn-put');
+				const v1 = 1.7e12;
+				const v2 = 1.8e12;
+				await db.put(key, makeValue(v1));
+
+				const native = (db as any).store.db;
+				// Seed the slot with v1.
+				native.getSync(key, POPULATE_VERSION_FLAG, undefined, undefined);
+				expect(db.verifyVersion(key, v1)).toBe(true);
+
+				// Non-transactional putSync with a new version.
+				native.putSync(key, makeValue(v2));
+
+				// v1 must no longer verify as FRESH (slot advanced by the write).
+				expect(db.verifyVersion(key, v1)).toBe(false);
+
+				// A getSync with stale expectedVersion must NOT return FRESH_VERSION_FLAG.
+				const result = native.getSync(key, 0, undefined, v1);
+				expect(result).not.toBe(FRESH_VERSION_FLAG);
+			}));
+
+		it('removeSync advances the slot so a stale expectedVersion is no longer FRESH', () =>
+			dbRunner({ dbOptions: [{ encoding: false, verificationTable: true }] }, async ({ db }) => {
+				const key = Buffer.from('non-txn-remove');
+				const v1 = 1.7e12;
+				await db.put(key, makeValue(v1));
+
+				const native = (db as any).store.db;
+				native.getSync(key, POPULATE_VERSION_FLAG, undefined, undefined);
+				expect(db.verifyVersion(key, v1)).toBe(true);
+
+				// Non-transactional removeSync invalidates the slot.
+				native.removeSync(key);
+
+				expect(db.verifyVersion(key, v1)).toBe(false);
+
+				// Key is gone and slot is settled-empty; FRESH_VERSION_FLAG must NOT fire.
+				const result = native.getSync(key, 0, undefined, v1);
+				expect(result).not.toBe(FRESH_VERSION_FLAG);
+				expect(result).toBeUndefined();
+			}));
 	});
 });

--- a/test/verification-table.test.ts
+++ b/test/verification-table.test.ts
@@ -218,9 +218,8 @@ describe('Verification Table', () => {
 		// sequence number > oldest_snapshot_seq), the snapshot cannot see it.
 		// Gate 2 (sequence-number check) blocks publication in that case.
 		//
-		// Note: rocksdb.oldest-snapshot-sequence returns 0 when no prior writes
-		// exist in the DB (sequence starts at 0). We write a sentinel key first
-		// so the snapshot is taken at sequence >= 1, making Gate 2 detectable.
+		// This case uses a sentinel write so the snapshot sits at sequence >= 1;
+		// the following test covers a snapshot taken at sequence 0 (fresh DB).
 		it('suppresses seeding for backdated version written after the open snapshot (FIX D)', () =>
 			dbRunner({ dbOptions: [{ encoding: false, verificationTable: true }] }, async ({ db }) => {
 				const key = Buffer.from('backdated-key');
@@ -229,9 +228,7 @@ describe('Verification Table', () => {
 				// a snapshot open right now.
 				const backdatedVersion = 1.0e12;
 
-				// Write a sentinel first so the DB has a non-zero write sequence.
-				// Without this, a snapshot taken on an empty DB gets seq=0 and
-				// rocksdb.oldest-snapshot-sequence returns 0 (Gate 2 cannot fire).
+				// Sentinel write so the snapshot is taken at a non-zero sequence.
 				await db.put(Buffer.from('sentinel'), makeValue(1.5e12));
 
 				// Open a snapshot to pin the current DB sequence (S1 >= 1).
@@ -254,6 +251,35 @@ describe('Verification Table', () => {
 				}
 
 				// After snapshot drains, the sequence gate passes and the slot settles.
+				const native = (db as any).store.db;
+				native.getSync(key, POPULATE_VERSION_FLAG, undefined, undefined);
+				expect(db.verifyVersion(key, backdatedVersion)).toBe(true);
+			}));
+
+		// A snapshot taken on a fresh DB legitimately has sequence 0; Gate 2 must
+		// still protect it (no `oldestSnapshotSeq != 0` exemption — a backdated
+		// write at seq > 0 would otherwise publish past the seq-0 snapshot).
+		it('suppresses seeding for a backdated write past a snapshot taken at sequence 0 (FIX D)', () =>
+			dbRunner({ dbOptions: [{ encoding: false, verificationTable: true }] }, async ({ db }) => {
+				const key = Buffer.from('backdated-seq0');
+				const backdatedVersion = 1.0e12;
+
+				// No sentinel write: the snapshot is taken on the fresh DB at seq 0.
+				const snap = new Transaction(db.store);
+				snap.getBinarySync(Buffer.from('missing')); // forces SetSnapshot at seq 0
+
+				try {
+					// Backdated write after the snapshot (seq > 0).
+					await db.put(key, makeValue(backdatedVersion));
+
+					const native = (db as any).store.db;
+					native.getSync(key, POPULATE_VERSION_FLAG, undefined, undefined);
+					expect(db.verifyVersion(key, backdatedVersion)).toBe(false);
+				} finally {
+					snap.abort();
+				}
+
+				// Snapshot drained → publication resumes.
 				const native = (db as any).store.db;
 				native.getSync(key, POPULATE_VERSION_FLAG, undefined, undefined);
 				expect(db.verifyVersion(key, backdatedVersion)).toBe(true);
@@ -314,6 +340,46 @@ describe('Verification Table', () => {
 				expect(result).not.toBe(FRESH_VERSION_FLAG);
 				expect(result).toBeUndefined();
 			}));
+	});
+
+	// Drop of a non-default column family bulk-deletes like clear() and must
+	// sweep the VT the same way (default-CF drop routes to clear(), covered above).
+	describe('VT invalidation on drop of a non-default column family', () => {
+		it('verifyVersion returns false after dropSync()', () =>
+			dbRunner(
+				{ dbOptions: [{ name: 'droppable', encoding: false, verificationTable: true }] },
+				async ({ db }) => {
+					const key = Buffer.from('drop-me');
+					const version = 1.73e12;
+					await db.put(key, makeValue(version));
+
+					const native = (db as any).store.db;
+					native.getSync(key, POPULATE_VERSION_FLAG, undefined, undefined);
+					expect(db.verifyVersion(key, version)).toBe(true);
+
+					db.dropSync();
+
+					expect(db.verifyVersion(key, version)).toBe(false);
+				}
+			));
+
+		it('verifyVersion returns false after async drop()', () =>
+			dbRunner(
+				{ dbOptions: [{ name: 'droppable-async', encoding: false, verificationTable: true }] },
+				async ({ db }) => {
+					const key = Buffer.from('drop-me-async');
+					const version = 1.74e12;
+					await db.put(key, makeValue(version));
+
+					const native = (db as any).store.db;
+					native.getSync(key, POPULATE_VERSION_FLAG, undefined, undefined);
+					expect(db.verifyVersion(key, version)).toBe(true);
+
+					await db.drop();
+
+					expect(db.verifyVersion(key, version)).toBe(false);
+				}
+			));
 	});
 
 	// FIX B: non-transactional putSync/removeSync must invalidate the VT.


### PR DESCRIPTION
Four fixes to the VerificationTable invalidation contract, found during a multi-agent review of harper#410 (which layers a per-worker WeakLRUCache over the VT via `expectedVersion`/`FRESH_VERSION_FLAG`). The invariant being enforced: **every write path on a VT-enabled store must invalidate the affected slot(s)** — previously only transactional writes did.

## A — `clear()` sweeps the VT (`db_handle.cpp`, `verification_table.{h,cpp}`)

`DBHandle::clear()` (compactRange + DeleteFilesInRange) never touched the VT, so after a table clear every other worker kept verifying its cached pre-clear versions as FRESH indefinitely — deleted records served forever (also mid-HNSW-reindex `dbi.clear()`). New `VerificationTable::settleAllSlots()` advances every non-lock slot to a fresh settled generation after the delete completes. Lock slots are skipped (their write-intent lifecycle already advances them on release). The sweep is coarse — process-global, since non-lock slots don't track provenance — costing spurious cache misses on other stores; acceptable for an operation as rare as clear(). Ordering argument (delete-visible → sweep → fresh generation) closes the stale re-publication window: a populate that observed a pre-sweep slot value fails its CAS; one that observed a post-sweep value read post-delete data.

## B — non-transactional `putSync`/`removeSync` settle the slot (`database.cpp`)

The direct `db->Put`/`db->Delete` branches had zero VT interaction, so any bare write on a VT-enabled store left the old version verifying FRESH on every other worker (harper aliases `db.put = db.putSync`, making this a standing footgun). Now mirrors the transactional path exactly: `lockSlotForWrite` before the write, `releaseWriteIntent` (→ fresh settled generation) after.

## C — snapshot pinned before VT slot load (`transaction.cpp`, `database.cpp`)

In the transactional read paths the slot was loaded *before* `ensureSnapshot()`. A full write cycle (lock → commit → settle) landing in that window on a transaction's first read could return cached V_old while pinning a post-V_new snapshot — a torn view. The snapshot is now established before the slot load in both `Transaction::GetSync` and the `Database::GetSync` txnId path (which also consolidates the duplicated txn lookup). Non-transactional reads are unaffected. Not deterministically testable from JS; correctness is by ordering argument.

## D — sequence gate for backdated versions (`database.h` `vtPopulateIfSettled`)

The populate gate compared the oldest open snapshot's *wall-clock creation time* against the record's *Harper version timestamp*. Replicated/catch-up writes carry origin timestamps that can predate an open local snapshot, so the gate passed and a pinned snapshot that legitimately sees V_old could get FRESH V_new. Added a second gate, run **only when Gate 1 passes** (open snapshot + version older than it — exactly the backdated case): defer publication when `oldest-snapshot-sequence < GetLatestSequenceNumber()`.

**Known conservatism:** Gate 2 uses the DB-wide latest sequence as a proxy for the key's write sequence, so while a snapshot is open and *any* write has landed after it, population of Gate-1-passing (old-versioned) records is deferred until the snapshot drains. The no-snapshot hot path is untouched. If benchmarks show population starvation under mixed read/write load, the follow-up is a per-key sequence check (`GetLatestSequenceForKey` with memtable-window handling).

## Tests

6 new cases in `test/verification-table.test.ts` covering A (clear → stale expectedVersion falls through to DB, verifyVersion false), B (non-txn putSync/removeSync invalidate the slot), and D (backdated version + open snapshot defers population; publication resumes after snapshot release). Full suite: 45 files, 602 passed / 1 skipped.

Pairs with harper#410; harper should bump this dep once released so the clear()/cross-worker fixes land behind the record-caching feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)