### PR TITLE
fix(ci): build win32-arm64 on windows-11-vs2026-arm runner

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -94,7 +94,12 @@ jobs:
             name: linux-x64-musl
             libc: musl
             target: x64
-          - runner: windows-11-arm
+          # windows-11-vs2026-arm (not windows-11-arm, which only has VS 2022):
+          # rocksdb-prebuilds are compiled with VS 2026 (MSVC 14.5x), whose STL
+          # emits ARM64 vector-algorithm symbols (__std_find_trivial_1, etc.)
+          # that VS 2022's ARM64 STL libs don't provide, so linking fails with
+          # LNK2001 unresolved externals unless we link with VS 2026 too.
+          - runner: windows-11-vs2026-arm
             name: win32-arm64
             target: arm64
           - runner: windows-latest


### PR DESCRIPTION
## Summary

The v2.4.0 publish failed on `win32-arm64` with dozens of `LNK2001: unresolved external symbol __std_search_1` / `__std_find_trivial_1` / `__std_find_last_of_trivial_pos_1` errors ([failing run](https://github.com/HarperFast/rocksdb-js/actions/runs/29000836306/job/86063202425)).

**Root cause:** the rocksdb-prebuilds Windows libraries (v11.1.2, built 2026-06-26) are cross-compiled on `windows-latest`, which now runs the `windows-2025-vs2026` image — VS 2026 / MSVC toolset 14.51. That STL enables ARM64 vector algorithms, so the prebuilt `rocksdb.lib` objects reference `__std_*` helper symbols that are defined in the *linking* toolset's STL support lib. The `windows-11-arm` runner only ships VS 2022 (17.14 / MSVC 14.44), whose ARM64 STL predates those symbols. `win32-x64` kept passing because it links on `windows-latest` with VS 2026.

**Fix:** switch the `win32-arm64` job to the `windows-11-vs2026-arm` image (actions/runner-images#14225) so the linker toolset matches the prebuilds, same as x64. One-line runner change plus an explanatory comment.

## Things to weigh

- `windows-11-vs2026-arm` is marked **public preview** (GA'd 2026-06-11), so there is a small risk of queue delays while GitHub balances capacity.
- This fixes CI, but source builds on Windows ARM64 with VS 2022 will still hit the same link error against prebuilds ≥ v11.1.2. The complementary, more durable fix is pinning the rocksdb-prebuilds Windows toolset (e.g. `VCPKG_PLATFORM_TOOLSET_VERSION` v143) — proposed as a follow-up in rocksdb-prebuilds rather than here.
- CI on this PR does **not** exercise the fix — only the Publish workflow builds win32-arm64. Verification happens on the next publish attempt.

Cross-model review skipped: single-line CI runner change, no product code.

Generated by Claude Code (Claude Fable 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)