### PR TITLE
ci: wire Claude + Gemini AI review (ai-review-prompts callers)

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -34,6 +34,22 @@ jobs:
     # `_claude-review.yml`'s authorize `if:`, not in this caller.
     if: ${{ vars.CLAUDE_ALWAYS_ON == 'true' || github.event.action == 'labeled' }}
     uses: HarperFast/ai-review-prompts/.github/workflows/_claude-review.yml@1255f2e155e2202992508034d21b421fa99d14be # main 2026-07-10 (#72 native-addon layer; on 9cf49d2 = #70 calibration + #71 prompt-ref tracking)
+    # Caller-side permissions at the calling-job level (NOT workflow-
+    # level — that placement caps the reusable's per-job grants below
+    # what they need and breaks the workflow at startup; see
+    # ai-review-prompts#39/#40). Union of what the reusable's authorize
+    # (`contents: read`) and review (`contents: read` + `pull-requests:
+    # write` + `id-token: write`) jobs declare. Without this block the
+    # grants are inherited from the repo's default-workflow-permissions
+    # setting instead (GitHub intersects the reusable's requests with
+    # the caller's ceiling — un-grantable scopes are silently dropped,
+    # and `pull-requests: write` survives only while the repo default
+    # is "write"). Explicit grants keep the caller independent of that
+    # setting, and match gemini-review.yml in this repo.
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
     with:
       # Same SHA as the `uses:` ref above. The reusable uses this to
       # check out HarperFast/ai-review-prompts (layer files + bash

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,78 @@
+name: Claude PR Review
+
+# Thin caller of the reusable in HarperFast/ai-review-prompts. The single
+# `uses:` ref pin below controls everything that moves together — workflow
+# logic, layer files, bash scripts, auth-gate behavior. Bumping the pin
+# is the entire upgrade motion.
+#
+# Pre-requisites (org-level secrets, configured once on HarperFast):
+#   - HARPERFAST_AI_CLIENT_ID       (the App's Client ID, like Iv23li…)
+#   - HARPERFAST_AI_APP_PRIVATE_KEY (.pem file contents)
+#
+# Plus the per-repo / inherited:
+#   - ANTHROPIC_API_KEY             (required)
+#   - AI_REVIEW_LOG_TOKEN           (optional — if set, threads each run
+#                                   into a per-PR issue in HarperFast/ai-review-log)
+
+on:
+  pull_request:
+    # `labeled` admits the `claude-review` label gesture for
+    # bot-authored PRs (renovate, dependabot). See ai-review-prompts#38.
+    types: [opened, synchronize, reopened, labeled]
+
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    # Always-on toggle — see ai-review-prompts USAGE.md "Reviewers & the
+    # always-on toggle". CLAUDE_ALWAYS_ON=true (repo/org variable) → auto-
+    # review trusted-author PRs; unset → opt-in via the claude-review
+    # label. The reusable's authorize job still owns WHO is admitted.
+    # Note: the `claude-review` label name is matched there too —
+    # `_claude-review.yml`'s authorize `if:`, not in this caller.
+    if: ${{ vars.CLAUDE_ALWAYS_ON == 'true' || github.event.action == 'labeled' }}
+    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-review.yml@1255f2e155e2202992508034d21b421fa99d14be # main 2026-07-10 (#72 native-addon layer; on 9cf49d2 = #70 calibration + #71 prompt-ref tracking)
+    with:
+      # Same SHA as the `uses:` ref above. The reusable uses this to
+      # check out HarperFast/ai-review-prompts (layer files + bash
+      # scripts) at the same ref as the workflow logic itself — keeps
+      # the upgrade motion atomic.
+      #
+      # The duplication is unavoidable: reusable workflows can't
+      # introspect their own ref (`github.workflow_ref` resolves to the
+      # CALLER's ref in `workflow_call` context), and `uses: …@<ref>`
+      # is parsed literally so we can't interpolate a variable.
+      ai-review-prompts-ref: 1255f2e155e2202992508034d21b421fa99d14be
+      review-layers: |
+        universal
+        repo-type/native-addon
+      repo-specific-checks: |
+        ## Repo-specific checks (@harperfast/rocksdb-js)
+
+        This is a Node.js native addon (TS over an N-API C++ binding) —
+        the repo-type/native-addon layer carries the core checks. On
+        top of it, repo specifics the shared layers don't cover:
+
+        - **Toolchain is pnpm + oxlint + oxfmt** (`pnpm check` runs
+          type-check + lint + format check). Advice referencing
+          npm/eslint/prettier doesn't apply here.
+        - **No build tolerance** — `pnpm check` type-checks cleanly;
+          flag type errors as real findings.
+        - **Vendored RocksDB bumps** (the `update-rocksdb.yml` flow /
+          `deps/` changes) are mechanical unless they also touch
+          `src/binding/` — a pure vendored-library bump with green CI
+          is the no-log mechanical-diff case.
+        - **Runtime deps are exactly three** (`msgpackr`,
+          `ordered-binary`, `@harperfast/extended-iterable`); a new one
+          needs explicit justification in the PR description.
+        - **Downstream consumer is Harper core** (`resources/
+          PrimaryRocksDatabase.ts` et al.). A behavior change here that
+          alters the MaybePromise contract or key encoding needs a
+          matching harper-core issue/PR reference.
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      AI_REVIEW_LOG_TOKEN: ${{ secrets.AI_REVIEW_LOG_TOKEN }}
+      HARPERFAST_AI_CLIENT_ID: ${{ secrets.HARPERFAST_AI_CLIENT_ID }}
+      HARPERFAST_AI_APP_PRIVATE_KEY: ${{ secrets.HARPERFAST_AI_APP_PRIVATE_KEY }}

--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -1,0 +1,104 @@
+name: Gemini PR Review
+
+# Thin caller of the Gemini reusable in HarperFast/ai-review-prompts.
+# Runs in parallel with claude-review.yml so the two reviewers can be
+# compared on the same PRs.
+#
+# Layer inputs and `repo-specific-checks:` MIRROR claude-review.yml in
+# this repo. Output comparability between the two providers depends on
+# them seeing the same review scope — keep them in sync when bumping
+# the pin or editing the checks block.
+#
+# Opt-in by default: Gemini runs only when a HarperFast org member
+# applies the `gemini-review` label, UNLESS the GEMINI_ALWAYS_ON repo
+# variable is set to 'true' (then it auto-reviews trusted-author PRs,
+# like claude-review). See ai-review-prompts USAGE.md "Reviewers & the
+# always-on toggle".
+#
+# Pre-requisites:
+#   - HARPERFAST_AI_CLIENT_ID       (org-level App Client ID)
+#   - HARPERFAST_AI_APP_PRIVATE_KEY (org-level App private key)
+#   - GEMINI_API_KEY                (per-repo; optional — a missing key
+#                                   cleanly skips the review with a
+#                                   workflow notice, so this is safe to
+#                                   merge before the key is set)
+#   - AI_REVIEW_LOG_TOKEN           (optional — threads each run into a
+#                                   per-(PR, provider) issue in
+#                                   HarperFast/ai-review-log with the
+#                                   `provider:gemini` label)
+
+on:
+  pull_request:
+    # `labeled` admits the `gemini-review` opt-in gesture. `vars.*`
+    # can't be read in `on:` (only in a job `if:`), so the trigger
+    # lists the union and the `review` job gates on GEMINI_ALWAYS_ON.
+    types: [opened, synchronize, reopened, labeled]
+
+concurrency:
+  # Different group key from claude-review so the two providers can run
+  # in parallel on the same PR. cancel-in-progress is per-group, so a
+  # synchronize push cancels the in-flight Gemini run without touching
+  # the Claude run (and vice versa).
+  group: gemini-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    # Always-on toggle — see ai-review-prompts USAGE.md "Reviewers & the
+    # always-on toggle". GEMINI_ALWAYS_ON=true (repo/org variable) → auto-
+    # review trusted-author PRs; unset → opt-in via the gemini-review
+    # label. The reusable's authorize job still owns WHO is admitted
+    # (CODEOWNERS trust set; the labeler, not the author, on `labeled`).
+    # Note: the `gemini-review` label name is matched there too —
+    # `_gemini-review.yml`'s authorize `if:`, not in this caller.
+    if: ${{ vars.GEMINI_ALWAYS_ON == 'true' || github.event.action == 'labeled' }}
+    uses: HarperFast/ai-review-prompts/.github/workflows/_gemini-review.yml@1255f2e155e2202992508034d21b421fa99d14be # main 2026-07-10 (#72 native-addon layer; on 9cf49d2 = #70 calibration + #71 prompt-ref tracking)
+    # Caller-side permissions at the calling-job level (NOT workflow-
+    # level — that placement caps the reusable's per-job grants below
+    # what they need and breaks the workflow at startup; see
+    # ai-review-prompts#39/#40). Union of what the reusable's authorize
+    # (`contents: read`) and review (`contents: read` + `pull-requests:
+    # write` + `id-token: write`) jobs declare.
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+    with:
+      # Same SHA as the `uses:` ref above. The reusable uses this to
+      # check out HarperFast/ai-review-prompts (layer files + bash
+      # scripts) at the same ref as the workflow logic itself. The
+      # duplication is unavoidable: reusable workflows can't introspect
+      # their own ref (`github.workflow_ref` resolves to the CALLER's
+      # ref in workflow_call context), and `uses: …@<ref>` is literal.
+      ai-review-prompts-ref: 1255f2e155e2202992508034d21b421fa99d14be
+      review-layers: |
+        universal
+        repo-type/native-addon
+      repo-specific-checks: |
+        ## Repo-specific checks (@harperfast/rocksdb-js)
+
+        This is a Node.js native addon (TS over an N-API C++ binding) —
+        the repo-type/native-addon layer carries the core checks. On
+        top of it, repo specifics the shared layers don't cover:
+
+        - **Toolchain is pnpm + oxlint + oxfmt** (`pnpm check` runs
+          type-check + lint + format check). Advice referencing
+          npm/eslint/prettier doesn't apply here.
+        - **No build tolerance** — `pnpm check` type-checks cleanly;
+          flag type errors as real findings.
+        - **Vendored RocksDB bumps** (the `update-rocksdb.yml` flow /
+          `deps/` changes) are mechanical unless they also touch
+          `src/binding/` — a pure vendored-library bump with green CI
+          is the no-log mechanical-diff case.
+        - **Runtime deps are exactly three** (`msgpackr`,
+          `ordered-binary`, `@harperfast/extended-iterable`); a new one
+          needs explicit justification in the PR description.
+        - **Downstream consumer is Harper core** (`resources/
+          PrimaryRocksDatabase.ts` et al.). A behavior change here that
+          alters the MaybePromise contract or key encoding needs a
+          matching harper-core issue/PR reference.
+    secrets:
+      GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+      AI_REVIEW_LOG_TOKEN: ${{ secrets.AI_REVIEW_LOG_TOKEN }}
+      HARPERFAST_AI_CLIENT_ID: ${{ secrets.HARPERFAST_AI_CLIENT_ID }}
+      HARPERFAST_AI_APP_PRIVATE_KEY: ${{ secrets.HARPERFAST_AI_APP_PRIVATE_KEY }}

--- a/.github/workflows/validate-caller-workflows.yml
+++ b/.github/workflows/validate-caller-workflows.yml
@@ -1,0 +1,35 @@
+name: Validate caller workflows
+
+# Thin caller of HarperFast/ai-review-prompts'
+# `_validate-caller-workflows.yml`. Validates
+# `.github/workflows/claude-*.yml` caller files for:
+#
+#   * Shadow jobs — a non-`uses:` job (or a `uses:` outside
+#     `HarperFast/`) alongside the legit reusable call would run
+#     with the caller's permissions WITHOUT going through the auth
+#     gate. Fail-closed.
+#   * Mutable refs in `uses:` or `with.ai-review-prompts-ref` —
+#     both must pin to a 40-char SHA.
+#
+# Runs on every PR and every push to `main` — no `paths:` filter.
+# A required status check that only fires on workflow-touching PRs
+# stays permanently pending on every other PR (GitHub has no
+# "required if it runs" semantic). The validator's runtime is
+# trivial (yq-parses a few caller files), so unconditional firing
+# is the right trade-off for satisfiability.
+#
+# Make this `validate` job a REQUIRED status check on `main`.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  validate:
+    uses: HarperFast/ai-review-prompts/.github/workflows/_validate-caller-workflows.yml@1255f2e155e2202992508034d21b421fa99d14be # main 2026-07-10 (#72 native-addon layer)
+    with:
+      # Same SHA as the `uses:` ref above — the reusable uses this
+      # to check out the validator script at the matching version.
+      # Same SHA-twice pattern as the other caller workflows.
+      ai-review-prompts-ref: 1255f2e155e2202992508034d21b421fa99d14be


### PR DESCRIPTION
## What

Wires **@harperfast/rocksdb-js** into the AI review pipeline — the Phase-1 expansion target from the 07-02 retro (52 PRs/30d, highest risk-per-line of the candidate repos). Three thin callers of the [ai-review-prompts](https://github.com/HarperFast/ai-review-prompts) reusables, pinned to main **`1255f2e`** ([#72](https://github.com/HarperFast/ai-review-prompts/pull/72) — the `repo-type/native-addon` layer written for this repo):

- **claude-review.yml** — layers: `universal` + `repo-type/native-addon`; repo-specific checks for the pnpm/oxlint/oxfmt toolchain, vendored-RocksDB bumps, the three-runtime-deps bar, and the harper-core consumer coupling (MaybePromise / key-encoding changes need a core reference).
- **gemini-review.yml** — mirrors the Claude caller; opt-in via `gemini-review` label unless `GEMINI_ALWAYS_ON=true`.
- **validate-caller-workflows.yml** — SHA-pin + shadow-job guard.

Already done outside this PR: `repo:rocksdb-js` label in ai-review-log; `claude-review` / `gemini-review` labels here.

## Setup needed on merge (repo settings — can't be done from a PR)

1. **Secrets**: add `ANTHROPIC_API_KEY` (required); `GEMINI_API_KEY` + `AI_REVIEW_LOG_TOKEN` (optional — missing keys skip cleanly; the log token reuses the existing fine-grained PAT). Add this repo to the visibility list of the org-level `HARPERFAST_AI_CLIENT_ID` / `HARPERFAST_AI_APP_PRIVATE_KEY` secrets.
2. **Variable**: set `CLAUDE_ALWAYS_ON=true` to auto-review trusted-author PRs (or leave unset for label-only opt-in while calibrating).
3. **Required check**: make `validate / validate` a required status check on `main`.
4. ai-review-log README "Reviewed repos" table — follow-up PR there once this lands.

Note: the Claude review check on *this* PR will fail with the expected "workflow file must match default branch" guard (it always does on PRs that introduce the caller workflows — claude-code-action's anti-tamper). Ignore it; it clears after merge.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
