### PR TITLE
Reject db.backup() into the database directory or a subdirectory

### DIFF
--- a/README.md
+++ b/README.md
@@ -1555,6 +1555,10 @@ re-copied.
 When the database was opened with `disableWAL`, the memtable is flushed before the backup by
 default so unflushed data is not lost; otherwise flushing follows `options.flushBeforeBackup`.
 
+`backupDir` must not be the database directory itself or a path beneath it — backing up into the
+live database directory would write backup files on top of RocksDB's own files. Such a call rejects
+before anything is written.
+
 ```typescript
 const id = await db.backup('/path/to/backups', { metadata: 'nightly-2026-06-04' });
 ```

--- a/src/backup.ts
+++ b/src/backup.ts
@@ -9,7 +9,7 @@ import {
 } from './load-binding.js';
 import { validateTransactionLogStore } from './validate-transaction-log.js';
 import { access, cp, mkdir, readdir, rm } from 'node:fs/promises';
-import { join, resolve as resolvePath } from 'node:path';
+import { isAbsolute, join, relative, resolve as resolvePath, sep } from 'node:path';
 
 /** Subdirectory (under a backup directory) holding per-backup transaction log snapshots. */
 const TRANSACTION_LOGS_DIRNAME = 'transaction_logs';
@@ -90,6 +90,30 @@ export async function withBackupDirLock<T>(
 		return await fn();
 	} finally {
 		fileLockRelease(token);
+	}
+}
+
+/**
+ * Throws if `backupDir` resolves to the database directory itself or any path
+ * beneath it. Backing up into the live database directory would write backup
+ * files (the `.backup.lock`, `meta/`, `shared/`, `private/` subtrees) on top of
+ * RocksDB's own files, and every subsequent backup would recursively capture
+ * the prior ones. Both paths are resolved first so trailing slashes and
+ * relative/absolute variants of the same location cannot slip past the check.
+ *
+ * Only the "backup dir at or under the database dir" direction is rejected —
+ * the case the user hits by pointing a backup at `<db>` or `<db>/backups`. The
+ * reverse (a database nested under the backup dir) is left to the caller: a
+ * backup engine writes into named subtrees, not on top of arbitrary sibling
+ * files, so it does not clobber the database in place.
+ */
+export function assertBackupDirOutsideDatabase(dbPath: string, backupDir: string): void {
+	const rel = relative(resolvePath(dbPath), resolvePath(backupDir));
+	const outside = rel === '..' || rel.startsWith(`..${sep}`) || isAbsolute(rel);
+	if (!outside) {
+		throw new Error(
+			`Backup directory must not be inside the database directory: ${backupDir} is at or within ${dbPath}`
+		);
 	}
 }
 

--- a/src/backup.ts
+++ b/src/backup.ts
@@ -106,9 +106,25 @@ export async function withBackupDirLock<T>(
  * reverse (a database nested under the backup dir) is left to the caller: a
  * backup engine writes into named subtrees, not on top of arbitrary sibling
  * files, so it does not clobber the database in place.
+ *
+ * On case-insensitive filesystems `<db>` and `<db>/../DB/backup` are the same
+ * directory on disk, but `relative()` compares case-sensitively and would call
+ * the second one "outside". We case-fold both paths on the platforms whose
+ * default filesystem is case-insensitive (macOS, Windows) so a casing
+ * difference cannot slip a backup into the database directory. This is a
+ * platform heuristic, not a per-volume probe (a case-sensitive macOS/Windows
+ * volume exists), so it can over-reject a legitimately differently-cased
+ * sibling there — the safe direction for a guard against clobbering the live
+ * database.
  */
 export function assertBackupDirOutsideDatabase(dbPath: string, backupDir: string): void {
-	const rel = relative(resolvePath(dbPath), resolvePath(backupDir));
+	let resolvedDb = resolvePath(dbPath);
+	let resolvedBackup = resolvePath(backupDir);
+	if (process.platform === 'win32' || process.platform === 'darwin') {
+		resolvedDb = resolvedDb.toLowerCase();
+		resolvedBackup = resolvedBackup.toLowerCase();
+	}
+	const rel = relative(resolvedDb, resolvedBackup);
 	const outside = rel === '..' || rel.startsWith(`..${sep}`) || isAbsolute(rel);
 	if (!outside) {
 		throw new Error(

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,5 +1,5 @@
 import { type BackupStreamOptions, backupToStream } from './backup-stream.js';
-import type { BackupOptions } from './backup.js';
+import { assertBackupDirOutsideDatabase, type BackupOptions } from './backup.js';
 import { DBIterator, type DBIteratorValue } from './dbi-iterator.js';
 import type { DBITransactional, IteratorOptions, RangeOptions } from './dbi.js';
 import {
@@ -432,6 +432,9 @@ export class Store {
 		if (typeof target !== 'string' && typeof target?.getWriter === 'function') {
 			return backupToStream(this.db, target, options as BackupStreamOptions);
 		}
+		// Refuse to write backup files into the live database directory (or a
+		// subdirectory of it), which would clobber RocksDB's own files.
+		assertBackupDirOutsideDatabase(this.path, target as string);
 		// The native side creates the directory (with missing parents) and holds
 		// the on-disk single-writer lock for the duration of the backup — see
 		// `runCreateBackup` in `src/binding/database/backup.cpp` and

--- a/test/backup.test.ts
+++ b/test/backup.test.ts
@@ -98,6 +98,38 @@ describe('Backups', () => {
 			expect(existsSync(backupDir)).toBe(true);
 		}));
 
+	it('should reject backing up into the database directory or a subdirectory', () =>
+		dbRunner(async ({ db }) => {
+			await writeAll(db, 5);
+
+			const dbPath = db.store.path;
+			const before = readdirSync(dbPath).sort();
+
+			// The database directory itself.
+			await expect(db.backup(dbPath)).rejects.toThrow(/must not be inside the database directory/);
+			// A subdirectory of the database directory.
+			await expect(db.backup(join(dbPath, 'backups'))).rejects.toThrow(
+				/must not be inside the database directory/
+			);
+			// Trailing-slash / relative variants must not slip past the guard.
+			await expect(db.backup(join(dbPath, 'nested', '..'))).rejects.toThrow(
+				/must not be inside the database directory/
+			);
+
+			// The guard runs before any directory is created or files are written.
+			expect(readdirSync(dbPath).sort()).toEqual(before);
+			expect(existsSync(join(dbPath, 'backups'))).toBe(false);
+		}));
+
+	it('should allow backing up to a sibling directory of the database', () =>
+		dbRunner(async ({ db }) => {
+			await writeAll(db, 5);
+
+			const backupDir = join(db.store.path, '..', 'sibling-backups');
+			tempDirs.push(backupDir);
+			expect(await db.backup(backupDir)).toBe(1);
+		}));
+
 	it('should create incremental backups and list them', () =>
 		dbRunner(async ({ db }) => {
 			const backupDir = tempDir();

--- a/test/backup.test.ts
+++ b/test/backup.test.ts
@@ -15,7 +15,7 @@ import {
 	statSync,
 	writeFileSync,
 } from 'node:fs';
-import { join } from 'node:path';
+import { basename, dirname, join } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
 
 /** Name of the on-disk backup lock file (mirrors LOCK_FILENAME in src/backup.ts). */
@@ -120,6 +120,21 @@ describe('Backups', () => {
 			expect(readdirSync(dbPath).sort()).toEqual(before);
 			expect(existsSync(join(dbPath, 'backups'))).toBe(false);
 		}));
+
+	// On case-insensitive filesystems (macOS/Windows defaults) a casing
+	// difference must not slip a backup into the database directory.
+	it.runIf(process.platform === 'darwin' || process.platform === 'win32')(
+		'should reject a case-differing path into the database directory on case-insensitive filesystems',
+		() =>
+			dbRunner(async ({ db }) => {
+				await writeAll(db, 5);
+
+				const dbPath = db.store.path;
+				// Same on-disk directory, different casing of the db segment.
+				const cased = join(dirname(dbPath), basename(dbPath).toUpperCase(), 'backups');
+				await expect(db.backup(cased)).rejects.toThrow(/must not be inside the database directory/);
+			})
+	);
 
 	it('should allow backing up to a sibling directory of the database', () =>
 		dbRunner(async ({ db }) => {


### PR DESCRIPTION
## Summary

`db.backup(backupDir)` never validated `backupDir` against the database's own path, so a caller could point a backup at the live database directory (or a subdirectory of it) — e.g. `db.backup('/path/to/harper/database/<db_name>')` — and write backup files (`.backup.lock`, `meta/`, `shared/`, `private/`) directly on top of RocksDB's own files. Every subsequent backup would then recursively capture the prior ones.

This adds `assertBackupDirOutsideDatabase()`, invoked from `Store.backup()` **before** any directory is created, rejecting when `backupDir` resolves to the database directory or a path beneath it.

## Purpose

Prevent a footgun where a backup destination clobbers the live database in place. Requested directly — there was no guard against backing up "anywhere in the database path including subdirectories."

## Notes for review

- **Containment check** ([src/backup.ts](../blob/fix/backup-dir-inside-db/src/backup.ts)): both paths are `resolve`d first, then `relative(db, backup)` is classified — a `..`/`..<sep>`-prefixed or absolute result is "outside" (allowed), everything else (including `''` for the same dir) rejects. This mirrors the existing `resolvePath`-based guard in `backups.restore()`, and handles trailing slashes, relative/absolute variants, `..` normalization, and Windows cross-drive.
- **Scope decision worth a look:** only the *backup-dir-at-or-under-db-dir* direction is rejected — the case the report hits. The reverse (a database nested under the backup dir) is intentionally left to the caller: a backup engine writes into named subtrees, not on top of arbitrary sibling files, so it doesn't clobber the db in place. Flag if you'd prefer the reverse guarded too.
- **Not covered:** symlink-based evasion (a symlink under the db pointing elsewhere, or vice versa). `resolve` does not follow symlinks — consistent with the existing restore guard, which would require an async `realpath` on paths that may not exist yet.
- Streaming backups target a `WritableStream`, not a directory, so that path is untouched.

## Tests

Added to `test/backup.test.ts`: rejects the db dir, a subdir, and a `..`-normalized variant (asserting nothing is written), and allows a sibling directory. Full `backup*.test.ts` suites pass (66 tests); type-check and lint clean.

## Docs

Added a note to the `db.backup()` README section. No separate documentation-repo PR — this repo's README is the API surface.

---
🤖 Generated by Claude (Opus 4.8, 1M context).
