### PR TITLE
fix: key VerificationTable slots by per-open epoch, not descriptor pointer

### DIFF
--- a/src/binding/core/verification_table.cpp
+++ b/src/binding/core/verification_table.cpp
@@ -97,7 +97,7 @@ VerificationTable::VerificationTable(size_t numEntries, uint64_t seed)
 VerificationTable::~VerificationTable() = default;
 
 std::atomic<uint64_t>* VerificationTable::slotFor(
-	uintptr_t dbPtr,
+	uint64_t dbId,
 	uint32_t cfId,
 	const rocksdb::Slice& key
 ) const {
@@ -105,7 +105,7 @@ std::atomic<uint64_t>* VerificationTable::slotFor(
 		return nullptr;
 	}
 	uint64_t h = seed_;
-	h ^= static_cast<uint64_t>(dbPtr);
+	h ^= dbId;
 	h = mix64(h);
 	h ^= static_cast<uint64_t>(cfId);
 	h = mix64(h);
@@ -196,7 +196,7 @@ uint64_t vtNextSettleGen() {
 	return vtGlobalSettleGen.fetch_add(1, std::memory_order_relaxed) & VT_SETTLED_GEN_MASK;
 }
 
-LockTracker* VerificationTable::lockSlotForWrite(std::atomic<uint64_t>* slot, uintptr_t dbPtr) {
+LockTracker* VerificationTable::lockSlotForWrite(std::atomic<uint64_t>* slot, uint64_t dbId) {
 	if (!slot) return nullptr;
 	std::lock_guard<std::mutex> lock(writerMutex_);
 	uint64_t v = slot->load(std::memory_order_acquire);
@@ -213,7 +213,7 @@ LockTracker* VerificationTable::lockSlotForWrite(std::atomic<uint64_t>* slot, ui
 	}
 	// Slot holds 0 or a version — install a fresh tracker.
 	uint16_t gen = vtNextGen();
-	LockTracker* t = new LockTracker(slotIndexOf(slot), gen, dbPtr);
+	LockTracker* t = new LockTracker(slotIndexOf(slot), gen, dbId);
 	t->holders.store(1, std::memory_order_relaxed);
 	t->refcount.store(1, std::memory_order_relaxed); // 1 reference == this holder
 	slot->store(vtEncodeLock(t, gen), std::memory_order_release);
@@ -286,7 +286,7 @@ void VerificationTable::settleAllSlots() {
 	}
 }
 
-void VerificationTable::cancelForDB(uintptr_t dbPtr) {
+void VerificationTable::cancelForDB(uint64_t dbId) {
 	if (!slots_) return;
 	std::lock_guard<std::mutex> lock(writerMutex_);
 	size_t n = mask_ + 1;
@@ -298,7 +298,7 @@ void VerificationTable::cancelForDB(uintptr_t dbPtr) {
 		// out from under us, so the loaded pointer is safe to dereference.
 		LockTracker* t = vtDecodeLock(v);
 		uint16_t gen = vtGenFromLock(v);
-		if (t->dbPtr != dbPtr) continue;
+		if (t->dbId != dbId) continue;
 
 		// Settle the slot to a fresh settled-empty generation; may fail
 		// harmlessly if it changed. (Like releaseWriteIntent, never back to 0.)

--- a/src/binding/core/verification_table.h
+++ b/src/binding/core/verification_table.h
@@ -92,14 +92,14 @@ struct LockTracker {
 	std::atomic<uint32_t> holders{0};   // count of active intent registrations
 	uint16_t              generation;   // immutable after install; matches slot encoding
 	size_t                slotIndex;    // index in VT slots_ array (for cancelForDB)
-	uintptr_t             dbPtr;        // identity of the owning DB descriptor
+	uint64_t              dbId;         // per-open epoch of the owning DB (DBDescriptor::vtEpoch)
 
 	bool                               woken{false};
 	std::mutex                         wakeCallbacksMutex;
 	std::vector<std::function<void()>> wakeCallbacks;
 
-	LockTracker(size_t idx, uint16_t gen, uintptr_t dbPtr)
-		: refcount(1), holders(0), generation(gen), slotIndex(idx), dbPtr(dbPtr) {}
+	LockTracker(size_t idx, uint16_t gen, uint64_t dbId)
+		: refcount(1), holders(0), generation(gen), slotIndex(idx), dbId(dbId) {}
 
 	/**
 	 * Registers a callback to be invoked when wake() is called.
@@ -142,7 +142,7 @@ public:
 	 * when the table is disabled.
 	 */
 	std::atomic<uint64_t>* slotFor(
-		uintptr_t dbPtr,
+		uint64_t dbId,
 		uint32_t cfId,
 		const rocksdb::Slice& key
 	) const;
@@ -209,7 +209,7 @@ public:
 	 * this via releaseIntent(); cancelForDB() is a defensive final pass for
 	 * unexpected races or shutdown ordering issues.
 	 */
-	void cancelForDB(uintptr_t dbPtr);
+	void cancelForDB(uint64_t dbId);
 
 	/**
 	 * Sweeps every non-lock slot in the table and advances it to a fresh
@@ -252,7 +252,7 @@ public:
 	 * tracker. Returns the tracker the caller now holds an intent on (to be
 	 * passed to releaseWriteIntent), or nullptr if the slot is null.
 	 */
-	LockTracker* lockSlotForWrite(std::atomic<uint64_t>* slot, uintptr_t dbPtr);
+	LockTracker* lockSlotForWrite(std::atomic<uint64_t>* slot, uint64_t dbId);
 
 	/**
 	 * Releases one write intent previously taken via lockSlotForWrite. When the

--- a/src/binding/database/database.cpp
+++ b/src/binding/database/database.cpp
@@ -1501,10 +1501,11 @@ napi_value Database::PutSync(napi_env env, napi_callback_info info) {
 		std::atomic<uint64_t>* vtSlot = nullptr;
 		LockTracker* vtTracker = nullptr;
 		if (vt) {
-			uintptr_t dbPtr = reinterpret_cast<uintptr_t>((*dbHandle)->descriptor.get());
+			// Per-open epoch, not the descriptor pointer (reused across reopen).
+			uint64_t dbId = (*dbHandle)->descriptor->vtEpoch;
 			uint32_t cfId = (*dbHandle)->getColumnFamilyHandle()->GetID();
-			vtSlot = vt->slotFor(dbPtr, cfId, keySlice);
-			vtTracker = vt->lockSlotForWrite(vtSlot, dbPtr);
+			vtSlot = vt->slotFor(dbId, cfId, keySlice);
+			vtTracker = vt->lockSlotForWrite(vtSlot, dbId);
 		}
 		rocksdb::WriteOptions writeOptions;
 		writeOptions.disableWAL = (*dbHandle)->disableWAL;
@@ -1565,10 +1566,11 @@ napi_value Database::RemoveSync(napi_env env, napi_callback_info info) {
 		std::atomic<uint64_t>* vtSlot = nullptr;
 		LockTracker* vtTracker = nullptr;
 		if (vt) {
-			uintptr_t dbPtr = reinterpret_cast<uintptr_t>((*dbHandle)->descriptor.get());
+			// Per-open epoch, not the descriptor pointer (reused across reopen).
+			uint64_t dbId = (*dbHandle)->descriptor->vtEpoch;
 			uint32_t cfId = (*dbHandle)->getColumnFamilyHandle()->GetID();
-			vtSlot = vt->slotFor(dbPtr, cfId, keySlice);
-			vtTracker = vt->lockSlotForWrite(vtSlot, dbPtr);
+			vtSlot = vt->slotFor(dbId, cfId, keySlice);
+			vtTracker = vt->lockSlotForWrite(vtSlot, dbId);
 		}
 		rocksdb::WriteOptions writeOptions;
 		writeOptions.disableWAL = (*dbHandle)->disableWAL;

--- a/src/binding/database/database.h
+++ b/src/binding/database/database.h
@@ -42,9 +42,11 @@ inline std::atomic<uint64_t>* vtSlotFor(
 	const rocksdb::Slice& key
 ) {
 	if (!vt) return nullptr;
-	uintptr_t dbPtr = reinterpret_cast<uintptr_t>(dbHandle->descriptor.get());
+	// Per-open epoch, not the descriptor pointer: the pointer is reused across a
+	// close/reopen of the same path while cfId stays stable (HarperFast/harper#1864).
+	uint64_t dbId = dbHandle->descriptor->vtEpoch;
 	uint32_t cfId = dbHandle->getColumnFamilyHandle()->GetID();
-	return vt->slotFor(dbPtr, cfId, key);
+	return vt->slotFor(dbId, cfId, key);
 }
 
 /**

--- a/src/binding/database/db_descriptor.cpp
+++ b/src/binding/database/db_descriptor.cpp
@@ -10,6 +10,15 @@ namespace rocksdb_js {
 // forward declarations
 static void callJsCallback(napi_env env, napi_value jsCallback, void* context, void* data);
 
+// Process-global monotonic source for DBDescriptor::vtEpoch. Starts at 1 so a
+// valid epoch is never 0. 64-bit: never wraps in practice, so every descriptor
+// open across the process lifetime gets a distinct VerificationTable identity.
+static std::atomic<uint64_t> vtEpochCounter{1};
+
+static uint64_t nextVtEpoch() {
+	return vtEpochCounter.fetch_add(1, std::memory_order_relaxed);
+}
+
 struct JobTracker final {
 	int columnFamilyCount = 0;
 	rocksdb::SequenceNumber flushedSequence = 0;
@@ -118,6 +127,7 @@ DBDescriptor::DBDescriptor(
 	std::shared_ptr<rocksdb::Statistics> statistics
 ):
 	path(path),
+	vtEpoch(nextVtEpoch()),
 	mode(options.mode),
 	readOnly(options.readOnly),
 	db(db),
@@ -218,7 +228,7 @@ void DBDescriptor::finishClose() {
 	{
 		auto* vt = DBSettings::getInstance().getVerificationTableRaw();
 		if (vt) {
-			vt->cancelForDB(reinterpret_cast<uintptr_t>(this));
+			vt->cancelForDB(this->vtEpoch);
 		}
 	}
 

--- a/src/binding/database/db_descriptor.h
+++ b/src/binding/database/db_descriptor.h
@@ -62,6 +62,22 @@ struct DBDescriptor final : public std::enable_shared_from_this<DBDescriptor> {
 	std::string path;
 
 	/**
+	 * Process-unique identity for this descriptor's *open lifecycle*, used as the
+	 * database component of every VerificationTable slot address (with cfId + key).
+	 *
+	 * The descriptor heap pointer is NOT usable for this: it is freed on close and
+	 * routinely re-used by the allocator on the next reopen of the same path, while
+	 * RocksDB keeps cfId stable across reopens. That let a version cached by a prior
+	 * in-process incarnation be addressed — and trusted (spurious FRESH) — by the
+	 * next one, resolving present keys as stale/absent until the slots settled
+	 * (HarperFast/harper#1864). A monotonic per-open epoch is unique across the whole
+	 * process lifetime, so a reopened DB can never collide with a prior incarnation's
+	 * slots regardless of address reuse. It is only ever compared for equality (slot
+	 * hashing, cancelForDB), never dereferenced.
+	 */
+	const uint64_t vtEpoch;
+
+	/**
 	 * The mode of the database: optimistic or pessimistic. `DBRegistry`
 	 * defaults this to `DBMode::Optimistic`.
 	 */

--- a/src/binding/transaction/transaction_handle.cpp
+++ b/src/binding/transaction/transaction_handle.cpp
@@ -140,11 +140,13 @@ void TransactionHandle::lockVTSlot(
 	auto* vt = DBSettings::getInstance().getVerificationTableRaw();
 	if (!vt) return;
 
-	// Use the transaction's base descriptor as the database identity key.
-	// All column families of the same physical DB share the same descriptor.
-	uintptr_t dbPtr = reinterpret_cast<uintptr_t>(this->dbHandle->descriptor.get());
+	// Use the descriptor's per-open epoch as the database identity key (not the
+	// descriptor pointer, which is reused across a close/reopen of the same path).
+	// All column families of the same physical DB share the same epoch, separated
+	// by cfId.
+	uint64_t dbId = this->dbHandle->descriptor->vtEpoch;
 	uint32_t cfId = dbHandle->getColumnFamilyHandle()->GetID();
-	auto* slot = vt->slotFor(dbPtr, cfId, key);
+	auto* slot = vt->slotFor(dbId, cfId, key);
 	if (!slot) return;
 
 	// Register a write intent on the slot. lockSlotForWrite installs a new
@@ -154,7 +156,7 @@ void TransactionHandle::lockVTSlot(
 	// if a second concurrent writer skipped registering an intent, a reader
 	// could repopulate the slot with a now-stale version after the first writer
 	// released but before the second committed.
-	LockTracker* t = vt->lockSlotForWrite(slot, dbPtr);
+	LockTracker* t = vt->lockSlotForWrite(slot, dbId);
 	if (t) {
 		lockedVTSlots.push_back(slot);
 		heldTrackers.push_back(t);

--- a/src/binding/transaction/transaction_handle.cpp
+++ b/src/binding/transaction/transaction_handle.cpp
@@ -144,7 +144,7 @@ void TransactionHandle::lockVTSlot(
 	// descriptor pointer, which is reused across a close/reopen of the same path).
 	// All column families of the same physical DB share the same epoch, separated
 	// by cfId.
-	uint64_t dbId = this->dbHandle->descriptor->vtEpoch;
+	uint64_t dbId = dbHandle->descriptor->vtEpoch;
 	uint32_t cfId = dbHandle->getColumnFamilyHandle()->GetID();
 	auto* slot = vt->slotFor(dbId, cfId, key);
 	if (!slot) return;

--- a/test/native/verification_table_test.cc
+++ b/test/native/verification_table_test.cc
@@ -105,6 +105,43 @@ TEST(VerificationTable, ColdPopulateSucceedsFromSettledWhenReobserved) {
 	EXPECT_TRUE(VerificationTable::verifyVersion(slot, kV2));
 }
 
+// Cross-incarnation isolation (HarperFast/harper#1864). A slot is addressed by
+// (dbId, cfId, key) where dbId is DBDescriptor::vtEpoch — a process-unique per-open
+// value. A later in-process reopen of the same path gets a fresh epoch, so even
+// though the reused descriptor address and (stable) cfId could be identical, the
+// new incarnation addresses a different, cold slot and can never observe the prior
+// incarnation's cached version (which previously surfaced as a spurious FRESH hit
+// resolving present keys as stale/absent). Deterministic: skip the rare hash
+// collision and assert on the first independent slot, which is found immediately.
+TEST(VerificationTable, DistinctDbEpochsAddressIndependentSlots) {
+	VerificationTable vt(1 << 12, 0xABCD);
+	rocksdb::Slice key("record-key");
+	const uint64_t epochOld = 1;
+
+	auto* slotOld = vt.slotFor(epochOld, 0, key);
+	ASSERT_NE(slotOld, nullptr);
+	ASSERT_TRUE(VerificationTable::populateVersion(slotOld, kV1));
+	ASSERT_TRUE(VerificationTable::verifyVersion(slotOld, kV1));
+
+	for (uint64_t epochNew = 2; epochNew < 100; ++epochNew) {
+		auto* slotNew = vt.slotFor(epochNew, 0, key);
+		if (slotNew == slotOld) continue;  // rare hash collision — try the next epoch
+		EXPECT_FALSE(VerificationTable::verifyVersion(slotNew, kV1))
+			<< "epoch " << epochNew << " must not see a prior incarnation's version";
+		EXPECT_EQ(slotNew->load(), 0u);  // fresh/cold, not a leaked version
+		return;
+	}
+	FAIL() << "expected at least one distinct slot across epochs";
+}
+
+// The same (dbId, cfId, key) is stable: a live incarnation keeps addressing its
+// own slot for the life of the open.
+TEST(VerificationTable, SameDbEpochIsStable) {
+	VerificationTable vt(1 << 12, 0xABCD);
+	rocksdb::Slice key("record-key");
+	EXPECT_EQ(vt.slotFor(7, 3, key), vt.slotFor(7, 3, key));
+}
+
 // Encoding classes (version / lock / settled / empty) are mutually exclusive.
 TEST(VerificationTable, EncodingClassesAreDisjoint) {
 	EXPECT_TRUE(vtIsVersion(kV1));

--- a/test/verification-table.test.ts
+++ b/test/verification-table.test.ts
@@ -428,4 +428,136 @@ describe('Verification Table', () => {
 				expect(result).toBeUndefined();
 			}));
 	});
+
+	// #1864: VT slot identity uses the DBDescriptor's per-open epoch, not its heap
+	// pointer. A descriptor pointer is freed on close and routinely re-used by the
+	// allocator on the next open of the same (or another) path, while RocksDB keeps
+	// cfId stable across reopens — so before the epoch, a version cached by a prior
+	// in-process incarnation could be addressed (and trusted, as a spurious FRESH)
+	// by a later one, resolving present/absent keys wrongly until the slots settled.
+	// A fresh empty DB opened right after a close is the most likely address-reuse
+	// victim; these tests exercise the end-to-end read paths across a close/reopen.
+	describe('VT identity across DB open/close lifecycle (#1864)', () => {
+		const settledVersion = 1.5e12; // well in the past → immediately cacheable
+
+		it('a version cached before close never leaks into a later incarnation (non-resurrection)', async () => {
+			const key = Buffer.from('reused-slot-key');
+			// Loop so allocator address-reuse (the real-world trigger) is very likely
+			// to occur at least once; the epoch makes every iteration read cold.
+			for (let i = 0; i < 40; i++) {
+				const db = new RocksDatabase(generateDBPath(), {
+					encoding: false,
+					verificationTable: true,
+				});
+				db.open();
+				try {
+					const native = (db as any).store.db;
+					// This incarnation is a brand-new, empty DB: the key does not exist
+					// here. A stale slot from the just-closed prior incarnation (which
+					// seeded `settledVersion` below) must NOT surface as FRESH — it must
+					// read through and report not-found.
+					const stale = native.getSync(key, 0, undefined, settledVersion);
+					expect(stale).not.toBe(FRESH_VERSION_FLAG);
+					expect(stale).toBeUndefined();
+					expect(db.verifyVersion(key, settledVersion)).toBe(false);
+
+					// Seed this incarnation's slot so the NEXT iteration's (likely
+					// address-reusing) descriptor would observe it without the epoch.
+					await db.put(key, makeValue(settledVersion));
+					native.getSync(key, POPULATE_VERSION_FLAG, undefined, undefined);
+					expect(db.verifyVersion(key, settledVersion)).toBe(true);
+				} finally {
+					db.close();
+				}
+			}
+		});
+
+		it('a transactional point-get after write/flush/close/reopen returns the persisted value and agrees with range/raw', async () => {
+			const path = generateDBPath();
+			const key = Buffer.from('persisted-key');
+			const value = makeValue(settledVersion);
+
+			// Incarnation 1: persist + flush to disk, seed the VT slot, then close.
+			{
+				const db = new RocksDatabase(path, { encoding: false, verificationTable: true });
+				db.open();
+				const native = (db as any).store.db;
+				await db.put(key, value);
+				await db.flush();
+				native.getSync(key, POPULATE_VERSION_FLAG, undefined, undefined);
+				expect(db.verifyVersion(key, settledVersion)).toBe(true);
+				db.close();
+			}
+
+			// Incarnation 2: reopen the same path (pre-existing persisted data). A
+			// transactional point-get must return the actual persisted bytes,
+			// agreeing with getRange and raw getBinarySync. (A cache-freshness read
+			// carrying the pre-close version may legitimately answer FRESH when the
+			// descriptor was reused for the same unchanged data; the false-positive
+			// paths — absent/deleted keys — are covered by the other two tests.)
+			{
+				const db = new RocksDatabase(path, { encoding: false, verificationTable: true });
+				db.open();
+				try {
+					const raw = db.getBinarySync(key) as Buffer;
+					expect(raw).toBeDefined();
+					expect(Buffer.from(raw).equals(value)).toBe(true);
+
+					const fromRange = [...db.getRange()].map((e: any) => e.value as Buffer);
+					expect(fromRange.length).toBe(1);
+					expect(Buffer.from(fromRange[0]).equals(value)).toBe(true);
+
+					await db.transaction(async (txn: Transaction) => {
+						const got = txn.getBinarySync(key);
+						expect(got).toBeDefined();
+						expect(Buffer.from(got as Buffer).equals(value)).toBe(true);
+					});
+				} finally {
+					db.close();
+				}
+			}
+		});
+
+		it('a delete in a reopened incarnation is not resurrected by a stale slot and holds under a snapshot', async () => {
+			const path = generateDBPath();
+			const key = Buffer.from('delete-me');
+			const value = makeValue(settledVersion);
+
+			// Incarnation 1: write + seed the slot, close (slot may hold the version).
+			{
+				const db = new RocksDatabase(path, { encoding: false, verificationTable: true });
+				db.open();
+				const native = (db as any).store.db;
+				await db.put(key, value);
+				native.getSync(key, POPULATE_VERSION_FLAG, undefined, undefined);
+				expect(db.verifyVersion(key, settledVersion)).toBe(true);
+				db.close();
+			}
+
+			// Incarnation 2: reopen, delete the record, then confirm no read path
+			// resurrects it via a stale slot — including a transactional read carrying
+			// the old version, and a snapshot opened after the delete.
+			{
+				const db = new RocksDatabase(path, { encoding: false, verificationTable: true });
+				db.open();
+				try {
+					const native = (db as any).store.db;
+					expect(db.getBinarySync(key)).toBeDefined(); // persisted row is present
+					native.removeSync(key);
+
+					expect(db.verifyVersion(key, settledVersion)).toBe(false);
+					expect(db.getBinarySync(key)).toBeUndefined();
+					expect([...db.getRange()].length).toBe(0);
+
+					await db.transaction(async (txn: Transaction) => {
+						const got = txn.getBinarySync(key, { expectedVersion: settledVersion } as any);
+						expect(got).not.toBe(FRESH_VERSION_FLAG);
+						expect(got).toBeUndefined();
+					});
+				} finally {
+					db.close();
+				}
+			}
+		});
+	});
 });


### PR DESCRIPTION
## Summary
The `VerificationTable` (VT) — the process-global, lock-free record-version cache in the native binding — identified each slot by `(DBDescriptor heap pointer, cfId, key)`. Across an **in-process** close→reopen of the same DB path, the descriptor pointer is freed and routinely re-used by the allocator on the next open, while RocksDB keeps `cfId` stable (persisted in the MANIFEST). A version cached by a prior incarnation was therefore addressed — and, when a caller passed the matching `expectedVersion`, trusted as a spurious `FRESH` hit **without any RocksDB read** — by the next incarnation.

## Purpose (fixes HarperFast/harper#1864)
With Harper 5.2 record caching active (harper #410 → this repo's #526), `PrimaryRocksDatabase.getEntry` passes `expectedVersion` to `getSync`. The stale cross-incarnation slot made point-gets for an entire table resolve as stale/absent for ~175s after an upgrade (an in-process reopen), while scans / `getKeys` / raw `getBinarySync` — none of which touch the VT — saw every row. It self-healed once writes/compaction settled the slots.

Notably this is **not** a process-restart bug: a restart rebuilds a fresh empty VT and would *clear* the condition. The trigger is any in-process DB-layer teardown+rebuild of the same path (upgrade, drop/recreate, redeploy, restore) — with the record cache and VT staying live.

## Fix
Replace the descriptor-pointer identity with `DBDescriptor::vtEpoch` — a process-global monotonic `uint64` assigned once per open — at every VT identity site: `slotFor`, `lockSlotForWrite`, `cancelForDB`, and `LockTracker`. The epoch is unique across the whole process lifetime, so a reopened DB gets a distinct identity and can never address a prior incarnation's slots, regardless of address reuse. It is only ever compared for equality, never dereferenced. Preserves the #693 clear/write/snapshot invalidation gates; the non-FRESH fallback still reads through the same transaction snapshot + CF.

## Where to look
- `db_descriptor.h/.cpp` — the new `const uint64_t vtEpoch` + its monotonic source.
- `verification_table.{h,cpp}` — `dbPtr → dbId` (`uintptr_t → uint64_t`) across the API and `LockTracker`.
- The 5 identity sites: `database.h` `vtSlotFor` (read), `transaction_handle.cpp` `lockVTSlot`, `database.cpp` `PutSync`/`RemoveSync`, `db_descriptor.cpp` `cancelForDB`.

## Known residual — please weigh (surfaced by cross-model review; **not** a regression)
The VT is a fixed-size **tagless** table: a slot holds only a 64-bit version, so distinct `(dbId,cfId,key)` triples that hash to the same index share it. `cancelForDB` settles only *lock* slots (version slots carry no provenance), so unlocked version slots from a closed DB linger. After this fix a new incarnation can therefore still, with probability ~`1/tableSize` × (two independent float64 versions colliding, ~2⁻⁵²), read a stale lingering version as `FRESH`.

This is the **pre-existing, documented** collision tolerance of the VT design (the header states collisions "can cause false invalidations but never incorrect results," and `verification-table.test.ts` already asserts cross-DB isolation *statistically*, tolerating `leaks < N/4`). Version slots also lingered after close **before** this PR — the change does not worsen it; it converts the #1864 failure from **deterministic** (100% on address reuse, for the same key) to this baseline probabilistic floor, which cannot produce a whole-table outage. Fully eliminating it would need either 128-bit slots carrying an epoch tag (doubles VT memory, breaks the single-atomic lock-free design) or a coarse `settleAllSlots()` on every close (O(n), evicts every other DB's cache) — both deliberately out of scope for this minimal correctness fix (see follow-up note).

## Tests
- **Native GoogleTest** (`verification_table_test.cc`): `DistinctDbEpochsAddressIndependentSlots` proves a version stored under `epochA` is not verifiable under `epochB` (deterministic); `SameDbEpochIsStable`.
- **Vitest** (`verification-table.test.ts`, new "VT identity across DB open/close lifecycle" block): a version cached before close never leaks into a later incarnation (looped to hit allocator address reuse); transactional point-get after write/flush/close/reopen returns persisted bytes and agrees with `getRange`/raw; delete-in-reopened-incarnation non-resurrection.
- Verified the lifecycle tests have teeth via a constant-epoch negative control (they fail without the fix). Full suite: 641 passed / 2 skipped; native: 92 passed; `pnpm check` clean.

## Follow-up
Requires a rocksdb-js patch release, then a Harper dependency bump + integration test against #1864. The tagless-collision residual above is a candidate for a separate hardening ticket if the team wants to close it.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: Claude Opus 4.8)