### PR TITLE
Bound RocksDB max_open_files with an fd-limit-derived default

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,13 @@ Creates a new database instance.
   - `enableStats: boolean` When `true` and the database is open, RocksDB will captures stats that
     are retrieved by calling `db.getStats()`. Enabling statistics imposes 5-10% in overhead.
     Defaults to `false`.
+  - `maxOpenFiles: number` The maximum number of table files RocksDB keeps open. `0` (the default)
+    derives a budget from the effective per-process open-file limit (an eighth of the limit —
+    several databases can share one process — clamped to `[1024, 262144]`); `-1` holds every table
+    file open (the RocksDB default, which can exhaust the process file-descriptor limit when
+    compaction falls behind under sustained ingest); a positive `int32` is an explicit cap. Reads
+    only pay a reopen cost when the number of live table files exceeds the budget, so raise the
+    process fd limit (and with it the derived budget) for very large databases.
   - `name: string` The column family name. Defaults to `"default"`.
   - `noBlockCache: boolean` When `true`, disables the block cache. Block caching is enabled by
     default and the cache is shared across all database instances.

--- a/binding.gyp
+++ b/binding.gyp
@@ -223,6 +223,7 @@
 				'test/native/encoding_test.cc',
 				'test/native/file_lock_test.cc',
 				'test/native/json_test.cc',
+				'test/native/platform_fd_limit_test.cc',
 				'test/native/transaction_log_madvise_test.cc',
 				'test/native/transaction_log_mmap_test.cc',
 				'test/native/transaction_log_recovery_test.cc',

--- a/src/binding/core/platform.cpp
+++ b/src/binding/core/platform.cpp
@@ -39,10 +39,15 @@ uint64_t getEffectiveOpenFileLimit() {
 	return 0;
 #else
 	struct rlimit limit;
-	if (::getrlimit(RLIMIT_NOFILE, &limit) != 0 || limit.rlim_cur == RLIM_INFINITY) {
+	if (::getrlimit(RLIMIT_NOFILE, &limit) != 0) {
 		return 0;
 	}
-	uint64_t effectiveLimit = static_cast<uint64_t>(limit.rlim_cur);
+	// An unlimited soft rlimit is "no rlimit constraint", not "unknown": it
+	// still flows through the macOS kernel cap below and the derivation
+	// ceiling in deriveMaxOpenFiles.
+	uint64_t effectiveLimit = limit.rlim_cur == RLIM_INFINITY
+		? std::numeric_limits<uint64_t>::max()
+		: static_cast<uint64_t>(limit.rlim_cur);
 	#ifdef __APPLE__
 	// macOS enforces kern.maxfilesperproc even when the rlimit is higher
 	int32_t maxFilesPerProc = 0;

--- a/src/binding/core/platform.cpp
+++ b/src/binding/core/platform.cpp
@@ -11,8 +11,11 @@
 #include <windows.h>
 #elif defined(__linux__)
 #include <sys/syscall.h>
+#include <sys/resource.h>
 #elif defined(__APPLE__)
 #include <pthread.h>
+#include <sys/resource.h>
+#include <sys/sysctl.h>
 #endif
 
 namespace rocksdb_js {
@@ -29,6 +32,45 @@ size_t getThreadId() {
 #else
 	return std::hash<std::thread::id>{}(std::this_thread::get_id());
 #endif
+}
+
+uint64_t getEffectiveOpenFileLimit() {
+#ifdef _WIN32
+	return 0;
+#else
+	struct rlimit limit;
+	if (::getrlimit(RLIMIT_NOFILE, &limit) != 0 || limit.rlim_cur == RLIM_INFINITY) {
+		return 0;
+	}
+	uint64_t effectiveLimit = static_cast<uint64_t>(limit.rlim_cur);
+	#ifdef __APPLE__
+	// macOS enforces kern.maxfilesperproc even when the rlimit is higher
+	int32_t maxFilesPerProc = 0;
+	size_t size = sizeof(maxFilesPerProc);
+	if (::sysctlbyname("kern.maxfilesperproc", &maxFilesPerProc, &size, nullptr, 0) == 0 &&
+		maxFilesPerProc > 0 &&
+		static_cast<uint64_t>(maxFilesPerProc) < effectiveLimit
+	) {
+		effectiveLimit = static_cast<uint64_t>(maxFilesPerProc);
+	}
+	#endif
+	return effectiveLimit;
+#endif
+}
+
+int32_t deriveMaxOpenFiles(uint64_t effectiveOpenFileLimit) {
+	if (effectiveOpenFileLimit == 0) {
+		return -1;
+	}
+	constexpr uint64_t minBudget = 1024;
+	constexpr uint64_t maxBudget = 262144;
+	uint64_t budget = effectiveOpenFileLimit / 8;
+	if (budget < minBudget) {
+		budget = minBudget;
+	} else if (budget > maxBudget) {
+		budget = maxBudget;
+	}
+	return static_cast<int32_t>(budget);
 }
 
 std::chrono::system_clock::time_point convertFileTimeToSystemTime(

--- a/src/binding/core/platform.h
+++ b/src/binding/core/platform.h
@@ -3,11 +3,30 @@
 
 #include <chrono>
 #include <cstddef>
+#include <cstdint>
 #include <filesystem>
 
 namespace rocksdb_js {
 
 size_t getThreadId();
+
+/**
+ * The effective per-process open-file limit: the soft `RLIMIT_NOFILE`, further
+ * capped by `kern.maxfilesperproc` on macOS (the kernel enforces it even when
+ * the rlimit is higher). Returns `0` when the limit cannot be determined
+ * (e.g. Windows, where no comparable per-process fd limit applies).
+ */
+uint64_t getEffectiveOpenFileLimit();
+
+/**
+ * Derives a bounded RocksDB `max_open_files` budget from the effective
+ * per-process open-file limit: an eighth of the limit — the limit is a
+ * process-wide budget shared by every database opened in the process (each
+ * derives independently) plus sockets, transaction logs, WAL, and everything
+ * else — clamped to [1024, 262144]. Returns `-1` (unlimited) when the limit
+ * is unknown (`0`).
+ */
+int32_t deriveMaxOpenFiles(uint64_t effectiveOpenFileLimit);
 
 std::chrono::system_clock::time_point convertFileTimeToSystemTime(const std::filesystem::file_time_type& fileTime);
 

--- a/src/binding/database/database.cpp
+++ b/src/binding/database/database.cpp
@@ -1399,6 +1399,11 @@ napi_value Database::Open(napi_env env, napi_callback_info info) {
 	NAPI_STATUS_THROWS(rocksdb_js::getProperty(env, options, "readOnly", dbHandleOptions.readOnly));
 	NAPI_STATUS_THROWS(rocksdb_js::getProperty(env, options, "parallelismThreads", dbHandleOptions.parallelismThreads));
 	NAPI_STATUS_THROWS(rocksdb_js::getProperty(env, options, "writeBufferSize", dbHandleOptions.writeBufferSize));
+	NAPI_STATUS_THROWS(rocksdb_js::getProperty(env, options, "maxOpenFiles", dbHandleOptions.maxOpenFiles));
+	if (dbHandleOptions.maxOpenFiles < -1) {
+		::napi_throw_error(env, nullptr, "maxOpenFiles must be -1 (unlimited), 0 (auto), or a positive number");
+		return nullptr;
+	}
 	NAPI_STATUS_THROWS(rocksdb_js::getProperty(env, options, "maxWriteBufferNumber", dbHandleOptions.maxWriteBufferNumber));
 	NAPI_STATUS_THROWS(rocksdb_js::getProperty(env, options, "dbWriteBufferSize", dbHandleOptions.dbWriteBufferSize));
 	NAPI_STATUS_THROWS(rocksdb_js::getProperty(env, options, "maxWriteBufferSizeToMaintain", dbHandleOptions.maxWriteBufferSizeToMaintain));

--- a/src/binding/database/database.cpp
+++ b/src/binding/database/database.cpp
@@ -1,5 +1,6 @@
 #include <node_api.h>
 #include <algorithm>
+#include <cmath>
 #include <sstream>
 #include "database/database.h"
 #include "database/db_handle.h"
@@ -1399,11 +1400,18 @@ napi_value Database::Open(napi_env env, napi_callback_info info) {
 	NAPI_STATUS_THROWS(rocksdb_js::getProperty(env, options, "readOnly", dbHandleOptions.readOnly));
 	NAPI_STATUS_THROWS(rocksdb_js::getProperty(env, options, "parallelismThreads", dbHandleOptions.parallelismThreads));
 	NAPI_STATUS_THROWS(rocksdb_js::getProperty(env, options, "writeBufferSize", dbHandleOptions.writeBufferSize));
-	NAPI_STATUS_THROWS(rocksdb_js::getProperty(env, options, "maxOpenFiles", dbHandleOptions.maxOpenFiles));
-	if (dbHandleOptions.maxOpenFiles < -1) {
-		::napi_throw_error(env, nullptr, "maxOpenFiles must be -1 (unlimited), 0 (auto), or a positive number");
+	// Parse as double and validate BEFORE narrowing: napi_get_value_int32
+	// truncates (-1.5 -> -1) and wraps modulo 2^32 (4294967295 -> -1), which
+	// would silently turn invalid values into "unlimited".
+	double maxOpenFilesValue = static_cast<double>(dbHandleOptions.maxOpenFiles);
+	NAPI_STATUS_THROWS(rocksdb_js::getProperty(env, options, "maxOpenFiles", maxOpenFilesValue));
+	if (std::isnan(maxOpenFilesValue) || maxOpenFilesValue != std::trunc(maxOpenFilesValue) ||
+		maxOpenFilesValue < -1.0 || maxOpenFilesValue > 2147483647.0
+	) {
+		::napi_throw_error(env, nullptr, "maxOpenFiles must be -1 (unlimited), 0 (auto), or a positive 32-bit integer");
 		return nullptr;
 	}
+	dbHandleOptions.maxOpenFiles = static_cast<int32_t>(maxOpenFilesValue);
 	NAPI_STATUS_THROWS(rocksdb_js::getProperty(env, options, "maxWriteBufferNumber", dbHandleOptions.maxWriteBufferNumber));
 	NAPI_STATUS_THROWS(rocksdb_js::getProperty(env, options, "dbWriteBufferSize", dbHandleOptions.dbWriteBufferSize));
 	NAPI_STATUS_THROWS(rocksdb_js::getProperty(env, options, "maxWriteBufferSizeToMaintain", dbHandleOptions.maxWriteBufferSizeToMaintain));

--- a/src/binding/database/db_descriptor.cpp
+++ b/src/binding/database/db_descriptor.cpp
@@ -1,3 +1,4 @@
+#include "core/platform.h"
 #include "database/db_descriptor.h"
 #include "database/db_settings.h"
 #include "transaction_log/transaction_log_store_registry.h"
@@ -699,6 +700,12 @@ std::shared_ptr<DBDescriptor> DBDescriptor::open(const std::string& path, const 
 		dbOptions.write_buffer_manager = wbm;
 	}
 	dbOptions.IncreaseParallelism(options.parallelismThreads);
+	// Bound how many table files RocksDB holds open: with the RocksDB default
+	// (-1, every SST open forever) compaction lag under sustained ingest can
+	// run the process out of fds (HarperFast/harper#1785 environment).
+	dbOptions.max_open_files = options.maxOpenFiles == 0
+		? deriveMaxOpenFiles(getEffectiveOpenFileLimit())
+		: options.maxOpenFiles;
 	dbOptions.keep_log_file_num = 5; // these are informational log files that clutter up the database directory
 	dbOptions.persist_user_defined_timestamps = true;
 	if (options.enableStats) {

--- a/src/binding/napi/helpers.h
+++ b/src/binding/napi/helpers.h
@@ -148,6 +148,10 @@ std::string getNapiExtendedError(napi_env env, napi_status& status, const char* 
 	return napi_ok;
 }
 
+[[maybe_unused]] static napi_status getValue(napi_env env, napi_value value, double& result) {
+	return ::napi_get_value_double(env, value, &result);
+}
+
 template<typename T = size_t>
 [[maybe_unused]] static typename std::enable_if<!std::is_same<T, uint64_t>::value, napi_status>::type
 getValue(napi_env env, napi_value value, size_t& result) {

--- a/src/binding/options/db_options.h
+++ b/src/binding/options/db_options.h
@@ -37,6 +37,11 @@ struct DBOptions final {
 	// `maxWriteBufferNumber * writeBufferSize` (the RocksDB-recommended default
 	// for OptimisticTransactionDB).
 	int64_t maxWriteBufferSizeToMaintain = -1;
+	// Maximum number of table files RocksDB keeps open (`max_open_files`).
+	// 0 = auto: derive a budget from the effective per-process open-file limit
+	// (see `deriveMaxOpenFiles`); -1 = unlimited (every SST held open — can
+	// exhaust the process fd limit under compaction lag); >0 = explicit cap.
+	int32_t maxOpenFiles = 0;
 	DBMode mode = DBMode::Optimistic;
 	std::string name;
 	bool noBlockCache = false;

--- a/src/load-binding.ts
+++ b/src/load-binding.ts
@@ -197,6 +197,7 @@ export type NativeDatabaseOptions = {
 	dbWriteBufferSize?: number;
 	disableWAL?: boolean;
 	enableStats?: boolean;
+	maxOpenFiles?: number;
 	maxWriteBufferNumber?: number;
 	maxWriteBufferSizeToMaintain?: number;
 	mode?: NativeDatabaseMode;

--- a/src/store.ts
+++ b/src/store.ts
@@ -205,6 +205,17 @@ export class Store {
 	maxKeySize: number;
 
 	/**
+	 * The maximum number of table files RocksDB keeps open. `0` (the default)
+	 * derives a budget from the effective per-process open-file limit (an
+	 * eighth of the limit — several databases can share one process — clamped
+	 * to `[1024, 262144]`); `-1` holds every table file open (the RocksDB
+	 * default, which can exhaust the process file-descriptor limit when
+	 * compaction falls behind under sustained ingest); a positive `int32` is
+	 * an explicit cap.
+	 */
+	maxOpenFiles?: number;
+
+	/**
 	 * The maximum number of memtables that can be queued per column family
 	 * before writes stall. Higher values absorb write bursts while flushes catch
 	 * up, at the cost of memory.
@@ -355,6 +366,7 @@ export class Store {
 		this.keyBuffer = KEY_BUFFER;
 		this.keyEncoding = keyEncoding;
 		this.maxKeySize = options?.maxKeySize ?? MAX_KEY_SIZE;
+		this.maxOpenFiles = options?.maxOpenFiles;
 		this.maxWriteBufferNumber = options?.maxWriteBufferNumber;
 		this.maxWriteBufferSizeToMaintain = options?.maxWriteBufferSizeToMaintain;
 		this.name = options?.name ?? 'default';
@@ -846,6 +858,7 @@ export class Store {
 			dbWriteBufferSize: this.dbWriteBufferSize,
 			disableWAL: this.disableWAL,
 			enableStats: this.enableStats,
+			maxOpenFiles: this.maxOpenFiles,
 			maxWriteBufferNumber: this.maxWriteBufferNumber,
 			maxWriteBufferSizeToMaintain: this.maxWriteBufferSizeToMaintain,
 			mode: this.pessimistic ? 'pessimistic' : 'optimistic',

--- a/test/db-options.test.ts
+++ b/test/db-options.test.ts
@@ -39,6 +39,32 @@ describe('Database write buffer options', () => {
 			}
 		));
 
+	it('should open with an explicit maxOpenFiles cap and serve reads across evicted table handles', () =>
+		dbRunner({ dbOptions: [{ maxOpenFiles: 32, writeBufferSize: 64 * 1024 }] }, async ({ db }) => {
+			// A small memtable produces many small SSTs so reads must reopen
+			// table files evicted from the 32-handle table cache.
+			const value = 'x'.repeat(1024);
+			for (let i = 0; i < 512; i++) {
+				await db.put(`key-${i.toString().padStart(6, '0')}`, value);
+			}
+			await db.flush();
+			expect(await db.get('key-000000')).toBe(value);
+			expect(await db.get('key-000511')).toBe(value);
+		}));
+
+	it('should open with maxOpenFiles -1 (unlimited, the previous default)', () =>
+		dbRunner({ dbOptions: [{ maxOpenFiles: -1 }] }, async ({ db }) => {
+			await db.put('foo', 'bar');
+			expect(await db.get('foo')).toBe('bar');
+		}));
+
+	it('should reject maxOpenFiles below -1', () =>
+		dbRunner({ dbOptions: [{ maxOpenFiles: -2 }], skipOpen: true }, async ({ db }) => {
+			expect(() => db.open()).toThrow(
+				'maxOpenFiles must be -1 (unlimited), 0 (auto), or a positive number'
+			);
+		}));
+
 	it('should flush memtables when writeBufferSize is exceeded', () =>
 		dbRunner({ dbOptions: [{ writeBufferSize: 64 * 1024 }] }, async ({ db }) => {
 			// 64KB memtable; write enough data to force at least one flush.

--- a/test/db-options.test.ts
+++ b/test/db-options.test.ts
@@ -61,8 +61,18 @@ describe('Database write buffer options', () => {
 	it('should reject maxOpenFiles below -1', () =>
 		dbRunner({ dbOptions: [{ maxOpenFiles: -2 }], skipOpen: true }, async ({ db }) => {
 			expect(() => db.open()).toThrow(
-				'maxOpenFiles must be -1 (unlimited), 0 (auto), or a positive number'
+				'maxOpenFiles must be -1 (unlimited), 0 (auto), or a positive 32-bit integer'
 			);
+		}));
+
+	it('should reject non-integer maxOpenFiles instead of truncating to -1', () =>
+		dbRunner({ dbOptions: [{ maxOpenFiles: -1.5 }], skipOpen: true }, async ({ db }) => {
+			expect(() => db.open()).toThrow('maxOpenFiles must be');
+		}));
+
+	it('should reject maxOpenFiles beyond int32 range instead of wrapping', () =>
+		dbRunner({ dbOptions: [{ maxOpenFiles: 2 ** 32 - 1 }], skipOpen: true }, async ({ db }) => {
+			expect(() => db.open()).toThrow('maxOpenFiles must be');
 		}));
 
 	it('should flush memtables when writeBufferSize is exceeded', () =>

--- a/test/native/platform_fd_limit_test.cc
+++ b/test/native/platform_fd_limit_test.cc
@@ -1,0 +1,34 @@
+#include <gtest/gtest.h>
+#include "core/platform.h"
+
+using rocksdb_js::deriveMaxOpenFiles;
+using rocksdb_js::getEffectiveOpenFileLimit;
+
+TEST(FdLimit, DeriveUnknownLimitIsUnlimited) {
+	EXPECT_EQ(deriveMaxOpenFiles(0), -1);
+}
+
+TEST(FdLimit, DeriveClampsToFloor) {
+	// An eighth of a small limit still yields the floor so RocksDB has a
+	// workable table cache even under a constrained ulimit.
+	EXPECT_EQ(deriveMaxOpenFiles(256), 1024);
+	EXPECT_EQ(deriveMaxOpenFiles(8192), 1024);
+}
+
+TEST(FdLimit, DeriveIsAnEighthOfTheLimitInRange) {
+	EXPECT_EQ(deriveMaxOpenFiles(65536), 8192);
+	EXPECT_EQ(deriveMaxOpenFiles(92160), 11520);
+}
+
+TEST(FdLimit, DeriveClampsToCeiling) {
+	EXPECT_EQ(deriveMaxOpenFiles(4194304), 262144);
+	EXPECT_EQ(deriveMaxOpenFiles(UINT64_MAX), 262144);
+}
+
+#ifndef _WIN32
+TEST(FdLimit, EffectiveLimitIsPositiveOnUnix) {
+	// The exact value depends on the environment; it just has to be a real
+	// limit rather than 0/unknown on POSIX systems.
+	EXPECT_GT(getEffectiveOpenFileLimit(), 0u);
+}
+#endif


### PR DESCRIPTION
## Summary

New `maxOpenFiles` open option controlling RocksDB's `max_open_files`, which we previously left at the RocksDB default of `-1` — every table file held open forever:

- `0` (**new default**): derive a budget from the effective per-process open-file limit — `min(soft RLIMIT_NOFILE, kern.maxfilesperproc on macOS) / 8`, clamped to `[1024, 262144]`
- `-1`: the previous unlimited behavior (explicit opt-out)
- `> 0`: explicit cap (`< -1` throws at open)

## Purpose

While reproducing HarperFast/harper#1785's trigger environment (sustained bulk ingest under CPU suspension), compaction lag produced **90,049 open .sst descriptors against macOS's `kern.maxfilesperproc` of 92,160** — at which point *everything* in the process starts failing with EMFILE/IO errors (RocksDB appends, sockets, spawns). The customer-side stall diagnostics on that issue show the same regime (12k+ open SSTs). A bounded table cache converts that failure mode into (at worst) slower reads.

## Performance

A/B benchmark (300k rows, ~150 small SSTs, 5 alternating rounds, median):

| config | full-range random reads | hot-set (block-cache-served) |
|---|---|---|
| `-1` unlimited | 343.8k ops/s | 906k ops/s |
| `65536` budget (no evictions) | 343.0k ops/s | 898k ops/s |
| `64` evicting cap | 53k ops/s | 941k ops/s |

The LRU table-cache lookup that `-1` bypasses is not measurable on this workload; only **eviction** (live SSTs > budget) is expensive, and that regime previously meant fd exhaustion instead. Healthy DBs run hundreds-to-low-thousands of SSTs, well under the derived budgets.

## Review attention

- **The default changes behavior** for every consumer that doesn't pass the option. Opt-out is `maxOpenFiles: -1`.
- **Derivation divisor**: /8 rather than /2 because the fd limit is a process-wide budget and each database in the process derives independently (Harper opens several); flagged by cross-model review. If a process opens more than ~8 auto-derived databases on a tight limit, aggregate budgets can still exceed the limit — judged acceptable vs. the complexity of process-global budget accounting.
- **Low-ulimit deployments** (soft 1024): the floor budget (1024) can put large DBs in the evicting regime — but under `-1` those same deployments EMFILE-crashed at the same file count, so slow-but-alive is the intended trade. README now advises raising the fd limit for very large databases.
- First-opener-wins on shared `DBDescriptor`s applies to this option like every other `dbOptions` field (pre-existing semantics).
- ~~Values beyond int32 range wrap via ECMAScript ToInt32~~ — fixed in the follow-up commit per Codex review: `maxOpenFiles` is now parsed as a double and validated (integral, `[-1, INT32_MAX]`) before narrowing, so `-1.5` / `2^32-1` throw instead of silently meaning unlimited. An `RLIM_INFINITY` soft rlimit now also flows through the macOS kernel cap and the ceiling instead of reverting auto mode to unlimited.

Cross-model review: **Codex** (correctness pass — three findings: first-opener-wins corroboration, validate-after-coercion, RLIM_INFINITY handling; latter two fixed in the second commit) + **Claude domain pass** (divisor composition + low-ulimit trade, addressed/accepted as noted above). Gemini leg unavailable (agy timeouts) — no perf/maintainability second-model coverage; the A/B benchmark stands in for that lens.

Generated by an LLM (Claude Fable 5), investigation + benchmarks included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

