### PR TITLE
Fix async transaction reads across column families

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -245,6 +245,13 @@ C++ code that needs to emit to JS without a database context should call
    unsupported/errored or reporting 0 (which also lets a genuinely-full local volume through — a real 0
    is indistinguishable from the spurious 0 some network filesystems report). The stream-target backup
    path never opens a `BackupEngine` against a volume and is not checked.
+9. **Transaction reads are database-wide, but column-family-specific**: one native transaction may
+   serve stores backed by any column family in its database. `TransactionHandle::get` must therefore
+   use the column family resolved from its `dbHandleOverride` in both the synchronous cache probe and
+   the queued disk read. The async state pins that `ColumnFamilyDescriptor` while the worker uses its
+   native handle, then releases the pin before `signalExecuteCompleted()` because that signal may let
+   transaction/database teardown proceed (HarperFast/harper#1881). Keep the cold-read cross-column-
+   family coverage in `test/transactions.test.ts`; cache hits alone do not exercise the async path.
 
 ## Debugging native heap corruption
 

--- a/src/binding/database/database.h
+++ b/src/binding/database/database.h
@@ -364,16 +364,22 @@ struct AsyncGetState final : BaseAsyncState<T> {
 		napi_env env,
 		T handle,
 		rocksdb::ReadOptions& readOptions,
-		std::string key
+		std::string key,
+		std::shared_ptr<ColumnFamilyDescriptor> targetColumnDescriptor = nullptr
 	) :
 		BaseAsyncState<T>(env, handle),
 		readOptions(readOptions),
-		key(std::move(key)) {}
+		key(std::move(key)),
+		targetColumnDescriptor(std::move(targetColumnDescriptor)) {}
 
 	rocksdb::ReadOptions readOptions;
 	// the data for key and value both need to be owned by AsyncGetState, so we need to use std::string (RocksDB Slice doesn't preserve ownership)
 	std::string key;
 	std::string value;
+	// Pins a transaction read's resolved column family until the native worker
+	// finishes. It must be reset before signalling transaction completion, which
+	// may allow the database to close.
+	std::shared_ptr<ColumnFamilyDescriptor> targetColumnDescriptor;
 
 	// Verification table state for post-read check and populate.
 	bool hasExpectedVersion = false;

--- a/src/binding/transaction/transaction_handle.cpp
+++ b/src/binding/transaction/transaction_handle.cpp
@@ -364,7 +364,13 @@ napi_value TransactionHandle::get(
 	));
 
 	readOptions.read_tier = rocksdb::kReadAllTier;
-	auto state = new AsyncGetState<TransactionHandle*>(env, this, readOptions, std::move(key));
+	auto state = new AsyncGetState<TransactionHandle*>(
+		env,
+		this,
+		readOptions,
+		std::move(key),
+		dbHandle->columnDescriptor
+	);
 	state->vtSlot = vtSlot;
 	state->vtObserved = observedSlot;
 	state->hasExpectedVersion = hasExpectedVersion;
@@ -380,16 +386,19 @@ napi_value TransactionHandle::get(
 		[](napi_env doNotUse, void* data) { // execute
 			auto state = reinterpret_cast<AsyncGetState<TransactionHandle*>*>(data);
 			// check if database is still open before proceeding
-			if (!state->handle || !state->handle->dbHandle || !state->handle->dbHandle->opened() || state->handle->dbHandle->isCancelled()) {
+			if (!state->handle || !state->handle->dbHandle || !state->handle->dbHandle->opened() || state->handle->dbHandle->isCancelled() || !state->targetColumnDescriptor) {
 				state->status = rocksdb::Status::Aborted("Database closed during transaction get operation");
 			} else {
 				state->status = state->handle->txn->Get(
 					state->readOptions,
-					state->handle->dbHandle->getColumnFamilyHandle(),
+					state->targetColumnDescriptor->column.get(),
 					state->key,
 					&state->value
 				);
 			}
+			// Transaction completion can allow database teardown, so release the
+			// column-family pin before signalling that the worker is done.
+			state->targetColumnDescriptor.reset();
 			// signal that execute handler is complete
 			state->signalExecuteCompleted();
 		},

--- a/test/transactions.test.ts
+++ b/test/transactions.test.ts
@@ -184,6 +184,33 @@ for (const { name, options, txnOptions } of testOptions) {
 				}
 			));
 
+		it(`${name} async should read cold values across column families`, () =>
+			dbRunner(
+				{
+					dbOptions: [
+						{ ...options, noBlockCache: true },
+						{ ...options, name: 'foo', noBlockCache: true },
+					],
+				},
+				async ({ db }, { db: db2 }) => {
+					await db.put('shared-key', 'default-column-value');
+					await db2.put('shared-key', 'other-column-before');
+					await Promise.all([db.flush(), db2.flush()]);
+
+					await db.transaction(async (txn: Transaction) => {
+						await db.get('shared-key', { transaction: txn });
+						await db2.put('shared-key', 'other-column-after');
+						await db2.flush();
+
+						const value = db2.get('shared-key', { transaction: txn });
+						expect(value).toBeInstanceOf(Promise);
+						expect(await value).toBe(
+							txnOptions?.disableSnapshot ? 'other-column-after' : 'other-column-before'
+						);
+					}, txnOptions);
+				}
+			));
+
 		it(`${name} async should allow multiple transactions to run in parallel`, () =>
 			dbRunner(
 				{ dbOptions: [options, { ...options, path: generateDBPath() }] },


### PR DESCRIPTION
Fixes HarperFast/harper#1881 by carrying the caller-resolved column family into deferred transaction reads, preserving database-wide transaction and snapshot behavior for cold cross-table reads. Adds a regression covering optimistic and pessimistic modes with and without snapshots.

Reviewer attention: the async state pins the target column-family descriptor only through the worker read, then releases it before signaling transaction completion so database teardown cannot outlive the RocksDB handle. Cross-model coverage: codex ✓ / gemini ✓; no unresolved blockers or significant concerns.

Generated by GPT-5 Codex.