### PR TITLE
Forbid stores from being shared

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,8 @@ Creates a new database instance.
   - `statsLevel: StatsLevel` Controls which type of statistics to skip and reduce statistic
     overhead. Defaults to `StatsLevel.ExceptDetailedTimers`.
   - `store: Store` A custom store that handles all interaction between the `RocksDatabase` or
-    `Transaction` instances and the native database interface. See [Custom Store](#custom-store) for
+    `Transaction` instances and the native database interface. A store is bound to a single
+    `RocksDatabase` instance and cannot be shared between them. See [Custom Store](#custom-store) for
     more information.
   - `transactionLogMaxAgeThreshold: number` The threshold for the transaction log file's last
     modified time to be older than the retention period before it is rotated to the next sequence
@@ -1766,6 +1767,13 @@ const db = RocksDatabase.open(myStore);
 await db.put('foo', 'bar');
 console.log(await db.get('foo'));
 ```
+
+> [!NOTE]
+> A `Store` is bound to a single `RocksDatabase` instance. Passing a store that another
+> `RocksDatabase` already owns throws `Store is already in use by another RocksDatabase instance`.
+> The claim is durable across `db.close()`, so reopening the original owner does not release it.
+> (Sharing a store with the owning database's `Transaction` instances is expected and handled
+> internally.)
 
 > [!IMPORTANT]
 > If your custom store overrides `putSync()` without calling `super.putSync()` and it performs its

--- a/src/database.ts
+++ b/src/database.ts
@@ -86,13 +86,19 @@ export class RocksDatabase extends DBI<DBITransactional> {
 	#name: string;
 
 	constructor(pathOrStore: string | Store, options?: RocksDatabaseOptions) {
+		// A store is bound to a single RocksDatabase instance. Each database claims
+		// its store on construction; passing a store another database already owns
+		// throws (see Store#claim).
+		let store: Store;
 		if (typeof pathOrStore === 'string') {
-			super(new Store(pathOrStore, options));
+			store = new Store(pathOrStore, options);
 		} else if (pathOrStore instanceof Store) {
-			super(pathOrStore);
+			store = pathOrStore;
 		} else {
 			throw new TypeError('Invalid database path or store');
 		}
+		store.claim();
+		super(store);
 		this.#name = options?.name ?? 'default';
 	}
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -138,9 +138,20 @@ export type ArrayBufferWithNotify = ArrayBuffer & { cancel: () => void; notify: 
  * single database instance can be shared between the main `RocksDatabase`
  * instance and the `Transaction` instance.
  *
- * This store should not be shared between `RocksDatabase` instances.
+ * A store is bound to a single `RocksDatabase` instance and must not be shared
+ * between `RocksDatabase` instances. Each `RocksDatabase` claims its store on
+ * construction (see `claim()`); passing a store that another `RocksDatabase`
+ * already owns throws. (Sharing with the owning database's `Transaction`
+ * instances is expected and allowed.)
  */
 export class Store {
+	/**
+	 * Whether a `RocksDatabase` has claimed this store. Durable across
+	 * close/reopen (unlike the handle's open state), so a store reused after its
+	 * owner temporarily closed is still recognized as in-use. See `claim()`.
+	 */
+	#claimed: boolean = false;
+
 	/**
 	 * The database instance.
 	 */
@@ -393,6 +404,19 @@ export class Store {
 	 */
 	close(): void {
 		this.db.close();
+	}
+
+	/**
+	 * Claims this store for a `RocksDatabase`. A store is bound to a single
+	 * database instance, so claiming a store that another `RocksDatabase` has
+	 * already claimed throws. The claim is durable across close/reopen, so a
+	 * store reused after its owner temporarily closed still throws.
+	 */
+	claim(): void {
+		if (this.#claimed) {
+			throw new Error('Store is already in use by another RocksDatabase instance');
+		}
+		this.#claimed = true;
 	}
 
 	/**

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -1,6 +1,6 @@
 import { RocksDatabase } from '../src/index.js';
 import { Store, StoreContext, type StorePutOptions } from '../src/store.js';
-import { generateDBPath } from './lib/util.js';
+import { dbRunner, generateDBPath } from './lib/util.js';
 import { rm } from 'node:fs/promises';
 import type { Key } from 'ordered-binary';
 import { describe, expect, it } from 'vitest';
@@ -29,4 +29,13 @@ describe('Custom Store', () => {
 			await rm(dbPath, { force: true, recursive: true, maxRetries: 3 });
 		}
 	});
+
+	it("should use one instance's store for another database", () =>
+		dbRunner(async ({ db }) => {
+			await db.put('foo', 'bar');
+
+			const db2 = new RocksDatabase(db.store);
+			expect(db2.isOpen()).toBe(true);
+			expect(await db2.get('foo')).toBe('bar');
+		}));
 });

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -38,6 +38,9 @@ describe('Custom Store', () => {
 			expect(db2.isOpen()).toBe(true);
 			expect(await db2.get('foo')).toBe('bar');
 
+			await db2.put('foo', 'bar2');
+			expect(await db.get('foo')).toBe('bar2');
+
 			db.close();
 			expect(db2.isOpen()).toBe(false);
 		}));

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -30,12 +30,15 @@ describe('Custom Store', () => {
 		}
 	});
 
-	it("should use one instance's store for another database", () =>
+	it('should allow sharing the store between databases', () =>
 		dbRunner(async ({ db }) => {
 			await db.put('foo', 'bar');
 
 			const db2 = new RocksDatabase(db.store);
 			expect(db2.isOpen()).toBe(true);
 			expect(await db2.get('foo')).toBe('bar');
+
+			db.close();
+			expect(db2.isOpen()).toBe(false);
 		}));
 });

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -30,18 +30,21 @@ describe('Custom Store', () => {
 		}
 	});
 
-	it('should allow sharing the store between databases', () =>
+	it('should not allow a store to be used by another RocksDatabase instance', () =>
 		dbRunner(async ({ db }) => {
 			await db.put('foo', 'bar');
+			expect(() => new RocksDatabase(db.store)).toThrow(
+				'Store is already in use by another RocksDatabase instance'
+			);
+		}));
 
-			const db2 = new RocksDatabase(db.store);
-			expect(db2.isOpen()).toBe(true);
-			expect(await db2.get('foo')).toBe('bar');
-
-			await db2.put('foo', 'bar2');
-			expect(await db.get('foo')).toBe('bar2');
-
+	it('should reject a reused store even after its owner temporarily closed', () =>
+		dbRunner(async ({ db }) => {
+			// The claim is durable: closing the owner does not release the store.
 			db.close();
-			expect(db2.isOpen()).toBe(false);
+			expect(() => new RocksDatabase(db.store)).toThrow(
+				'Store is already in use by another RocksDatabase instance'
+			);
+			db.open();
 		}));
 });


### PR DESCRIPTION
While reviewing https://github.com/HarperFast/harper/pull/1888/changes#diff-4ff51263bd99981165fc179149c3195ea0c0ca3e2f360bafee2a6bb356964377R605, I realized it's technically possible to share stores between `RocksDatabase` instances. The store owns the native DB handle and sharing could lead to bugs. It's best to forbid stores from being shared.