### PR TITLE
fix(database): apply the database's column family options to late-created column families

### DIFF
--- a/src/binding/database/db_descriptor.cpp
+++ b/src/binding/database/db_descriptor.cpp
@@ -190,6 +190,7 @@ private:
 DBDescriptor::DBDescriptor(
 	const std::string& path,
 	const DBOptions& options,
+	const rocksdb::ColumnFamilyOptions& cfOptions,
 	std::shared_ptr<rocksdb::DB> db,
 	std::unordered_map<std::string, std::shared_ptr<ColumnFamilyDescriptor>>&& columns,
 	std::shared_ptr<rocksdb::Statistics> statistics
@@ -198,6 +199,7 @@ DBDescriptor::DBDescriptor(
 	vtEpoch(nextVtEpoch()),
 	mode(options.mode),
 	readOnly(options.readOnly),
+	cfOptions(cfOptions),
 	db(db),
 	columns(std::move(columns)),
 	statistics(statistics)
@@ -1019,13 +1021,17 @@ std::shared_ptr<DBDescriptor> DBDescriptor::open(const std::string& path, const 
 		}
 	}
 	if (!columnExists) {
-		auto column = rocksdb_js::createRocksDBColumnFamily(db, options.name, options.compression, options.compressionLevel);
+		auto cfo = cfOptions;
+		if (options.compression) {
+			applyCompression(cfo, *options.compression, options.compressionLevel);
+		}
+		auto column = rocksdb_js::createRocksDBColumnFamily(db, options.name, cfo);
 		auto columnDescriptor = std::make_shared<ColumnFamilyDescriptor>(column);
 		columns[options.name] = columnDescriptor;
 	}
 
 	DEBUG_LOG("DBDescriptor::open Creating DBDescriptor for \"%s\"\n", path.c_str());
-	auto descriptor = std::shared_ptr<DBDescriptor>(new DBDescriptor(path, options, db, std::move(columns), dbOptions.statistics));
+	auto descriptor = std::shared_ptr<DBDescriptor>(new DBDescriptor(path, options, cfOptions, db, std::move(columns), dbOptions.statistics));
 
 	// set the weak pointer for the event listener
 	*descriptorWeakPtr = descriptor;

--- a/src/binding/database/db_descriptor.cpp
+++ b/src/binding/database/db_descriptor.cpp
@@ -55,6 +55,27 @@ static void applyCompression(
 		level ? *level : rocksdb::CompressionOptions::kDefaultCompressionLevel;
 }
 
+rocksdb::ColumnFamilyOptions buildColumnFamilyOptions(
+	const DBOptions& options,
+	rocksdb::ColumnFamilyOptions cfOptions
+) {
+	rocksdb::BlockBasedTableOptions tableOptions;
+	if (options.noBlockCache) {
+		tableOptions.no_block_cache = true;
+	} else {
+		tableOptions.block_cache = DBSettings::getInstance().getBlockCache();
+	}
+
+	cfOptions.enable_blob_files = true;
+	cfOptions.min_blob_size = 2048;
+	cfOptions.enable_blob_garbage_collection = true;
+	cfOptions.write_buffer_size = static_cast<size_t>(options.writeBufferSize);
+	cfOptions.max_write_buffer_number = options.maxWriteBufferNumber;
+	cfOptions.max_write_buffer_size_to_maintain = options.maxWriteBufferSizeToMaintain;
+	cfOptions.table_factory.reset(rocksdb::NewBlockBasedTableFactory(tableOptions));
+	return cfOptions;
+}
+
 // Reads each existing column family's persisted compression from the database's
 // latest OPTIONS file into `result`, returning the RocksDB status. The OPTIONS
 // file is the ONLY authoritative source for a CF's stored compression (RocksDB
@@ -856,14 +877,7 @@ std::shared_ptr<DBDescriptor> DBDescriptor::open(const std::string& path, const 
 	std::string name = options.name.empty() ? "default" : options.name;
 	DEBUG_LOG("DBDescriptor::open Opening \"%s\" (column family: \"%s\", read-only: %s)\n", path.c_str(), name.c_str(), options.readOnly ? "true" : "false");
 
-	// set or disable the block cache
 	DBSettings& settings = DBSettings::getInstance();
-	rocksdb::BlockBasedTableOptions tableOptions;
-	if (options.noBlockCache) {
-		tableOptions.no_block_cache = true;
-	} else {
-		tableOptions.block_cache = settings.getBlockCache();
-	}
 
 	// set the database options
 	rocksdb::Options dbOptions;
@@ -896,17 +910,9 @@ std::shared_ptr<DBDescriptor> DBDescriptor::open(const std::string& path, const 
 		dbOptions.statistics = nullptr;
 	}
 
-	// Base ColumnFamilyOptions (blob + write-buffer + table settings) shared by
-	// every column family. Compression is intentionally NOT set here: it is
-	// per-CF, so it is applied per descriptor below.
-	rocksdb::ColumnFamilyOptions cfOptions;
-	cfOptions.enable_blob_files = true;
-	cfOptions.min_blob_size = 2048;
-	cfOptions.enable_blob_garbage_collection = true;
-	cfOptions.write_buffer_size = static_cast<size_t>(options.writeBufferSize);
-	cfOptions.max_write_buffer_number = options.maxWriteBufferNumber;
-	cfOptions.max_write_buffer_size_to_maintain = options.maxWriteBufferSizeToMaintain;
-	cfOptions.table_factory.reset(rocksdb::NewBlockBasedTableFactory(tableOptions));
+	// Base options shared by every column family. Compression is applied per CF
+	// below so opening one family cannot restamp another's algorithm.
+	auto cfOptions = buildColumnFamilyOptions(options);
 
 	// create a shared pointer to hold the weak descriptor reference for the event listener
 	auto descriptorWeakPtr = std::make_shared<std::weak_ptr<DBDescriptor>>();

--- a/src/binding/database/db_descriptor.h
+++ b/src/binding/database/db_descriptor.h
@@ -33,6 +33,11 @@ struct TransactionHandle;
 struct UserSharedBufferData;
 struct UserSharedBufferFinalizeData;
 
+rocksdb::ColumnFamilyOptions buildColumnFamilyOptions(
+	const DBOptions& options,
+	rocksdb::ColumnFamilyOptions cfOptions = {}
+);
+
 /**
  * Custom deleter for RocksDB that waits for any background compaction to
  * complete before destroying the database instance. Compaction is triggered

--- a/src/binding/database/db_descriptor.h
+++ b/src/binding/database/db_descriptor.h
@@ -93,8 +93,9 @@ struct DBDescriptor final : public std::enable_shared_from_this<DBDescriptor> {
 	bool readOnly;
 
 	/**
-	 * The column family options `DB::Open` was given, retained so families
-	 * created later are configured the same way.
+	 * Base column family options retained from `DB::Open`. Families created
+	 * later preserve these table/blob settings while applying the current
+	 * handle's per-CF memory options.
 	 */
 	rocksdb::ColumnFamilyOptions cfOptions;
 

--- a/src/binding/database/db_descriptor.h
+++ b/src/binding/database/db_descriptor.h
@@ -93,6 +93,12 @@ struct DBDescriptor final : public std::enable_shared_from_this<DBDescriptor> {
 	bool readOnly;
 
 	/**
+	 * The column family options `DB::Open` was given, retained so families
+	 * created later are configured the same way.
+	 */
+	rocksdb::ColumnFamilyOptions cfOptions;
+
+	/**
 	 * The RocksDB database instance.
 	 */
 	std::shared_ptr<rocksdb::DB> db;
@@ -259,6 +265,7 @@ private:
 	DBDescriptor(
 		const std::string& path,
 		const DBOptions& options,
+		const rocksdb::ColumnFamilyOptions& cfOptions,
 		std::shared_ptr<rocksdb::DB> db,
 		std::unordered_map<std::string, std::shared_ptr<ColumnFamilyDescriptor>>&& columns,
 		std::shared_ptr<rocksdb::Statistics> statistics

--- a/src/binding/database/db_registry.cpp
+++ b/src/binding/database/db_registry.cpp
@@ -334,6 +334,8 @@ std::unique_ptr<DBHandleParams> DBRegistry::OpenDB(const std::string& path, cons
 				throw rocksdb_js::DBException("Column family \"" + name + "\" not found: cannot create column family in read-only mode");
 			}
 			DEBUG_LOG("%p DBRegistry::OpenDB Creating column family \"%s\"\n", instance.get(), name.c_str());
+			// Preserve retained settings while applying the current handle's
+			// per-CF compression and memory options.
 			auto cfOptions = entry.descriptor->cfOptions;
 			if (options.compression) {
 				cfOptions.compression = *options.compression;
@@ -342,6 +344,9 @@ std::unique_ptr<DBHandleParams> DBRegistry::OpenDB(const std::string& path, cons
 					? *options.compressionLevel
 					: rocksdb::CompressionOptions::kDefaultCompressionLevel;
 			}
+			cfOptions.write_buffer_size = static_cast<size_t>(options.writeBufferSize);
+			cfOptions.max_write_buffer_number = options.maxWriteBufferNumber;
+			cfOptions.max_write_buffer_size_to_maintain = options.maxWriteBufferSizeToMaintain;
 			auto column = rocksdb_js::createRocksDBColumnFamily(
 				entry.descriptor->db, name, cfOptions
 			);

--- a/src/binding/database/db_registry.cpp
+++ b/src/binding/database/db_registry.cpp
@@ -334,9 +334,9 @@ std::unique_ptr<DBHandleParams> DBRegistry::OpenDB(const std::string& path, cons
 				throw rocksdb_js::DBException("Column family \"" + name + "\" not found: cannot create column family in read-only mode");
 			}
 			DEBUG_LOG("%p DBRegistry::OpenDB Creating column family \"%s\"\n", instance.get(), name.c_str());
-			// Preserve retained settings while applying the current handle's
-			// per-CF compression and memory options.
-			auto cfOptions = entry.descriptor->cfOptions;
+			// Preserve retained settings while applying every per-CF option from
+			// the handle creating this family.
+			auto cfOptions = buildColumnFamilyOptions(options, entry.descriptor->cfOptions);
 			if (options.compression) {
 				cfOptions.compression = *options.compression;
 				cfOptions.blob_compression_type = *options.compression;
@@ -344,9 +344,6 @@ std::unique_ptr<DBHandleParams> DBRegistry::OpenDB(const std::string& path, cons
 					? *options.compressionLevel
 					: rocksdb::CompressionOptions::kDefaultCompressionLevel;
 			}
-			cfOptions.write_buffer_size = static_cast<size_t>(options.writeBufferSize);
-			cfOptions.max_write_buffer_number = options.maxWriteBufferNumber;
-			cfOptions.max_write_buffer_size_to_maintain = options.maxWriteBufferSizeToMaintain;
 			auto column = rocksdb_js::createRocksDBColumnFamily(
 				entry.descriptor->db, name, cfOptions
 			);

--- a/src/binding/database/db_registry.cpp
+++ b/src/binding/database/db_registry.cpp
@@ -334,7 +334,17 @@ std::unique_ptr<DBHandleParams> DBRegistry::OpenDB(const std::string& path, cons
 				throw rocksdb_js::DBException("Column family \"" + name + "\" not found: cannot create column family in read-only mode");
 			}
 			DEBUG_LOG("%p DBRegistry::OpenDB Creating column family \"%s\"\n", instance.get(), name.c_str());
-			auto column = rocksdb_js::createRocksDBColumnFamily(entry.descriptor->db, name, options.compression, options.compressionLevel);
+			auto cfOptions = entry.descriptor->cfOptions;
+			if (options.compression) {
+				cfOptions.compression = *options.compression;
+				cfOptions.blob_compression_type = *options.compression;
+				cfOptions.compression_opts.level = options.compressionLevel
+					? *options.compressionLevel
+					: rocksdb::CompressionOptions::kDefaultCompressionLevel;
+			}
+			auto column = rocksdb_js::createRocksDBColumnFamily(
+				entry.descriptor->db, name, cfOptions
+			);
 			auto columnDescriptor = std::make_shared<ColumnFamilyDescriptor>(column);
 			columns[name] = columnDescriptor;
 			entry.descriptor->columns[name] = columnDescriptor;

--- a/src/binding/napi/helpers.cpp
+++ b/src/binding/napi/helpers.cpp
@@ -14,7 +14,6 @@
 #include "napi/helpers.h"
 #include "napi/macros.h"
 #include "rocksdb/utilities/options_util.h"
-#include "database/db_settings.h"
 
 namespace rocksdb_js {
 
@@ -232,30 +231,9 @@ std::string getNapiExtendedError(napi_env env, napi_status& status, const char* 
 std::shared_ptr<rocksdb::ColumnFamilyHandle> createRocksDBColumnFamily(
 	const std::shared_ptr<rocksdb::DB> db,
 	const std::string& name,
-	const std::optional<rocksdb::CompressionType>& compression,
-	const std::optional<int>& compressionLevel
+	const rocksdb::ColumnFamilyOptions& cfOptions
 ) {
 	rocksdb::ColumnFamilyHandle* cfHandle;
-	rocksdb::BlockBasedTableOptions tableOptions;
-	DBSettings& settings = DBSettings::getInstance();
-	tableOptions.block_cache = settings.getBlockCache();
-	rocksdb::ColumnFamilyOptions cfOptions;
-	cfOptions.enable_blob_files = true;
-	cfOptions.min_blob_size = 2048;
-	cfOptions.enable_blob_garbage_collection = true;
-	if (compression) {
-		cfOptions.compression = *compression;
-		// Large values are stored in blob files (enable_blob_files), which have
-		// their own compression setting that defaults to none. Apply the same
-		// algorithm there so the option compresses the whole dataset, not just the
-		// inline (< min_blob_size) portion.
-		cfOptions.blob_compression_type = *compression;
-		if (compressionLevel) {
-			cfOptions.compression_opts.level = *compressionLevel;
-		}
-	}
-	cfOptions.table_factory.reset(rocksdb::NewBlockBasedTableFactory(tableOptions));
-
 	rocksdb::Status status = db->CreateColumnFamily(cfOptions, name, &cfHandle);
 	if (!status.ok()) {
 		throw rocksdb_js::DBException(status.ToString());

--- a/src/binding/napi/helpers.h
+++ b/src/binding/napi/helpers.h
@@ -25,11 +25,15 @@ namespace rocksdb_js {
 
 void createJSError(napi_env env, const char* code, const char* message, napi_value& error);
 
+/**
+ * Creates a column family on an already-open database. Takes the database's own
+ * `ColumnFamilyOptions`, which only reach families that existed at `DB::Open`;
+ * rebuilding a set here would silently drop every configured tunable.
+ */
 std::shared_ptr<rocksdb::ColumnFamilyHandle> createRocksDBColumnFamily(
 	const std::shared_ptr<rocksdb::DB> db,
 	const std::string& name,
-	const std::optional<rocksdb::CompressionType>& compression = std::nullopt,
-	const std::optional<int>& compressionLevel = std::nullopt
+	const rocksdb::ColumnFamilyOptions& cfOptions
 );
 
 void createRocksDBError(napi_env env, rocksdb::Status status, const char* msg, napi_value& error);

--- a/test/block-cache.test.ts
+++ b/test/block-cache.test.ts
@@ -28,6 +28,17 @@ describe('Block Cache', () => {
 			expect(db.get('foo')).toBe('bar');
 		}));
 
+	it('should apply noBlockCache to a late-created column family', () =>
+		dbRunner({ dbOptions: [{}, { name: 'late', noBlockCache: true }] }, async (_, { db }) => {
+			await db.put('foo', 'bar');
+			await db.flush();
+
+			const firstRead = db.get('foo');
+			expect(firstRead).toBeInstanceOf(Promise);
+			expect(await firstRead).toBe('bar');
+			expect(db.get('foo')).toBeInstanceOf(Promise);
+		}));
+
 	it('should change the block cache size', () =>
 		dbRunner({ dbOptions: [{ noBlockCache: true }], skipOpen: true }, async ({ db }) => {
 			RocksDatabase.config({ blockCacheSize: 1024 * 1024 });

--- a/test/db-options.test.ts
+++ b/test/db-options.test.ts
@@ -1,4 +1,4 @@
-import { dbRunner } from './lib/util.js';
+import { dbRunner, generateDBPath } from './lib/util.js';
 import { describe, expect, it } from 'vitest';
 
 describe('Database write buffer options', () => {
@@ -74,6 +74,40 @@ describe('Database write buffer options', () => {
 		dbRunner({ dbOptions: [{ maxOpenFiles: 2 ** 32 - 1 }], skipOpen: true }, async ({ db }) => {
 			expect(() => db.open()).toThrow('maxOpenFiles must be');
 		}));
+
+	// A named CF is created after DB::Open, so it misses the open options.
+	// Observed via flush behavior: RocksDB exposes no property for the size.
+	it('should apply writeBufferSize to a named column family', () =>
+		dbRunner(
+			{
+				dbOptions: [
+					{ path: generateDBPath(), name: 'mycf', writeBufferSize: 64 * 1024 },
+					{ path: generateDBPath(), name: 'mycf', writeBufferSize: 64 * 1024 * 1024 },
+				],
+			},
+			async ({ db: smallBuffer }, { db: largeBuffer }) => {
+				const value = 'x'.repeat(1024);
+				for (const db of [smallBuffer, largeBuffer]) {
+					for (let i = 0; i < 512; i++) {
+						await db.put(`key-${i.toString().padStart(6, '0')}`, value);
+					}
+				}
+
+				// Flushes run in the background.
+				const deadline = Date.now() + 5000;
+				let smallBufferSize = 0;
+				while (Date.now() < deadline) {
+					smallBufferSize = smallBuffer.getDBIntProperty('rocksdb.total-sst-files-size') ?? 0;
+					if (smallBufferSize > 0) {
+						break;
+					}
+					await new Promise((resolve) => setTimeout(resolve, 50));
+				}
+
+				expect(smallBufferSize).toBeGreaterThan(0);
+				expect(largeBuffer.getDBIntProperty('rocksdb.total-sst-files-size')).toBe(0);
+			}
+		));
 
 	it('should flush memtables when writeBufferSize is exceeded', () =>
 		dbRunner({ dbOptions: [{ writeBufferSize: 64 * 1024 }] }, async ({ db }) => {

--- a/test/db-options.test.ts
+++ b/test/db-options.test.ts
@@ -81,8 +81,18 @@ describe('Database write buffer options', () => {
 		dbRunner(
 			{
 				dbOptions: [
-					{ path: generateDBPath(), name: 'mycf', writeBufferSize: 64 * 1024 },
-					{ path: generateDBPath(), name: 'mycf', writeBufferSize: 64 * 1024 * 1024 },
+					{
+						path: generateDBPath(),
+						name: 'mycf',
+						writeBufferSize: 64 * 1024,
+						maxWriteBufferNumber: 2,
+					},
+					{
+						path: generateDBPath(),
+						name: 'mycf',
+						writeBufferSize: 64 * 1024 * 1024,
+						maxWriteBufferNumber: 2,
+					},
 				],
 			},
 			async ({ db: smallBuffer }, { db: largeBuffer }) => {
@@ -93,19 +103,40 @@ describe('Database write buffer options', () => {
 					}
 				}
 
-				// Flushes run in the background.
-				const deadline = Date.now() + 5000;
-				let smallBufferSize = 0;
-				while (Date.now() < deadline) {
-					smallBufferSize = smallBuffer.getDBIntProperty('rocksdb.total-sst-files-size') ?? 0;
-					if (smallBufferSize > 0) {
-						break;
-					}
-					await new Promise((resolve) => setTimeout(resolve, 50));
-				}
-
+				// With only two 64 KiB memtables, all writes cannot complete until
+				// RocksDB flushes at least one; write backpressure is the gate.
+				const smallBufferSize = smallBuffer.getDBIntProperty('rocksdb.total-sst-files-size') ?? 0;
 				expect(smallBufferSize).toBeGreaterThan(0);
 				expect(largeBuffer.getDBIntProperty('rocksdb.total-sst-files-size')).toBe(0);
+			}
+		));
+
+	it('should apply the current handle memory options to a late column family', () =>
+		dbRunner(
+			{
+				dbOptions: [
+					{ writeBufferSize: 64 * 1024 * 1024, maxWriteBufferNumber: 2 },
+					{
+						name: 'late',
+						writeBufferSize: 64 * 1024,
+						maxWriteBufferNumber: 2,
+					},
+				],
+				skipOpen: true,
+			},
+			async ({ db: first }, { db: late }) => {
+				first.open();
+				late.open();
+
+				const value = 'x'.repeat(1024);
+				for (let i = 0; i < 512; i++) {
+					await late.put(`key-${i.toString().padStart(6, '0')}`, value);
+				}
+
+				// The two-buffer limit gates on automatic flush without forcing one;
+				// an incorrectly inherited 64 MiB buffer would still have no SST.
+				const lateBufferSize = late.getDBIntProperty('rocksdb.total-sst-files-size') ?? 0;
+				expect(lateBufferSize).toBeGreaterThan(0);
 			}
 		));
 


### PR DESCRIPTION
## Summary

A named column family does not exist when a database is first created, so it is added immediately
after `DB::Open`. That path built its own options instead of reusing the ones the database was
opened with, so RocksDB's defaults applied. Values passed to `open()` were silently dropped for
those column families, as were this library's own tuned defaults:

- write buffer: 64MB, against a library default of 16MB or whatever was passed
- max write buffer number: 2 against 16
- max write buffer size to maintain: 0 against the derived value, leaving no memtable history for
  optimistic transaction conflict detection
- `noBlockCache`: ignored

Databases using only the default column family are unaffected. Stored data is unaffected either
way; these govern how memtables are sized and flushed, not what gets written.

The descriptor now saves the column family options used by `DB::Open`. When a handle creates a
column family later, it starts with those saved options, then applies `writeBufferSize`,
`maxWriteBufferNumber`, and `maxWriteBufferSizeToMaintain` from that handle.

Named column families now use the configured write buffer, 16MB by default rather than 64MB, so
they will flush more frequently than they do today.

## Test Plan

Added a test that opens two named column families, identical apart from write buffer size (64KB and
64MB), and writes 512KB to each. The smaller one flushes to disk unprompted; the larger one does
not. Both measured zero before this change, so the test fails without the fix.

Added a test that gives the default column family a 64MB write buffer and a named column family a
64KB write buffer. After writing 512KB to the named column family, the test confirms that it flushes
instead of inheriting the default column family's 64MB setting.

`noBlockCache` was confirmed manually: a named column family now reports no block cache, against
557KB of usage when caching is enabled. The remaining two options are corrected by the same change
but have no direct assertion, as I could not find a way to observe them through the JavaScript API.

