### PR TITLE
feat(database): add opt-in SST block compression

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,13 @@ Creates a new database instance.
 - `path: string` The path to write the database files to. This path does not need to exist, but the
   parent directories do.
 - `options: object` [optional]
+  - `compression: boolean | string` Enables SST block compression for newly written table files.
+    `true` selects `'zlib'`, the only algorithm the published prebuilt links (and slower per
+    write than `lz4`/`snappy`, so benchmark write-heavy databases); `false` means none. Omitting
+    it leaves whatever your RocksDB build defaults to, which is none in the published prebuilt but
+    is snappy in a build that links it. Naming another algorithm (`'snappy'`, `'lz4'`, `'lz4hc'`,
+    `'zstd'`, `'bzip2'`, `'none'`) throws unless your build links it. Applies database-wide and is fixed by the first `open()` of a
+    path, since every handle on a path shares one RocksDB instance.
   - `disableWAL: boolean` Whether to disable the RocksDB write ahead log. Defaults to `false`.
   - `enableStats: boolean` When `true` and the database is open, RocksDB will captures stats that
     are retrieved by calling `db.getStats()`. Enabling statistics imposes 5-10% in overhead.

--- a/README.md
+++ b/README.md
@@ -44,12 +44,14 @@ Creates a new database instance.
   parent directories do.
 - `options: object` [optional]
   - `compression: boolean | string` Enables SST block compression for newly written table files.
-    `true` selects `'zlib'`, the only algorithm the published prebuilt links (and slower per
-    write than `lz4`/`snappy`, so benchmark write-heavy databases); `false` means none. Omitting
-    it leaves whatever your RocksDB build defaults to, which is none in the published prebuilt but
-    is snappy in a build that links it. Naming another algorithm (`'snappy'`, `'lz4'`, `'lz4hc'`,
-    `'zstd'`, `'bzip2'`, `'none'`) throws unless your build links it. Applies database-wide and is fixed by the first `open()` of a
-    path; a later handle may omit it, but a conflicting value throws.
+    Values whose uncompressed size is 2,048 bytes or greater are stored in blob files, which remain
+    uncompressed; this option does not affect them. `true` selects `'zlib'`, the only algorithm the
+    published prebuilt links (and slower per write than `lz4`/`snappy`, so benchmark write-heavy
+    databases); `false` means none. Omitting it leaves whatever your RocksDB build defaults to, which
+    is none in the published prebuilt but is snappy in a build that links it. Naming another
+    algorithm (`'snappy'`, `'lz4'`, `'lz4hc'`, `'zstd'`, `'bzip2'`, `'none'`) throws unless your build
+    links it. Applies database-wide and is fixed by the first `open()` of a path; a later handle may
+    omit it, but a conflicting value throws.
   - `disableWAL: boolean` Whether to disable the RocksDB write ahead log. Defaults to `false`.
   - `enableStats: boolean` When `true` and the database is open, RocksDB will captures stats that
     are retrieved by calling `db.getStats()`. Enabling statistics imposes 5-10% in overhead.

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Creates a new database instance.
     it leaves whatever your RocksDB build defaults to, which is none in the published prebuilt but
     is snappy in a build that links it. Naming another algorithm (`'snappy'`, `'lz4'`, `'lz4hc'`,
     `'zstd'`, `'bzip2'`, `'none'`) throws unless your build links it. Applies database-wide and is fixed by the first `open()` of a
-    path, since every handle on a path shares one RocksDB instance.
+    path; a later handle may omit it, but a conflicting value throws.
   - `disableWAL: boolean` Whether to disable the RocksDB write ahead log. Defaults to `false`.
   - `enableStats: boolean` When `true` and the database is open, RocksDB will captures stats that
     are retrieved by calling `db.getStats()`. Enabling statistics imposes 5-10% in overhead.

--- a/binding.gyp
+++ b/binding.gyp
@@ -40,6 +40,7 @@
 			],
 			'sources': [
 				'src/binding/binding.cpp',
+				'src/binding/core/compression.cpp',
 				'src/binding/core/debug.cpp',
 				'src/binding/core/platform.cpp',
 				'src/binding/core/file_lock.cpp',
@@ -209,6 +210,7 @@
 				'deps/googletest/googlemock/include',
 			],
 			'sources': [
+				'src/binding/core/compression.cpp',
 				'src/binding/core/debug.cpp',
 				'src/binding/core/platform.cpp',
 				'src/binding/core/file_lock.cpp',
@@ -220,6 +222,7 @@
 				'test/native/event_emitter_stub.cc',
 				'test/native/rocksdb_version_test.cc',
 				'test/native/backup_disk_space_test.cc',
+				'test/native/compression_test.cc',
 				'test/native/encoding_test.cc',
 				'test/native/file_lock_test.cc',
 				'test/native/json_test.cc',

--- a/binding.gyp
+++ b/binding.gyp
@@ -4,7 +4,10 @@
 	# do not reliably override a target-scoped default under node-gyp's make
 	# generator, so an explicit env read is used instead. Enable with:
 	#   ROCKSDB_ASAN=1 node-gyp rebuild
-	'variables': { "rocksdb_asan%": "<!(node -p \"process.env.ROCKSDB_ASAN==='1'?1:0\")" },
+	'variables': {
+		"rocksdb_asan%": "<!(node -p \"process.env.ROCKSDB_ASAN==='1'?1:0\")",
+		"rocksdb_from_source%": "<!(node -p \"process.env.ROCKSDB_PATH?1:0\")",
+	},
 	# Node 26's Windows headers (common.gypi) inject Clang ThinLTO options
 	# (-flto=thin and /opt:lldltojobs=N) into every Release target. The official
 	# Node Windows build is now compiled with ClangCL + ThinLTO, but this addon
@@ -113,18 +116,23 @@
 					'cflags_cc+': ['-fexceptions'],
 					'link_settings': {
 						'libraries': [
-							'<(module_root_dir)/deps/rocksdb/lib/librocksdb.a',
-							# librocksdb.a references zlib (BuiltinZlibCompressor) but does not
-							# bundle it; link the zlib static lib shipped alongside it in the
-							# RocksDB prebuild so the compressor object resolves when the linker
-							# pulls it in. Must come after librocksdb.a (GNU ld is order-sensitive).
-							'<(module_root_dir)/deps/rocksdb/lib/libz.a'
+							'<(module_root_dir)/deps/rocksdb/lib/librocksdb.a'
 						]
 					},
 					'xcode_settings': {
 						'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
 						'MACOSX_DEPLOYMENT_TARGET': '26.0',
 						'CLANG_CXX_LANGUAGE_STANDARD': 'c++20',
+					}
+				}],
+				['(OS=="linux" or OS=="mac") and rocksdb_from_source==0', {
+					'link_settings': {
+						'libraries': [
+							# The downloaded prebuild's librocksdb.a references zlib but does
+							# not bundle it. ROCKSDB_PATH builds supply their own dependency
+							# linkage and must not be forced to provide this prebuild-only file.
+							'<(module_root_dir)/deps/rocksdb/lib/libz.a'
+						]
 					}
 				}],
 				# AddressSanitizer instrumentation for diagnosing heap corruption
@@ -274,18 +282,23 @@
 					'cflags_cc+': ['-fexceptions'],
 					'link_settings': {
 						'libraries': [
-							'<(module_root_dir)/deps/rocksdb/lib/librocksdb.a',
-							# librocksdb.a references zlib (BuiltinZlibCompressor) but does not
-							# bundle it; link the zlib static lib shipped alongside it in the
-							# RocksDB prebuild so the compressor object resolves when the linker
-							# pulls it in. Must come after librocksdb.a (GNU ld is order-sensitive).
-							'<(module_root_dir)/deps/rocksdb/lib/libz.a'
+							'<(module_root_dir)/deps/rocksdb/lib/librocksdb.a'
 						]
 					},
 					'xcode_settings': {
 						'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
 						'MACOSX_DEPLOYMENT_TARGET': '26.0',
 						'CLANG_CXX_LANGUAGE_STANDARD': 'c++20',
+					}
+				}],
+				['(OS=="linux" or OS=="mac") and rocksdb_from_source==0', {
+					'link_settings': {
+						'libraries': [
+							# The downloaded prebuild's librocksdb.a references zlib but does
+							# not bundle it. ROCKSDB_PATH builds supply their own dependency
+							# linkage and must not be forced to provide this prebuild-only file.
+							'<(module_root_dir)/deps/rocksdb/lib/libz.a'
+						]
 					}
 				}],
 				# ASan for the standalone (no-Node) GoogleTest binary. Unlike the

--- a/scripts/test-binding.mjs
+++ b/scripts/test-binding.mjs
@@ -1,5 +1,20 @@
-import { versions } from '../dist/index.mjs';
+import { RocksDatabase, versions } from '../dist/index.mjs';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+// Published bindings promise that the boolean shorthand selects zlib. Keep
+// that packaging guarantee here rather than in the generic native suite,
+// where a custom ROCKSDB_PATH build may legitimately omit zlib.
+const tempDir = await mkdtemp(join(tmpdir(), 'rocksdb-js-binding-'));
+const db = new RocksDatabase(join(tempDir, 'db'), { compression: true });
+try {
+	db.open();
+} finally {
+	db.close();
+	await rm(tempDir, { force: true, recursive: true, maxRetries: 3, retryDelay: 500 });
+}
 
 console.log(
-	`rocksdb-js v${versions['rocksdb-js']} (RocksDB v${versions.rocksdb}) loaded successfully!`
+	`rocksdb-js v${versions['rocksdb-js']} (RocksDB v${versions.rocksdb}) loaded successfully with zlib compression!`
 );

--- a/src/binding/core/compression.cpp
+++ b/src/binding/core/compression.cpp
@@ -1,0 +1,79 @@
+#include "core/compression.h"
+#include "rocksdb/convenience.h"
+#include <algorithm>
+#include <vector>
+
+namespace rocksdb_js {
+
+namespace {
+
+struct CompressionName final {
+	const char* name;
+	rocksdb::CompressionType type;
+};
+
+// The names the binding accepts; the TS `RocksDBCompression` union mirrors it.
+constexpr CompressionName kCompressionNames[] = {
+	{"none", rocksdb::kNoCompression},
+	{"snappy", rocksdb::kSnappyCompression},
+	{"zlib", rocksdb::kZlibCompression},
+	{"bzip2", rocksdb::kBZip2Compression},
+	{"lz4", rocksdb::kLZ4Compression},
+	{"lz4hc", rocksdb::kLZ4HCCompression},
+	{"zstd", rocksdb::kZSTD},
+};
+
+bool isLinkedIn(rocksdb::CompressionType type) {
+	// GetSupportedCompressions() does not report kNoCompression.
+	if (type == rocksdb::kNoCompression) {
+		return true;
+	}
+	static const std::vector<rocksdb::CompressionType> supported = rocksdb::GetSupportedCompressions();
+	return std::find(supported.begin(), supported.end(), type) != supported.end();
+}
+
+} // namespace
+
+bool tryResolveCompressionType(
+	const std::string& name,
+	rocksdb::CompressionType& type,
+	std::string& error
+) {
+	const CompressionName* match = nullptr;
+	for (const auto& entry : kCompressionNames) {
+		if (name == entry.name) {
+			match = &entry;
+			break;
+		}
+	}
+
+	if (match == nullptr) {
+		error = "Unknown compression type: \"" + name + "\". Available in this build: " + supportedCompressionNames();
+		return false;
+	}
+
+	if (!isLinkedIn(match->type)) {
+		error = "Compression type \"" + name +
+			"\" is not supported by this RocksDB build. Available in this build: " + supportedCompressionNames();
+		return false;
+	}
+
+	type = match->type;
+	return true;
+}
+
+std::string supportedCompressionNames() {
+	std::string result;
+	for (const auto& entry : kCompressionNames) {
+		if (!isLinkedIn(entry.type)) {
+			continue;
+		}
+		if (!result.empty()) {
+			result += ", ";
+		}
+		result += entry.name;
+	}
+	return result;
+}
+
+} // namespace rocksdb_js

--- a/src/binding/core/compression.h
+++ b/src/binding/core/compression.h
@@ -1,0 +1,25 @@
+#ifndef __CORE_COMPRESSION_H__
+#define __CORE_COMPRESSION_H__
+
+#include "rocksdb/options.h"
+#include <string>
+
+namespace rocksdb_js {
+
+/**
+ * Maps a lowercase algorithm name to its `CompressionType`. Returns false with
+ * `error` set if the name is unknown or its compressor was not linked in.
+ * RocksDB degrades silently in that case, so it has to be caught here.
+ */
+bool tryResolveCompressionType(
+	const std::string& name,
+	rocksdb::CompressionType& type,
+	std::string& error
+);
+
+/** Comma-separated names usable in this build, for error messages. */
+std::string supportedCompressionNames();
+
+} // namespace rocksdb_js
+
+#endif

--- a/src/binding/database/database.cpp
+++ b/src/binding/database/database.cpp
@@ -1,6 +1,7 @@
 #include <node_api.h>
 #include <algorithm>
 #include <cmath>
+#include <optional>
 #include <sstream>
 #include "database/database.h"
 #include "database/db_handle.h"
@@ -1403,18 +1404,21 @@ napi_value Database::Open(napi_env env, napi_callback_info info) {
 	}
 
 	NAPI_STATUS_THROWS(rocksdb_js::getProperty(env, options, "name", dbHandleOptions.name));
-	NAPI_STATUS_THROWS(rocksdb_js::getProperty(env, options, "compression", dbHandleOptions.compression));
+	std::optional<std::string> compression;
+	NAPI_STATUS_THROWS(rocksdb_js::getProperty(env, options, "compression", compression));
 	// Validated here, not in DBDescriptor::open: an open that reuses an
-	// already-open path never reaches it.
-	if (!dbHandleOptions.compression.empty()) {
+	// already-open path never reaches it. Preserve property presence so an
+	// explicit empty string is rejected rather than treated as omission.
+	if (compression.has_value()) {
 		rocksdb::CompressionType compressionType;
 		std::string compressionError;
 		if (!rocksdb_js::tryResolveCompressionType(
-			dbHandleOptions.compression, compressionType, compressionError
+			*compression, compressionType, compressionError
 		)) {
 			::napi_throw_error(env, nullptr, compressionError.c_str());
 			return nullptr;
 		}
+		dbHandleOptions.compression = *compression;
 	}
 	NAPI_STATUS_THROWS(rocksdb_js::getProperty(env, options, "noBlockCache", dbHandleOptions.noBlockCache));
 	NAPI_STATUS_THROWS(rocksdb_js::getProperty(env, options, "readOnly", dbHandleOptions.readOnly));

--- a/src/binding/database/database.cpp
+++ b/src/binding/database/database.cpp
@@ -11,6 +11,7 @@
 #include "napi/macros.h"
 #include "transaction/transaction.h"
 #include "transaction/transaction_handle.h"
+#include "core/compression.h"
 #include "core/platform.h"
 #include "napi/helpers.h"
 #include "napi/async.h"
@@ -1402,6 +1403,19 @@ napi_value Database::Open(napi_env env, napi_callback_info info) {
 	}
 
 	NAPI_STATUS_THROWS(rocksdb_js::getProperty(env, options, "name", dbHandleOptions.name));
+	NAPI_STATUS_THROWS(rocksdb_js::getProperty(env, options, "compression", dbHandleOptions.compression));
+	// Validated here, not in DBDescriptor::open: an open that reuses an
+	// already-open path never reaches it.
+	if (!dbHandleOptions.compression.empty()) {
+		rocksdb::CompressionType compressionType;
+		std::string compressionError;
+		if (!rocksdb_js::tryResolveCompressionType(
+			dbHandleOptions.compression, compressionType, compressionError
+		)) {
+			::napi_throw_error(env, nullptr, compressionError.c_str());
+			return nullptr;
+		}
+	}
 	NAPI_STATUS_THROWS(rocksdb_js::getProperty(env, options, "noBlockCache", dbHandleOptions.noBlockCache));
 	NAPI_STATUS_THROWS(rocksdb_js::getProperty(env, options, "readOnly", dbHandleOptions.readOnly));
 	NAPI_STATUS_THROWS(rocksdb_js::getProperty(env, options, "parallelismThreads", dbHandleOptions.parallelismThreads));

--- a/src/binding/database/db_descriptor.cpp
+++ b/src/binding/database/db_descriptor.cpp
@@ -123,6 +123,7 @@ private:
 DBDescriptor::DBDescriptor(
 	const std::string& path,
 	const DBOptions& options,
+	const rocksdb::ColumnFamilyOptions& cfOptions,
 	std::shared_ptr<rocksdb::DB> db,
 	std::unordered_map<std::string, std::shared_ptr<ColumnFamilyDescriptor>>&& columns,
 	std::shared_ptr<rocksdb::Statistics> statistics
@@ -131,6 +132,7 @@ DBDescriptor::DBDescriptor(
 	vtEpoch(nextVtEpoch()),
 	mode(options.mode),
 	readOnly(options.readOnly),
+	cfOptions(cfOptions),
 	db(db),
 	columns(std::move(columns)),
 	statistics(statistics)
@@ -918,13 +920,13 @@ std::shared_ptr<DBDescriptor> DBDescriptor::open(const std::string& path, const 
 		}
 	}
 	if (!columnExists) {
-		auto column = rocksdb_js::createRocksDBColumnFamily(db, options.name);
+		auto column = rocksdb_js::createRocksDBColumnFamily(db, options.name, cfOptions);
 		auto columnDescriptor = std::make_shared<ColumnFamilyDescriptor>(column);
 		columns[options.name] = columnDescriptor;
 	}
 
 	DEBUG_LOG("DBDescriptor::open Creating DBDescriptor for \"%s\"\n", path.c_str());
-	auto descriptor = std::shared_ptr<DBDescriptor>(new DBDescriptor(path, options, db, std::move(columns), dbOptions.statistics));
+	auto descriptor = std::shared_ptr<DBDescriptor>(new DBDescriptor(path, options, cfOptions, db, std::move(columns), dbOptions.statistics));
 
 	// set the weak pointer for the event listener
 	*descriptorWeakPtr = descriptor;

--- a/src/binding/database/db_descriptor.cpp
+++ b/src/binding/database/db_descriptor.cpp
@@ -1,3 +1,4 @@
+#include "core/compression.h"
 #include "core/platform.h"
 #include "database/db_descriptor.h"
 #include "database/db_settings.h"
@@ -837,6 +838,13 @@ std::shared_ptr<DBDescriptor> DBDescriptor::open(const std::string& path, const 
 	cfOptions.write_buffer_size = static_cast<size_t>(options.writeBufferSize);
 	cfOptions.max_write_buffer_number = options.maxWriteBufferNumber;
 	cfOptions.max_write_buffer_size_to_maintain = options.maxWriteBufferSizeToMaintain;
+	// Applies to every column family opened below, not just `options.name`.
+	if (!options.compression.empty()) {
+		std::string error;
+		if (!tryResolveCompressionType(options.compression, cfOptions.compression, error)) {
+			throw rocksdb_js::DBException(error);
+		}
+	}
 	cfOptions.table_factory.reset(rocksdb::NewBlockBasedTableFactory(tableOptions));
 
 	// create a shared pointer to hold the weak descriptor reference for the event listener

--- a/src/binding/database/db_descriptor.cpp
+++ b/src/binding/database/db_descriptor.cpp
@@ -133,6 +133,7 @@ DBDescriptor::DBDescriptor(
 	vtEpoch(nextVtEpoch()),
 	mode(options.mode),
 	readOnly(options.readOnly),
+	compression(options.compression),
 	cfOptions(cfOptions),
 	db(db),
 	columns(std::move(columns)),

--- a/src/binding/database/db_descriptor.h
+++ b/src/binding/database/db_descriptor.h
@@ -92,6 +92,9 @@ struct DBDescriptor final : public std::enable_shared_from_this<DBDescriptor> {
 	 */
 	bool readOnly;
 
+	/** Compression name the database was opened with; empty means unset. */
+	std::string compression;
+
 	/**
 	 * The column family options `DB::Open` was given, retained so families
 	 * created later are configured the same way.

--- a/src/binding/database/db_descriptor.h
+++ b/src/binding/database/db_descriptor.h
@@ -93,6 +93,12 @@ struct DBDescriptor final : public std::enable_shared_from_this<DBDescriptor> {
 	bool readOnly;
 
 	/**
+	 * The column family options `DB::Open` was given, retained so families
+	 * created later are configured the same way.
+	 */
+	rocksdb::ColumnFamilyOptions cfOptions;
+
+	/**
 	 * The RocksDB database instance.
 	 */
 	std::shared_ptr<rocksdb::DB> db;
@@ -259,6 +265,7 @@ private:
 	DBDescriptor(
 		const std::string& path,
 		const DBOptions& options,
+		const rocksdb::ColumnFamilyOptions& cfOptions,
 		std::shared_ptr<rocksdb::DB> db,
 		std::unordered_map<std::string, std::shared_ptr<ColumnFamilyDescriptor>>&& columns,
 		std::shared_ptr<rocksdb::Statistics> statistics

--- a/src/binding/database/db_registry.cpp
+++ b/src/binding/database/db_registry.cpp
@@ -350,8 +350,14 @@ std::unique_ptr<DBHandleParams> DBRegistry::OpenDB(const std::string& path, cons
 				throw rocksdb_js::DBException("Column family \"" + name + "\" not found: cannot create column family in read-only mode");
 			}
 			DEBUG_LOG("%p DBRegistry::OpenDB Creating column family \"%s\"\n", instance.get(), name.c_str());
+			// Preserve descriptor-wide table/compression settings, but apply the
+			// current handle's per-CF memory options to the family it is creating.
+			auto cfOptions = entry.descriptor->cfOptions;
+			cfOptions.write_buffer_size = static_cast<size_t>(options.writeBufferSize);
+			cfOptions.max_write_buffer_number = options.maxWriteBufferNumber;
+			cfOptions.max_write_buffer_size_to_maintain = options.maxWriteBufferSizeToMaintain;
 			auto column = rocksdb_js::createRocksDBColumnFamily(
-				entry.descriptor->db, name, entry.descriptor->cfOptions
+				entry.descriptor->db, name, cfOptions
 			);
 			auto columnDescriptor = std::make_shared<ColumnFamilyDescriptor>(column);
 			columns[name] = columnDescriptor;

--- a/src/binding/database/db_registry.cpp
+++ b/src/binding/database/db_registry.cpp
@@ -1,5 +1,6 @@
 #include "database/db_registry.h"
 #include "napi/macros.h"
+#include "core/compression.h"
 #include "core/platform.h"
 #include "napi/helpers.h"
 #include "napi/async.h"
@@ -310,6 +311,22 @@ std::unique_ptr<DBHandleParams> DBRegistry::OpenDB(const std::string& path, cons
 				(entry.descriptor->mode == DBMode::Optimistic ? std::string("optimistic") : std::string("pessimistic")) +
 				"' mode"
 			);
+		}
+
+		// Resolved types, not names: an omitted option leaves RocksDB's default.
+		if (!options.compression.empty()) {
+			rocksdb::CompressionType requested;
+			std::string error;
+			if (!tryResolveCompressionType(options.compression, requested, error)) {
+				throw rocksdb_js::DBException(error);
+			}
+			if (requested != entry.descriptor->cfOptions.compression) {
+				throw rocksdb_js::DBException(
+					"Database already open with compression '" +
+					(entry.descriptor->compression.empty() ? std::string("default") : entry.descriptor->compression) +
+					"', requested '" + options.compression + "'"
+				);
+			}
 		}
 
 		DEBUG_LOG("%p DBRegistry::OpenDB Database already open \"%s\"\n", instance.get(), path.c_str());

--- a/src/binding/database/db_registry.cpp
+++ b/src/binding/database/db_registry.cpp
@@ -333,7 +333,9 @@ std::unique_ptr<DBHandleParams> DBRegistry::OpenDB(const std::string& path, cons
 				throw rocksdb_js::DBException("Column family \"" + name + "\" not found: cannot create column family in read-only mode");
 			}
 			DEBUG_LOG("%p DBRegistry::OpenDB Creating column family \"%s\"\n", instance.get(), name.c_str());
-			auto column = rocksdb_js::createRocksDBColumnFamily(entry.descriptor->db, name);
+			auto column = rocksdb_js::createRocksDBColumnFamily(
+				entry.descriptor->db, name, entry.descriptor->cfOptions
+			);
 			auto columnDescriptor = std::make_shared<ColumnFamilyDescriptor>(column);
 			columns[name] = columnDescriptor;
 			entry.descriptor->columns[name] = columnDescriptor;

--- a/src/binding/napi/helpers.cpp
+++ b/src/binding/napi/helpers.cpp
@@ -14,7 +14,6 @@
 #include "napi/helpers.h"
 #include "napi/macros.h"
 #include "rocksdb/utilities/options_util.h"
-#include "database/db_settings.h"
 
 namespace rocksdb_js {
 
@@ -229,17 +228,12 @@ std::string getNapiExtendedError(napi_env env, napi_status& status, const char* 
 	return std::string(errorStr);
 }
 
-std::shared_ptr<rocksdb::ColumnFamilyHandle> createRocksDBColumnFamily(const std::shared_ptr<rocksdb::DB> db, const std::string& name) {
+std::shared_ptr<rocksdb::ColumnFamilyHandle> createRocksDBColumnFamily(
+	const std::shared_ptr<rocksdb::DB> db,
+	const std::string& name,
+	const rocksdb::ColumnFamilyOptions& cfOptions
+) {
 	rocksdb::ColumnFamilyHandle* cfHandle;
-	rocksdb::BlockBasedTableOptions tableOptions;
-	DBSettings& settings = DBSettings::getInstance();
-	tableOptions.block_cache = settings.getBlockCache();
-	rocksdb::ColumnFamilyOptions cfOptions;
-	cfOptions.enable_blob_files = true;
-	cfOptions.min_blob_size = 2048;
-	cfOptions.enable_blob_garbage_collection = true;
-	cfOptions.table_factory.reset(rocksdb::NewBlockBasedTableFactory(tableOptions));
-
 	rocksdb::Status status = db->CreateColumnFamily(cfOptions, name, &cfHandle);
 	if (!status.ok()) {
 		throw rocksdb_js::DBException(status.ToString());

--- a/src/binding/napi/helpers.h
+++ b/src/binding/napi/helpers.h
@@ -25,7 +25,16 @@ namespace rocksdb_js {
 
 void createJSError(napi_env env, const char* code, const char* message, napi_value& error);
 
-std::shared_ptr<rocksdb::ColumnFamilyHandle> createRocksDBColumnFamily(const std::shared_ptr<rocksdb::DB> db, const std::string& name);
+/**
+ * Creates a column family on an already-open database. Takes the database's own
+ * `ColumnFamilyOptions`, which only reach families that existed at `DB::Open`;
+ * rebuilding a set here would silently drop every configured tunable.
+ */
+std::shared_ptr<rocksdb::ColumnFamilyHandle> createRocksDBColumnFamily(
+	const std::shared_ptr<rocksdb::DB> db,
+	const std::string& name,
+	const rocksdb::ColumnFamilyOptions& cfOptions
+);
 
 void createRocksDBError(napi_env env, rocksdb::Status status, const char* msg, napi_value& error);
 

--- a/src/binding/options/db_options.h
+++ b/src/binding/options/db_options.h
@@ -20,6 +20,9 @@ enum class DBMode {
  * values passed in from public `open()` method.
  */
 struct DBOptions final {
+	// Normalized compression name (see `tryResolveCompressionType`). Empty
+	// leaves the RocksDB default. Applies to the whole database, not one CF.
+	std::string compression;
 	// Global memtable size trigger across all column families. When the sum of
 	// all memtables reaches this size, the largest memtable is flushed. With
 	// `atomic_flush = true`, this triggers flushes across every CF. 0 disables

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ export {
 	fileLockRelease,
 	tryFileLock,
 	registryStatus,
+	type RocksDBCompression,
 	stats,
 	shutdown,
 	TransactionLog,

--- a/src/load-binding.ts
+++ b/src/load-binding.ts
@@ -193,7 +193,16 @@ export declare class NativeIteratorCls {
 
 export type NativeDatabaseMode = 'optimistic' | 'pessimistic';
 
+/**
+ * Algorithm names the native layer accepts. Which ones work depends on the
+ * compressors linked into the RocksDB build; requesting an unlinked one throws
+ * on open rather than silently writing uncompressed data.
+ */
+export type RocksDBCompression = 'none' | 'snappy' | 'zlib' | 'bzip2' | 'lz4' | 'lz4hc' | 'zstd';
+
 export type NativeDatabaseOptions = {
+	/** Already normalized: the `boolean` shorthand is resolved before this point. */
+	compression?: RocksDBCompression;
 	dbWriteBufferSize?: number;
 	disableWAL?: boolean;
 	enableStats?: boolean;

--- a/src/store.ts
+++ b/src/store.ts
@@ -90,7 +90,8 @@ export interface StoreOptions extends Omit<
 	 * Naming an algorithm the build lacks throws.
 	 *
 	 * Applies database-wide and is fixed by the first `open()` of a path, since
-	 * every handle shares one RocksDB instance.
+	 * every handle shares one RocksDB instance. A later handle may omit it; a
+	 * conflicting value throws.
 	 */
 	compression?: boolean | RocksDBCompression;
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -83,11 +83,14 @@ export interface StoreOptions extends Omit<
 	'compression' | 'mode' | 'transactionLogRetentionMs'
 > {
 	/**
-	 * Enables SST block compression for newly written table files. `true`
-	 * selects `'zlib'`, the only algorithm the published prebuilt links; `false`
-	 * means none. Omitting it leaves whatever your RocksDB build defaults to,
-	 * which is none in the published prebuilt but snappy in a build linking it.
-	 * Naming an algorithm the build lacks throws.
+	 * Enables SST block compression for newly written table files. Values whose
+	 * uncompressed size is 2,048 bytes or greater are stored in blob files, which
+	 * remain uncompressed; this option does not affect them.
+	 *
+	 * `true` selects `'zlib'`, the only algorithm the published prebuilt links;
+	 * `false` means none. Omitting it leaves whatever your RocksDB build defaults
+	 * to, which is none in the published prebuilt but snappy in a build linking
+	 * it. Naming an algorithm the build lacks throws.
 	 *
 	 * Applies database-wide and is fixed by the first `open()` of a path, since
 	 * every handle shares one RocksDB instance. A later handle may omit it; a

--- a/src/store.ts
+++ b/src/store.ts
@@ -19,6 +19,7 @@ import {
 	type NativeDatabaseOptions,
 	NativeIterator,
 	NativeTransaction,
+	type RocksDBCompression,
 	stats,
 	type TransactionLog,
 	type UserSharedBufferCallback,
@@ -79,8 +80,20 @@ export type CompactOptions = {
  */
 export interface StoreOptions extends Omit<
 	NativeDatabaseOptions,
-	'mode' | 'transactionLogRetentionMs'
+	'compression' | 'mode' | 'transactionLogRetentionMs'
 > {
+	/**
+	 * Enables SST block compression for newly written table files. `true`
+	 * selects `'zlib'`, the only algorithm the published prebuilt links; `false`
+	 * means none. Omitting it leaves whatever your RocksDB build defaults to,
+	 * which is none in the published prebuilt but snappy in a build linking it.
+	 * Naming an algorithm the build lacks throws.
+	 *
+	 * Applies database-wide and is fixed by the first `open()` of a path, since
+	 * every handle shares one RocksDB instance.
+	 */
+	compression?: boolean | RocksDBCompression;
+
 	decoder?: Encoder | null;
 	encoder?: Encoder | null;
 	encoding?: Encoding;
@@ -151,6 +164,11 @@ export class Store {
 	 * owner temporarily closed is still recognized as in-use. See `claim()`.
 	 */
 	#claimed: boolean = false;
+
+	/**
+	 * The SST block compression algorithm, or a boolean shorthand.
+	 */
+	compression?: boolean | RocksDBCompression;
 
 	/**
 	 * The database instance.
@@ -365,6 +383,7 @@ export class Store {
 			options?.keyEncoder
 		);
 
+		this.compression = options?.compression;
 		this.db = new NativeDatabase();
 		this.dbWriteBufferSize = options?.dbWriteBufferSize;
 		this.decoder = options?.decoder ?? null;
@@ -879,6 +898,7 @@ export class Store {
 		}
 
 		this.db.open(this.path, {
+			compression: normalizeCompression(this.compression),
 			dbWriteBufferSize: this.dbWriteBufferSize,
 			disableWAL: this.disableWAL,
 			enableStats: this.enableStats,
@@ -1007,6 +1027,26 @@ export class Store {
 
 		return this.db.withLock(this.encodeKey(key), callback);
 	}
+}
+
+/**
+ * Resolves the `compression` option's boolean shorthand to the algorithm name
+ * the native layer expects. `undefined` is passed through so the native layer
+ * leaves the RocksDB default in place.
+ */
+function normalizeCompression(
+	compression: boolean | RocksDBCompression | undefined
+): RocksDBCompression | undefined {
+	if (compression === undefined) {
+		return undefined;
+	}
+	if (compression === true) {
+		return 'zlib';
+	}
+	if (compression === false) {
+		return 'none';
+	}
+	return compression;
 }
 
 /**

--- a/test/db-options.test.ts
+++ b/test/db-options.test.ts
@@ -244,4 +244,61 @@ describe('Database compression options', () => {
 			}
 		);
 	});
+
+	it('should reject a conflicting compression on an already-open path', () =>
+		dbRunner(
+			{
+				dbOptions: [{ compression: 'none' }, { compression: 'zlib', name: 'other' }],
+				skipOpen: true,
+			},
+			async ({ db: first }, { db: second }) => {
+				first.open();
+				// All handles on a path share one RocksDB instance, so the second
+				// request cannot be honored — reject instead of silently ignoring it.
+				expect(() => second.open()).toThrow('Database already open with compression');
+			}
+		));
+
+	it('should not treat an omitted compression and an explicit none as a conflict', () =>
+		dbRunner(
+			{
+				dbOptions: [
+					{ compression: false },
+					{ name: 'omittedSecond' },
+					{ compression: false, name: 'noneSecond' },
+				],
+				skipOpen: true,
+			},
+			async ({ db: first }, { db: omittedSecond }, { db: noneSecond }) => {
+				first.open();
+				expect(() => omittedSecond.open()).not.toThrow();
+				expect(() => noneSecond.open()).not.toThrow();
+			}
+		));
+
+	it('should not treat an explicit none after an omitted compression as a conflict', () =>
+		dbRunner(
+			{ dbOptions: [{}, { compression: false, name: 'other' }], skipOpen: true },
+			async ({ db: first }, { db: second }) => {
+				first.open();
+				expect(() => second.open()).not.toThrow();
+			}
+		));
+
+	it('should allow reopening an open path with a matching or omitted compression', () =>
+		dbRunner(
+			{
+				dbOptions: [
+					{ compression: 'zlib' },
+					{ compression: 'zlib', name: 'matching' },
+					{ name: 'omitted' },
+				],
+				skipOpen: true,
+			},
+			async ({ db: first }, { db: matching }, { db: omitted }) => {
+				first.open();
+				expect(() => matching.open()).not.toThrow();
+				expect(() => omitted.open()).not.toThrow();
+			}
+		));
 });

--- a/test/db-options.test.ts
+++ b/test/db-options.test.ts
@@ -1,4 +1,4 @@
-import { dbRunner } from './lib/util.js';
+import { dbRunner, generateDBPath } from './lib/util.js';
 import { describe, expect, it } from 'vitest';
 
 describe('Database write buffer options', () => {
@@ -74,6 +74,40 @@ describe('Database write buffer options', () => {
 		dbRunner({ dbOptions: [{ maxOpenFiles: 2 ** 32 - 1 }], skipOpen: true }, async ({ db }) => {
 			expect(() => db.open()).toThrow('maxOpenFiles must be');
 		}));
+
+	// A named CF is created after DB::Open, so it misses the open options.
+	// Observed via flush behavior: RocksDB exposes no property for the size.
+	it('should apply writeBufferSize to a named column family', () =>
+		dbRunner(
+			{
+				dbOptions: [
+					{ path: generateDBPath(), name: 'mycf', writeBufferSize: 64 * 1024 },
+					{ path: generateDBPath(), name: 'mycf', writeBufferSize: 64 * 1024 * 1024 },
+				],
+			},
+			async ({ db: smallBuffer }, { db: largeBuffer }) => {
+				const value = 'x'.repeat(1024);
+				for (const db of [smallBuffer, largeBuffer]) {
+					for (let i = 0; i < 512; i++) {
+						await db.put(`key-${i.toString().padStart(6, '0')}`, value);
+					}
+				}
+
+				// Flushes run in the background.
+				const deadline = Date.now() + 5000;
+				let smallBufferSize = 0;
+				while (Date.now() < deadline) {
+					smallBufferSize = smallBuffer.getDBIntProperty('rocksdb.total-sst-files-size') ?? 0;
+					if (smallBufferSize > 0) {
+						break;
+					}
+					await new Promise((resolve) => setTimeout(resolve, 50));
+				}
+
+				expect(smallBufferSize).toBeGreaterThan(0);
+				expect(largeBuffer.getDBIntProperty('rocksdb.total-sst-files-size')).toBe(0);
+			}
+		));
 
 	it('should flush memtables when writeBufferSize is exceeded', () =>
 		dbRunner({ dbOptions: [{ writeBufferSize: 64 * 1024 }] }, async ({ db }) => {

--- a/test/db-options.test.ts
+++ b/test/db-options.test.ts
@@ -1,3 +1,4 @@
+import { RocksDatabase } from '../src/index.js';
 import { dbRunner, generateDBPath } from './lib/util.js';
 import { describe, expect, it } from 'vitest';
 
@@ -124,4 +125,123 @@ describe('Database write buffer options', () => {
 			expect(sstSize).toBeDefined();
 			expect(sstSize!).toBeGreaterThan(0);
 		}));
+});
+
+// Highly compressible so zlib wins decisively, and below min_blob_size (2048)
+// so the values stay in SST blocks — blob files are not affected by this option.
+const COMPRESSIBLE_VALUE = 'a'.repeat(1000);
+
+/**
+ * Writes a compressible payload and returns the resulting on-disk SST size.
+ * Comparing this between two otherwise-identical databases is the only way to
+ * observe that compression was really applied: an ignored `compression` option
+ * still reads and writes correctly, just without shrinking anything.
+ */
+async function writeCompressiblePayload(db: RocksDatabase): Promise<number> {
+	for (let i = 0; i < 1500; i++) {
+		await db.put(`key-${i.toString().padStart(6, '0')}`, COMPRESSIBLE_VALUE);
+	}
+	await db.flush();
+	const size = db.getDBIntProperty('rocksdb.total-sst-files-size');
+	expect(size).toBeGreaterThan(0);
+	return size!;
+}
+
+describe('Database compression options', () => {
+	it('should round-trip data with compression enabled (true -> zlib)', () =>
+		dbRunner({ dbOptions: [{ compression: true }] }, async ({ db }) => {
+			await db.put('foo', 'bar');
+			expect(await db.get('foo')).toBe('bar');
+		}));
+
+	it('should round-trip data with an explicit zlib algorithm', () =>
+		dbRunner({ dbOptions: [{ compression: 'zlib' }] }, async ({ db }) => {
+			await db.put('foo', 'bar');
+			expect(await db.get('foo')).toBe('bar');
+		}));
+
+	it('should round-trip data with compression disabled (false -> none)', () =>
+		dbRunner({ dbOptions: [{ compression: false }] }, async ({ db }) => {
+			await db.put('foo', 'bar');
+			expect(await db.get('foo')).toBe('bar');
+		}));
+
+	it('should reject an unknown compression type on open', () =>
+		dbRunner({ dbOptions: [{ compression: 'gzip' as any }], skipOpen: true }, async ({ db }) => {
+			expect(() => db.open()).toThrow('Unknown compression type');
+			// The message must point at what this build can actually use.
+			expect(() => db.open()).toThrow('Available in this build');
+		}));
+
+	it('should reject an unknown compression type when the path is already open', () =>
+		dbRunner(
+			{ dbOptions: [{}, { compression: 'gzip' as any, name: 'other' }], skipOpen: true },
+			async ({ db: first }, { db: second }) => {
+				first.open();
+				// Validation must not depend on this open being the one that
+				// creates the descriptor.
+				expect(() => second.open()).toThrow('Unknown compression type');
+			}
+		));
+
+	it('should write smaller table files with zlib than with no compression', () =>
+		dbRunner(
+			{
+				dbOptions: [
+					{ path: generateDBPath(), compression: 'none', writeBufferSize: 64 * 1024 },
+					{ path: generateDBPath(), compression: 'zlib', writeBufferSize: 64 * 1024 },
+				],
+			},
+			async ({ db: uncompressed }, { db: compressed }) => {
+				const uncompressedSize = await writeCompressiblePayload(uncompressed);
+				const compressedSize = await writeCompressiblePayload(compressed);
+				expect(compressedSize).toBeLessThan(uncompressedSize);
+
+				// Data still reads back correctly through the compressed path.
+				expect(await compressed.get('key-000000')).toBe(COMPRESSIBLE_VALUE);
+				expect(await compressed.get('key-001499')).toBe(COMPRESSIBLE_VALUE);
+			}
+		));
+
+	// A named column family does not exist on a fresh path, so it is created
+	// after `DB::Open` rather than being handed the open options. It must still
+	// get the requested compression.
+	it('should compress a named column family created at open time', () =>
+		dbRunner(
+			{
+				dbOptions: [
+					{ path: generateDBPath(), name: 'mycf', compression: 'none' },
+					{ path: generateDBPath(), name: 'mycf', compression: 'zlib' },
+				],
+			},
+			async ({ db: uncompressed }, { db: compressed }) => {
+				const uncompressedSize = await writeCompressiblePayload(uncompressed);
+				const compressedSize = await writeCompressiblePayload(compressed);
+				expect(compressedSize).toBeLessThan(uncompressedSize);
+				expect(await compressed.get('key-000000')).toBe(COMPRESSIBLE_VALUE);
+			}
+		));
+
+	// Same requirement for a column family added to a database that is already
+	// open, which goes through the registry rather than `DBDescriptor::open`.
+	it('should compress a column family added to an already-open database', () => {
+		const uncompressedPath = generateDBPath();
+		const compressedPath = generateDBPath();
+		return dbRunner(
+			{
+				dbOptions: [
+					{ path: uncompressedPath, compression: 'none' },
+					{ path: uncompressedPath, name: 'late' },
+					{ path: compressedPath, compression: 'zlib' },
+					{ path: compressedPath, name: 'late' },
+				],
+			},
+			async (_base, { db: lateUncompressed }, _compressedBase, { db: lateCompressed }) => {
+				const uncompressedSize = await writeCompressiblePayload(lateUncompressed);
+				const compressedSize = await writeCompressiblePayload(lateCompressed);
+				expect(compressedSize).toBeLessThan(uncompressedSize);
+				expect(await lateCompressed.get('key-000000')).toBe(COMPRESSIBLE_VALUE);
+			}
+		);
+	});
 });

--- a/test/db-options.test.ts
+++ b/test/db-options.test.ts
@@ -1,6 +1,24 @@
-import { RocksDatabase } from '../src/index.js';
+import { RocksDatabase, type RocksDBCompression } from '../src/index.js';
 import { dbRunner, generateDBPath } from './lib/util.js';
+import { rmSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
+
+function isCompressionSupported(compression: RocksDBCompression): boolean {
+	const path = generateDBPath();
+	const db = new RocksDatabase(path, { compression });
+	try {
+		db.open();
+		return true;
+	} catch (error) {
+		if (error instanceof Error && error.message.includes('not supported by this RocksDB build')) {
+			return false;
+		}
+		throw error;
+	} finally {
+		db.close();
+		rmSync(path, { force: true, recursive: true, maxRetries: 3, retryDelay: 500 });
+	}
+}
 
 describe('Database write buffer options', () => {
 	it('should open with default write buffer settings', () =>
@@ -110,6 +128,40 @@ describe('Database write buffer options', () => {
 			}
 		));
 
+	it('should apply the current handle memory options to a late column family', () =>
+		dbRunner(
+			{
+				dbOptions: [
+					{ writeBufferSize: 64 * 1024 * 1024 },
+					{ name: 'late', writeBufferSize: 64 * 1024 },
+				],
+				skipOpen: true,
+			},
+			async ({ db: first }, { db: late }) => {
+				first.open();
+				late.open();
+
+				const value = 'x'.repeat(1024);
+				for (let i = 0; i < 512; i++) {
+					await late.put(`key-${i.toString().padStart(6, '0')}`, value);
+				}
+
+				// Do not force a flush: automatic flush behavior is what distinguishes
+				// the late handle's requested 64 KiB buffer from the first opener's 64 MiB.
+				const deadline = Date.now() + 5000;
+				let lateBufferSize = 0;
+				while (Date.now() < deadline) {
+					lateBufferSize = late.getDBIntProperty('rocksdb.total-sst-files-size') ?? 0;
+					if (lateBufferSize > 0) {
+						break;
+					}
+					await new Promise((resolve) => setTimeout(resolve, 50));
+				}
+
+				expect(lateBufferSize).toBeGreaterThan(0);
+			}
+		));
+
 	it('should flush memtables when writeBufferSize is exceeded', () =>
 		dbRunner({ dbOptions: [{ writeBufferSize: 64 * 1024 }] }, async ({ db }) => {
 			// 64KB memtable; write enough data to force at least one flush.
@@ -147,18 +199,27 @@ async function writeCompressiblePayload(db: RocksDatabase): Promise<number> {
 	return size!;
 }
 
+const zlibSupported = isCompressionSupported('zlib');
+const zlibIt = zlibSupported ? it : it.skip;
+
 describe('Database compression options', () => {
-	it('should round-trip data with compression enabled (true -> zlib)', () =>
-		dbRunner({ dbOptions: [{ compression: true }] }, async ({ db }) => {
-			await db.put('foo', 'bar');
-			expect(await db.get('foo')).toBe('bar');
+	it('should resolve true to zlib when supported and reject it otherwise', () =>
+		dbRunner({ dbOptions: [{ compression: true }], skipOpen: true }, async ({ db }) => {
+			if (zlibSupported) {
+				db.open();
+				await db.put('foo', 'bar');
+				expect(await db.get('foo')).toBe('bar');
+			} else {
+				expect(() => db.open()).toThrow('not supported by this RocksDB build');
+			}
 		}));
 
-	it('should round-trip data with an explicit zlib algorithm', () =>
+	zlibIt('should round-trip data with an explicit zlib algorithm', () =>
 		dbRunner({ dbOptions: [{ compression: 'zlib' }] }, async ({ db }) => {
 			await db.put('foo', 'bar');
 			expect(await db.get('foo')).toBe('bar');
-		}));
+		})
+	);
 
 	it('should round-trip data with compression disabled (false -> none)', () =>
 		dbRunner({ dbOptions: [{ compression: false }] }, async ({ db }) => {
@@ -184,7 +245,16 @@ describe('Database compression options', () => {
 			}
 		));
 
-	it('should write smaller table files with zlib than with no compression', () =>
+	it('should reject an explicitly empty compression instead of treating it as omitted', () =>
+		dbRunner(
+			{ dbOptions: [{}, { compression: '' as any, name: 'other' }], skipOpen: true },
+			async ({ db: first }, { db: second }) => {
+				first.open();
+				expect(() => second.open()).toThrow('Unknown compression type');
+			}
+		));
+
+	zlibIt('should write smaller table files with zlib than with no compression', () =>
 		dbRunner(
 			{
 				dbOptions: [
@@ -201,12 +271,13 @@ describe('Database compression options', () => {
 				expect(await compressed.get('key-000000')).toBe(COMPRESSIBLE_VALUE);
 				expect(await compressed.get('key-001499')).toBe(COMPRESSIBLE_VALUE);
 			}
-		));
+		)
+	);
 
 	// A named column family does not exist on a fresh path, so it is created
 	// after `DB::Open` rather than being handed the open options. It must still
 	// get the requested compression.
-	it('should compress a named column family created at open time', () =>
+	zlibIt('should compress a named column family created at open time', () =>
 		dbRunner(
 			{
 				dbOptions: [
@@ -220,11 +291,12 @@ describe('Database compression options', () => {
 				expect(compressedSize).toBeLessThan(uncompressedSize);
 				expect(await compressed.get('key-000000')).toBe(COMPRESSIBLE_VALUE);
 			}
-		));
+		)
+	);
 
 	// Same requirement for a column family added to a database that is already
 	// open, which goes through the registry rather than `DBDescriptor::open`.
-	it('should compress a column family added to an already-open database', () => {
+	zlibIt('should compress a column family added to an already-open database', () => {
 		const uncompressedPath = generateDBPath();
 		const compressedPath = generateDBPath();
 		return dbRunner(
@@ -245,7 +317,7 @@ describe('Database compression options', () => {
 		);
 	});
 
-	it('should reject a conflicting compression on an already-open path', () =>
+	zlibIt('should reject a conflicting compression on an already-open path', () =>
 		dbRunner(
 			{
 				dbOptions: [{ compression: 'none' }, { compression: 'zlib', name: 'other' }],
@@ -257,7 +329,8 @@ describe('Database compression options', () => {
 				// request cannot be honored — reject instead of silently ignoring it.
 				expect(() => second.open()).toThrow('Database already open with compression');
 			}
-		));
+		)
+	);
 
 	it('should not treat an omitted compression and an explicit none as a conflict', () =>
 		dbRunner(
@@ -276,16 +349,21 @@ describe('Database compression options', () => {
 			}
 		));
 
-	it('should not treat an explicit none after an omitted compression as a conflict', () =>
+	it('should compare explicit none against the effective omitted compression', () =>
 		dbRunner(
 			{ dbOptions: [{}, { compression: false, name: 'other' }], skipOpen: true },
 			async ({ db: first }, { db: second }) => {
+				const snappySupported = isCompressionSupported('snappy');
 				first.open();
-				expect(() => second.open()).not.toThrow();
+				if (snappySupported) {
+					expect(() => second.open()).toThrow('Database already open with compression');
+				} else {
+					expect(() => second.open()).not.toThrow();
+				}
 			}
 		));
 
-	it('should allow reopening an open path with a matching or omitted compression', () =>
+	zlibIt('should allow reopening an open path with a matching or omitted compression', () =>
 		dbRunner(
 			{
 				dbOptions: [
@@ -300,5 +378,6 @@ describe('Database compression options', () => {
 				expect(() => matching.open()).not.toThrow();
 				expect(() => omitted.open()).not.toThrow();
 			}
-		));
+		)
+	);
 });

--- a/test/native/compression_test.cc
+++ b/test/native/compression_test.cc
@@ -71,16 +71,6 @@ TEST(CompressionTest, EveryKnownNameEitherResolvesOrReportsUnsupported) {
 	}
 }
 
-// zlib backs the `compression: true` shorthand, and the prebuilt links libz
-// explicitly for this reason. If this fails on a platform, that shorthand is
-// broken there and needs a different default.
-TEST(CompressionTest, ZlibIsAvailable) {
-	rocksdb::CompressionType type = rocksdb::kNoCompression;
-	std::string error;
-	EXPECT_TRUE(tryResolveCompressionType("zlib", type, error)) << error;
-	EXPECT_EQ(type, rocksdb::kZlibCompression);
-}
-
 TEST(CompressionTest, SupportedNamesAlwaysIncludesNone) {
 	EXPECT_NE(supportedCompressionNames().find("none"), std::string::npos);
 }

--- a/test/native/compression_test.cc
+++ b/test/native/compression_test.cc
@@ -1,0 +1,86 @@
+#include <gtest/gtest.h>
+#include <algorithm>
+#include <string>
+#include <vector>
+#include "core/compression.h"
+#include "rocksdb/convenience.h"
+#include "rocksdb/options.h"
+
+using rocksdb_js::supportedCompressionNames;
+using rocksdb_js::tryResolveCompressionType;
+
+namespace {
+
+bool isLinkedIn(rocksdb::CompressionType type) {
+	const std::vector<rocksdb::CompressionType> supported = rocksdb::GetSupportedCompressions();
+	return std::find(supported.begin(), supported.end(), type) != supported.end();
+}
+
+} // namespace
+
+// `none` requires no compressor, so it resolves in every build. This is the
+// case the resolver must never gate on GetSupportedCompressions(), which does
+// not report kNoCompression.
+TEST(CompressionTest, ResolvesNoneInAnyBuild) {
+	rocksdb::CompressionType type = rocksdb::kZlibCompression;
+	std::string error;
+	ASSERT_TRUE(tryResolveCompressionType("none", type, error)) << error;
+	EXPECT_EQ(type, rocksdb::kNoCompression);
+	EXPECT_TRUE(error.empty());
+}
+
+TEST(CompressionTest, RejectsUnknownNameAndListsAlternatives) {
+	rocksdb::CompressionType type = rocksdb::kNoCompression;
+	std::string error;
+	EXPECT_FALSE(tryResolveCompressionType("gzip", type, error));
+	EXPECT_NE(error.find("Unknown compression type"), std::string::npos);
+	// The message must name what the caller can actually use instead.
+	EXPECT_NE(error.find(supportedCompressionNames()), std::string::npos);
+}
+
+// Names are matched exactly: the TypeScript layer lowercases before handing
+// them over, so an uppercase name reaching here is a caller bug, not a variant
+// to silently accept.
+TEST(CompressionTest, RejectsNonLowercaseName) {
+	rocksdb::CompressionType type = rocksdb::kNoCompression;
+	std::string error;
+	EXPECT_FALSE(tryResolveCompressionType("ZLIB", type, error));
+	EXPECT_FALSE(tryResolveCompressionType("", type, error));
+}
+
+// The point of the resolver: a known name whose compressor was not linked in
+// must fail loudly instead of letting RocksDB degrade to writing uncompressed
+// table files. Which algorithms are linked varies per build, so assert the
+// rule rather than a fixed set.
+TEST(CompressionTest, EveryKnownNameEitherResolvesOrReportsUnsupported) {
+	const char* names[] = {"none", "snappy", "zlib", "bzip2", "lz4", "lz4hc", "zstd"};
+	for (const char* name : names) {
+		rocksdb::CompressionType type = rocksdb::kNoCompression;
+		std::string error;
+		if (tryResolveCompressionType(name, type, error)) {
+			EXPECT_TRUE(type == rocksdb::kNoCompression || isLinkedIn(type))
+				<< name << " resolved but is not linked in";
+			EXPECT_NE(supportedCompressionNames().find(name), std::string::npos)
+				<< name << " resolved but is missing from the supported list";
+		} else {
+			EXPECT_NE(error.find("not supported by this RocksDB build"), std::string::npos)
+				<< name << " failed with an unexpected error: " << error;
+			EXPECT_EQ(supportedCompressionNames().find(name), std::string::npos)
+				<< name << " is unsupported but listed as available";
+		}
+	}
+}
+
+// zlib backs the `compression: true` shorthand, and the prebuilt links libz
+// explicitly for this reason. If this fails on a platform, that shorthand is
+// broken there and needs a different default.
+TEST(CompressionTest, ZlibIsAvailable) {
+	rocksdb::CompressionType type = rocksdb::kNoCompression;
+	std::string error;
+	EXPECT_TRUE(tryResolveCompressionType("zlib", type, error)) << error;
+	EXPECT_EQ(type, rocksdb::kZlibCompression);
+}
+
+TEST(CompressionTest, SupportedNamesAlwaysIncludesNone) {
+	EXPECT_NE(supportedCompressionNames().find("none"), std::string::npos);
+}


### PR DESCRIPTION
## Summary

Adds a `compression` option accepting `true` (zlib), `false` (none), or an explicit algorithm name.
Omitting it leaves RocksDB's own default untouched, so existing callers are unaffected. That
default is snappy on builds that link it and none otherwise; the published prebuilt has no snappy,
so omitting the option today means no compression. Values at or above 2,048 bytes are stored in
blob files, which remain uncompressed and are unaffected by this option.

Requesting an algorithm the RocksDB build does not include causes `open()` to fail. This is
deliberate: RocksDB reports no error in that case and silently writes uncompressed files. The error
message lists what the running build supports.

The name resolver is in a translation unit free of Node dependencies so the GoogleTest suite can
link against it directly. Validation runs on every `open()` rather than only the first, so a call
that reuses an already-open path is checked as well.

This also rejects an `open()` requesting different compression on a path that is already
open. All handles on a path share one RocksDB instance, so a later open cannot change how table
files are written; previously the request was ignored and the caller would believe compression was
active. The check compares resolved `CompressionType` values rather than the requested names, since
the default varies by build as noted above. The error is uncoded, consistent with the existing
"already open in X mode" error rather than `ERR_DATABASE_READONLY`.

Depends on #721. Compression is a column family option and cannot reach named column families
without that fix; this diff includes that commit until #721 merges.

## Test Plan

Compression is asserted against on-disk SST size rather than a round trip, since an option that has
no effect still reads and writes correctly. The same payload produces substantially smaller SST
files with zlib than without compression. Verified on the default column family, a named column
family, and one added to an already-open database, which exercise three separate code paths.

Tests adapt to the compression algorithms the running build supports. Also verified with
`ROCKSDB_PATH` pointing to a build with all optional compressors disabled. The packaging smoke test
checks that the published prebuilt includes zlib.

Local runs are macOS arm64 only.

