### PR TITLE
Backport #717 to v2.4.x: resolve transaction reads against the caller's column family

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -207,6 +207,21 @@ C++ code that needs to emit to JS without a database context should call
    (`list`, `verify`, a restore's source read) are not locked since concurrent readers are safe; a
    reader racing a `delete`/`purge` is a caller-managed hazard. Different directories are independent
    (separate lock files) and run fully in parallel.
+8. **Transactional reads are database-wide, but async column-family pins end before teardown**:
+   a RocksDB transaction can read any column family in its database, so a read issued through another
+   `RocksDatabase` must use that caller's `ColumnFamilyDescriptor`, not the transaction's original
+   `DBHandle`. Register setup briefly against the caller's `DBHandle` before copying its descriptor,
+   so a cross-environment close cannot reset the descriptor between the open check and the pin. The
+   transaction itself must be registered before inspecting `txn`/state, then that registration is
+   transferred to the queued async state; failed N-API setup must release refs/work/state without
+   double-unregistering or retaining the descriptor.
+   cold-cache async path then pins that descriptor in `AsyncGetState` while the worker uses its native
+   column-family handle, and resets the pin **before** `signalExecuteCompleted()`; that
+   signal can unblock transaction/database close, which destroys column families before the RocksDB
+   database. Do not retain a raw/native column-family handle into the N-API completion callback or
+   inspect a concurrently closing `DBHandle` from the worker. Transactional count iterators must also
+   pass the transaction snapshot through `ReadOptions`; `disableSnapshot` intentionally leaves it null
+   so counts observe the latest committed state.
 
 ## Debugging native heap corruption
 

--- a/src/binding/database/database.cpp
+++ b/src/binding/database/database.cpp
@@ -765,6 +765,12 @@ napi_value Database::Get(napi_env env, napi_callback_info info) {
 		&state->asyncWork // -> result
 	));
 
+	// Balances the unregisterAsyncWork() that BaseAsyncState::signalExecuteCompleted()
+	// performs at the end of the execute handler. Without it the count goes negative,
+	// so close() does not wait for this read and the worker dereferences a descriptor
+	// that close() has already reset.
+	(*dbHandle)->registerAsyncWork();
+
 	NAPI_STATUS_THROWS(::napi_queue_async_work(env, state->asyncWork));
 
 	napi_value returnStatus;

--- a/src/binding/database/database.h
+++ b/src/binding/database/database.h
@@ -375,6 +375,20 @@ struct AsyncGetState final : BaseAsyncState<T> {
 	std::string key;
 	std::string value;
 
+	// Column family the read was issued against. A transaction belongs to a
+	// database rather than a single column family, so a read routed through
+	// another DBI in the same database must resolve against that DBI's column
+	// family, not the one the transaction was created with.
+	std::shared_ptr<DBHandle> readDbHandle;
+
+	// The column family handle itself, resolved on the JS thread. A transactional
+	// read registers its async work on the TransactionHandle, so closing the DBI
+	// being read does not wait for it; DBHandle::close() then resets
+	// columnDescriptor and getColumnFamilyHandle() would dereference null on the
+	// worker thread. Holding the handle keeps it alive for the read regardless of
+	// close ordering.
+	std::shared_ptr<rocksdb::ColumnFamilyHandle> readColumnFamily;
+
 	// Verification table state for post-read check and populate.
 	bool hasExpectedVersion = false;
 	uint64_t expectedVersion = 0;

--- a/src/binding/database/database.h
+++ b/src/binding/database/database.h
@@ -375,19 +375,11 @@ struct AsyncGetState final : BaseAsyncState<T> {
 	std::string key;
 	std::string value;
 
-	// Column family the read was issued against. A transaction belongs to a
-	// database rather than a single column family, so a read routed through
-	// another DBI in the same database must resolve against that DBI's column
-	// family, not the one the transaction was created with.
-	std::shared_ptr<DBHandle> readDbHandle;
-
-	// The column family handle itself, resolved on the JS thread. A transactional
-	// read registers its async work on the TransactionHandle, so closing the DBI
-	// being read does not wait for it; DBHandle::close() then resets
-	// columnDescriptor and getColumnFamilyHandle() would dereference null on the
-	// worker thread. Holding the handle keeps it alive for the read regardless of
-	// close ordering.
-	std::shared_ptr<rocksdb::ColumnFamilyHandle> readColumnFamily;
+	// A transaction belongs to the database rather than a single column family,
+	// so pin the descriptor selected by the caller until the worker finishes.
+	// The pin must be released before async completion is signaled because that
+	// signal can unblock database teardown.
+	std::shared_ptr<ColumnFamilyDescriptor> readColumnDescriptor;
 
 	// Verification table state for post-read check and populate.
 	bool hasExpectedVersion = false;

--- a/src/binding/iterator/db_iterator_handle.cpp
+++ b/src/binding/iterator/db_iterator_handle.cpp
@@ -30,9 +30,10 @@ DBIteratorHandle::DBIteratorHandle(
 
 DBIteratorHandle::DBIteratorHandle(
 	TransactionHandle* txnHandle,
-	DBIteratorOptions& options
+	DBIteratorOptions& options,
+	std::shared_ptr<DBHandle> dbHandleOverride
 ) :
-	dbHandle(txnHandle->dbHandle),
+	dbHandle(dbHandleOverride ? dbHandleOverride : txnHandle->dbHandle),
 	exclusiveStart(options.exclusiveStart),
 	inclusiveEnd(options.inclusiveEnd),
 	reverse(options.reverse),
@@ -45,7 +46,7 @@ DBIteratorHandle::DBIteratorHandle(
 	this->iterator = std::unique_ptr<rocksdb::Iterator>(
 		txnHandle->txn->GetIterator(
 			options.readOptions,
-			txnHandle->dbHandle->getColumnFamilyHandle()
+			this->dbHandle->getColumnFamilyHandle()
 		)
 	);
 

--- a/src/binding/iterator/db_iterator_handle.h
+++ b/src/binding/iterator/db_iterator_handle.h
@@ -24,8 +24,17 @@ struct DBIteratorHandle final : Closable, public std::enable_shared_from_this<DB
 
 	/**
 	 * Initializes the iterator handle using a transaction handle.
+	 *
+	 * `dbHandleOverride` selects the column family to iterate. A transaction
+	 * belongs to a database rather than a single column family, so a caller
+	 * iterating through another DBI in the same database passes that DBI's
+	 * handle here. Defaults to the transaction's own column family.
 	 */
-	DBIteratorHandle(TransactionHandle* txnHandle, DBIteratorOptions& options);
+	DBIteratorHandle(
+		TransactionHandle* txnHandle,
+		DBIteratorOptions& options,
+		std::shared_ptr<DBHandle> dbHandleOverride = nullptr
+	);
 
 	/**
 	 * Cleans up the iterator handle.

--- a/src/binding/transaction/transaction_handle.cpp
+++ b/src/binding/transaction/transaction_handle.cpp
@@ -368,11 +368,10 @@ napi_value TransactionHandle::get(
 	// Read against the column family the caller issued the read on, which is not
 	// necessarily the one this transaction was created with. Resolve the column
 	// family here on the JS thread and hold it, so the worker never traverses a
-	// DBHandle that close() may concurrently tear down.
+	// DBHandle that close() may concurrently tear down. The block-cache attempt
+	// above already dereferenced columnDescriptor on this thread, so it is live.
 	state->readDbHandle = dbHandle;
-	if (dbHandle->columnDescriptor) {
-		state->readColumnFamily = dbHandle->columnDescriptor->column;
-	}
+	state->readColumnFamily = dbHandle->columnDescriptor->column;
 	state->vtSlot = vtSlot;
 	state->vtObserved = observedSlot;
 	state->hasExpectedVersion = hasExpectedVersion;
@@ -389,10 +388,11 @@ napi_value TransactionHandle::get(
 			auto state = reinterpret_cast<AsyncGetState<TransactionHandle*>*>(data);
 			// check if database is still open before proceeding
 			auto& readDbHandle = state->readDbHandle;
+			// Abort if either the transaction or the column family being read was
+			// torn down after this work was queued.
 			if (
 				!state->handle
-				|| !readDbHandle
-				|| !state->readColumnFamily
+				|| state->handle->isCancelled()
 				|| !readDbHandle->opened()
 				|| readDbHandle->isCancelled()
 			) {

--- a/src/binding/transaction/transaction_handle.cpp
+++ b/src/binding/transaction/transaction_handle.cpp
@@ -365,6 +365,14 @@ napi_value TransactionHandle::get(
 
 	readOptions.read_tier = rocksdb::kReadAllTier;
 	auto state = new AsyncGetState<TransactionHandle*>(env, this, readOptions, std::move(key));
+	// Read against the column family the caller issued the read on, which is not
+	// necessarily the one this transaction was created with. Resolve the column
+	// family here on the JS thread and hold it, so the worker never traverses a
+	// DBHandle that close() may concurrently tear down.
+	state->readDbHandle = dbHandle;
+	if (dbHandle->columnDescriptor) {
+		state->readColumnFamily = dbHandle->columnDescriptor->column;
+	}
 	state->vtSlot = vtSlot;
 	state->vtObserved = observedSlot;
 	state->hasExpectedVersion = hasExpectedVersion;
@@ -380,12 +388,19 @@ napi_value TransactionHandle::get(
 		[](napi_env doNotUse, void* data) { // execute
 			auto state = reinterpret_cast<AsyncGetState<TransactionHandle*>*>(data);
 			// check if database is still open before proceeding
-			if (!state->handle || !state->handle->dbHandle || !state->handle->dbHandle->opened() || state->handle->dbHandle->isCancelled()) {
+			auto& readDbHandle = state->readDbHandle;
+			if (
+				!state->handle
+				|| !readDbHandle
+				|| !state->readColumnFamily
+				|| !readDbHandle->opened()
+				|| readDbHandle->isCancelled()
+			) {
 				state->status = rocksdb::Status::Aborted("Database closed during transaction get operation");
 			} else {
 				state->status = state->handle->txn->Get(
 					state->readOptions,
-					state->handle->dbHandle->getColumnFamilyHandle(),
+					state->readColumnFamily.get(),
 					state->key,
 					&state->value
 				);
@@ -421,7 +436,8 @@ void TransactionHandle::getCount(
 	uint64_t& count,
 	std::shared_ptr<DBHandle> dbHandleOverride
 ) {
-	std::unique_ptr<DBIteratorHandle> itHandle = std::make_unique<DBIteratorHandle>(this, itOptions);
+	std::unique_ptr<DBIteratorHandle> itHandle =
+		std::make_unique<DBIteratorHandle>(this, itOptions, dbHandleOverride);
 	for (count = 0; itHandle->iterator->Valid(); ++count) {
 		itHandle->iterator->Next();
 	}

--- a/src/binding/transaction/transaction_handle.cpp
+++ b/src/binding/transaction/transaction_handle.cpp
@@ -11,6 +11,70 @@
 
 namespace rocksdb_js {
 
+namespace {
+
+/**
+ * Keeps a target DBHandle open while a transaction resolves and pins that
+ * handle's column descriptor. This bridges the gap between the caller's open
+ * check and the transaction's async-work registration without making the
+ * worker access a concurrently closing DBHandle.
+ */
+struct ScopedAsyncWorkRegistration {
+	AsyncWorkHandle* handle;
+
+	explicit ScopedAsyncWorkRegistration(AsyncWorkHandle* handle)
+		: handle(handle) {
+		if (this->handle) {
+			this->handle->registerAsyncWork();
+		}
+	}
+
+	~ScopedAsyncWorkRegistration() {
+		if (this->handle) {
+			this->handle->unregisterAsyncWork();
+		}
+	}
+
+	ScopedAsyncWorkRegistration(const ScopedAsyncWorkRegistration&) = delete;
+	ScopedAsyncWorkRegistration& operator=(const ScopedAsyncWorkRegistration&) = delete;
+
+	void release() {
+		this->handle = nullptr;
+	}
+};
+
+template<typename State>
+struct PendingAsyncState {
+	napi_env env;
+	State* state;
+
+	PendingAsyncState(napi_env env, State* state)
+		: env(env), state(state) {}
+
+	~PendingAsyncState() {
+		if (!this->state) return;
+		if (this->state->resolveRef) {
+			::napi_delete_reference(this->env, this->state->resolveRef);
+			this->state->resolveRef = nullptr;
+		}
+		if (this->state->rejectRef) {
+			::napi_delete_reference(this->env, this->state->rejectRef);
+			this->state->rejectRef = nullptr;
+		}
+		this->state->deleteAsyncWork();
+		delete this->state;
+	}
+
+	void release() {
+		this->state = nullptr;
+	}
+
+	PendingAsyncState(const PendingAsyncState&) = delete;
+	PendingAsyncState& operator=(const PendingAsyncState&) = delete;
+};
+
+} // namespace
+
 /**
  * Creates a new RocksDB transaction, enables snapshots, and sets the
  * transaction id.
@@ -296,7 +360,12 @@ napi_value TransactionHandle::get(
 	uint64_t expectedVersion,
 	bool wantsPopulate
 ) {
-	if (!this->txn) {
+	// Register before inspecting txn/state. Descriptor-wide close can select the
+	// transaction before the target DBHandle, and close() must not reset txn in
+	// the middle of this setup. Async fallback transfers this registration to its
+	// state; synchronous and failed setup paths release it on return.
+	ScopedAsyncWorkRegistration transactionRegistration(this);
+	if (this->isCancelled() || !this->txn) {
 		::napi_throw_error(env, nullptr, "Transaction is closed");
 		return nullptr;
 	}
@@ -315,6 +384,15 @@ napi_value TransactionHandle::get(
 	napi_value returnStatus;
 	std::string value;
 	std::shared_ptr<DBHandle> dbHandle = dbHandleOverride ? dbHandleOverride : this->dbHandle;
+	// Cross-column-family reads enter through another DBHandle. Register against
+	// that handle while copying its descriptor so a concurrent close cannot reset
+	// columnDescriptor in the gap between the caller's open check and this read.
+	ScopedAsyncWorkRegistration targetHandleRegistration(dbHandleOverride.get());
+	if (dbHandleOverride && dbHandle->isCancelled()) {
+		::napi_throw_error(env, nullptr, "Database closed during transaction get operation");
+		return nullptr;
+	}
+	auto readColumnDescriptor = dbHandle->columnDescriptor;
 
 	rocksdb::ReadOptions readOptions;
 	if (this->snapshotSet) {
@@ -324,7 +402,7 @@ napi_value TransactionHandle::get(
 
 	rocksdb::Status status = this->txn->Get(
 		readOptions,
-		dbHandle->getColumnFamilyHandle(),
+		readColumnDescriptor->column.get(),
 		key,
 		&value
 	);
@@ -365,13 +443,14 @@ napi_value TransactionHandle::get(
 
 	readOptions.read_tier = rocksdb::kReadAllTier;
 	auto state = new AsyncGetState<TransactionHandle*>(env, this, readOptions, std::move(key));
-	// Read against the column family the caller issued the read on, which is not
-	// necessarily the one this transaction was created with. Resolve the column
-	// family here on the JS thread and hold it, so the worker never traverses a
-	// DBHandle that close() may concurrently tear down. The block-cache attempt
-	// above already dereferenced columnDescriptor on this thread, so it is live.
-	state->readDbHandle = dbHandle;
-	state->readColumnFamily = dbHandle->columnDescriptor->column;
+	// Until the transaction registration is transferred below, setup failures
+	// must delete this state without unregistering work it does not own.
+	state->completed.store(true);
+	PendingAsyncState pendingState(env, state);
+	// Resolve and pin the caller's column family on the JS thread. The worker
+	// releases this descriptor before signaling completion so the native column
+	// family handle cannot outlive its RocksDB database during teardown.
+	state->readColumnDescriptor = std::move(readColumnDescriptor);
 	state->vtSlot = vtSlot;
 	state->vtObserved = observedSlot;
 	state->hasExpectedVersion = hasExpectedVersion;
@@ -386,25 +465,17 @@ napi_value TransactionHandle::get(
 		name,      // async_resource_name
 		[](napi_env doNotUse, void* data) { // execute
 			auto state = reinterpret_cast<AsyncGetState<TransactionHandle*>*>(data);
-			// check if database is still open before proceeding
-			auto& readDbHandle = state->readDbHandle;
-			// Abort if either the transaction or the column family being read was
-			// torn down after this work was queued.
-			if (
-				!state->handle
-				|| state->handle->isCancelled()
-				|| !readDbHandle->opened()
-				|| readDbHandle->isCancelled()
-			) {
+			if (!state->handle || state->handle->isCancelled()) {
 				state->status = rocksdb::Status::Aborted("Database closed during transaction get operation");
 			} else {
 				state->status = state->handle->txn->Get(
 					state->readOptions,
-					state->readColumnFamily.get(),
+					state->readColumnDescriptor->column.get(),
 					state->key,
 					&state->value
 				);
 			}
+			state->readColumnDescriptor.reset();
 			// signal that execute handler is complete
 			state->signalExecuteCompleted();
 		},
@@ -422,10 +493,14 @@ napi_value TransactionHandle::get(
 		&state->asyncWork // -> result
 	));
 
-	// register the async work with the transaction handle
-	this->registerAsyncWork();
-
+	// Transfer the registration claimed at function entry to the queued state.
+	// If queueing fails, PendingAsyncState deletes the state, whose base
+	// destructor releases the registration and whose derived members release the
+	// column descriptor first.
+	state->completed.store(false);
+	transactionRegistration.release();
 	NAPI_STATUS_THROWS(::napi_queue_async_work(env, state->asyncWork));
+	pendingState.release();
 
 	NAPI_STATUS_THROWS(::napi_create_uint32(env, 1, &returnStatus));
 	return returnStatus;
@@ -436,6 +511,11 @@ void TransactionHandle::getCount(
 	uint64_t& count,
 	std::shared_ptr<DBHandle> dbHandleOverride
 ) {
+	this->ensureSnapshot();
+	if (this->snapshotSet) {
+		itOptions.readOptions.snapshot = this->txn->GetSnapshot();
+	}
+
 	std::unique_ptr<DBIteratorHandle> itHandle =
 		std::make_unique<DBIteratorHandle>(this, itOptions, dbHandleOverride);
 	for (count = 0; itHandle->iterator->Valid(); ++count) {

--- a/test/transaction-cross-column-family.test.ts
+++ b/test/transaction-cross-column-family.test.ts
@@ -125,6 +125,29 @@ describe('transaction reads across column families', () => {
 		}
 	});
 
+	it('finishes queued reads after the target column family handle closes', async () => {
+		const { db, other, third } = await seedAndReopen();
+		try {
+			await db.transaction(async (txn: Transaction) => {
+				const reads = Array.from({ length: 25 }, (_, i) =>
+					other.get(`key-${i}`, { transaction: txn })
+				);
+
+				// Transactional reads register against the transaction, not this DBI.
+				// Closing the caller must not invalidate the descriptor already pinned
+				// by the queued workers.
+				other.close();
+				await expect(Promise.all(reads)).resolves.toEqual(
+					Array.from({ length: 25 }, (_, i) => `value-${i}`)
+				);
+			});
+		} finally {
+			third.close();
+			other.close();
+			db.close();
+		}
+	});
+
 	it('getKeysCount on another column family counts that column family', async () => {
 		const { db, other, third } = await seedAndReopen();
 		try {
@@ -133,7 +156,22 @@ describe('transaction reads across column families', () => {
 				expect(other.getKeysCount({ transaction: txn })).toBe(25);
 				expect(third.getKeysCount({ transaction: txn })).toBe(25);
 				expect(db.getKeysCount({ transaction: txn })).toBe(26);
+
+				// The first count establishes the transaction snapshot. A committed
+				// write outside the transaction must not change subsequent counts.
+				await other.put('after-snapshot', 'new-value');
+				expect(other.getKeysCount({ transaction: txn })).toBe(25);
 			});
+			expect(other.getKeysCount()).toBe(26);
+
+			await db.transaction(
+				async (txn: Transaction) => {
+					expect(other.getKeysCount({ transaction: txn })).toBe(26);
+					await other.put('latest-value', 'newer-value');
+					expect(other.getKeysCount({ transaction: txn })).toBe(27);
+				},
+				{ disableSnapshot: true }
+			);
 		} finally {
 			third.close();
 			other.close();

--- a/test/transaction-cross-column-family.test.ts
+++ b/test/transaction-cross-column-family.test.ts
@@ -1,0 +1,88 @@
+import { RocksDatabase } from '../src/database.js';
+import type { Transaction } from '../src/transaction.js';
+import { generateDBPath } from './lib/util.js';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * A transaction belongs to a *database*, so it must serve reads on any column
+ * family in that database — not only the one it was created against.
+ *
+ * `TransactionHandle::get` attempts a synchronous block-cache read first and
+ * only falls back to async work when that misses, so these tests reopen the
+ * database to guarantee a cold block cache. Reading a value still resident in
+ * the block cache takes the synchronous path and passes even when the async
+ * path is broken.
+ */
+describe('transaction reads across column families', () => {
+	async function seedAndReopen() {
+		const path = generateDBPath();
+		let db = new RocksDatabase(path);
+		let other = new RocksDatabase(path, { name: 'other' });
+		db.open();
+		other.open();
+		await db.put('anchor', 'anchor-value');
+		for (let i = 0; i < 25; i++) {
+			await other.put(`key-${i}`, `value-${i}`);
+		}
+		// push the records out of the memtable and into SSTs
+		await other.compact();
+		await db.compact();
+		other.close();
+		db.close();
+
+		// reopening drops the block cache, so the first read of each key misses
+		// the block-cache tier and takes the async path under test
+		db = new RocksDatabase(path);
+		other = new RocksDatabase(path, { name: 'other' });
+		db.open();
+		other.open();
+		return { db, other };
+	}
+
+	it('async get on another column family returns the record with a cold block cache', async () => {
+		const { db, other } = await seedAndReopen();
+		try {
+			await db.transaction(async (txn: Transaction) => {
+				// the transaction was created against `db`'s column family; every
+				// read below is issued on `other`'s
+				const values: (string | undefined)[] = [];
+				for (let i = 0; i < 25; i++) {
+					values.push(await other.get(`key-${i}`, { transaction: txn }));
+				}
+				expect(values).toEqual(Array.from({ length: 25 }, (_, i) => `value-${i}`));
+			});
+		} finally {
+			other.close();
+			db.close();
+		}
+	});
+
+	it("async get on another column family does not read the transaction's own column family", async () => {
+		const { db, other } = await seedAndReopen();
+		try {
+			await db.transaction(async (txn: Transaction) => {
+				// 'anchor' exists only in db's column family. Reading it through
+				// `other` must report not-found rather than resolving against the
+				// transaction's own column family.
+				expect(await other.get('anchor', { transaction: txn })).toBeUndefined();
+			});
+		} finally {
+			other.close();
+			db.close();
+		}
+	});
+
+	it('getKeysCount on another column family counts that column family', async () => {
+		const { db, other } = await seedAndReopen();
+		try {
+			await db.transaction(async (txn: Transaction) => {
+				// db's column family holds exactly one key ('anchor'); other's holds 25
+				expect(other.getKeysCount({ transaction: txn })).toBe(25);
+				expect(db.getKeysCount({ transaction: txn })).toBe(1);
+			});
+		} finally {
+			other.close();
+			db.close();
+		}
+	});
+});

--- a/test/transaction-cross-column-family.test.ts
+++ b/test/transaction-cross-column-family.test.ts
@@ -18,15 +18,21 @@ describe('transaction reads across column families', () => {
 		const path = generateDBPath();
 		let db = new RocksDatabase(path);
 		let other = new RocksDatabase(path, { name: 'other' });
+		let third = new RocksDatabase(path, { name: 'third' });
 		db.open();
 		other.open();
+		third.open();
 		await db.put('anchor', 'anchor-value');
 		for (let i = 0; i < 25; i++) {
+			await db.put(`own-${i}`, `own-value-${i}`);
 			await other.put(`key-${i}`, `value-${i}`);
+			await third.put(`third-${i}`, `third-value-${i}`);
 		}
 		// push the records out of the memtable and into SSTs
 		await other.compact();
+		await third.compact();
 		await db.compact();
+		third.close();
 		other.close();
 		db.close();
 
@@ -34,13 +40,15 @@ describe('transaction reads across column families', () => {
 		// the block-cache tier and takes the async path under test
 		db = new RocksDatabase(path);
 		other = new RocksDatabase(path, { name: 'other' });
+		third = new RocksDatabase(path, { name: 'third' });
 		db.open();
 		other.open();
-		return { db, other };
+		third.open();
+		return { db, other, third };
 	}
 
 	it('async get on another column family returns the record with a cold block cache', async () => {
-		const { db, other } = await seedAndReopen();
+		const { db, other, third } = await seedAndReopen();
 		try {
 			await db.transaction(async (txn: Transaction) => {
 				// the transaction was created against `db`'s column family; every
@@ -52,13 +60,14 @@ describe('transaction reads across column families', () => {
 				expect(values).toEqual(Array.from({ length: 25 }, (_, i) => `value-${i}`));
 			});
 		} finally {
+			third.close();
 			other.close();
 			db.close();
 		}
 	});
 
 	it("async get on another column family does not read the transaction's own column family", async () => {
-		const { db, other } = await seedAndReopen();
+		const { db, other, third } = await seedAndReopen();
 		try {
 			await db.transaction(async (txn: Transaction) => {
 				// 'anchor' exists only in db's column family. Reading it through
@@ -67,20 +76,66 @@ describe('transaction reads across column families', () => {
 				expect(await other.get('anchor', { transaction: txn })).toBeUndefined();
 			});
 		} finally {
+			third.close();
+			other.close();
+			db.close();
+		}
+	});
+
+	// Reading the transaction's own column family must not poison the reads that
+	// follow on another one, and vice versa. A single foreign read per transaction
+	// would not catch an override that is applied once and then latches.
+	it('alternates between the own and a foreign column family within one transaction', async () => {
+		const { db, other, third } = await seedAndReopen();
+		try {
+			await db.transaction(async (txn: Transaction) => {
+				for (let i = 0; i < 10; i++) {
+					expect(await db.get(`own-${i}`, { transaction: txn })).toBe(`own-value-${i}`);
+					expect(await other.get(`key-${i}`, { transaction: txn })).toBe(`value-${i}`);
+				}
+				// and the own column family still reads correctly afterwards
+				expect(await db.get('anchor', { transaction: txn })).toBe('anchor-value');
+			});
+		} finally {
+			third.close();
+			other.close();
+			db.close();
+		}
+	});
+
+	// The reported failure aggregated four tables in one request, so cover more
+	// than a single foreign column family per transaction.
+	it('reads three column families within one transaction', async () => {
+		const { db, other, third } = await seedAndReopen();
+		try {
+			await db.transaction(async (txn: Transaction) => {
+				for (let i = 0; i < 10; i++) {
+					expect(await other.get(`key-${i}`, { transaction: txn })).toBe(`value-${i}`);
+					expect(await third.get(`third-${i}`, { transaction: txn })).toBe(`third-value-${i}`);
+					expect(await db.get(`own-${i}`, { transaction: txn })).toBe(`own-value-${i}`);
+				}
+				// each column family sees only its own keys
+				expect(await third.get('anchor', { transaction: txn })).toBeUndefined();
+				expect(await other.get('third-0', { transaction: txn })).toBeUndefined();
+			});
+		} finally {
+			third.close();
 			other.close();
 			db.close();
 		}
 	});
 
 	it('getKeysCount on another column family counts that column family', async () => {
-		const { db, other } = await seedAndReopen();
+		const { db, other, third } = await seedAndReopen();
 		try {
 			await db.transaction(async (txn: Transaction) => {
-				// db's column family holds exactly one key ('anchor'); other's holds 25
+				// db holds 'anchor' plus 25 own-* keys; the other two hold 25 each
 				expect(other.getKeysCount({ transaction: txn })).toBe(25);
-				expect(db.getKeysCount({ transaction: txn })).toBe(1);
+				expect(third.getKeysCount({ transaction: txn })).toBe(25);
+				expect(db.getKeysCount({ transaction: txn })).toBe(26);
 			});
 		} finally {
+			third.close();
 			other.close();
 			db.close();
 		}


### PR DESCRIPTION
Backports [Resolve transaction reads against the caller's column family (#717)](https://github.com/HarperFast/rocksdb-js/pull/717) onto the `v2.4.x` release branch via cherry-pick.

## Commits
- `fix(transaction): resolve reads against the caller's column family`
- `fix(transaction): abort async get when the transaction is cancelled`
- `test(transaction): cover interleaved and three-way cross-CF reads`
- `fix(database): register async work for the async get`
- `Harden cross-column-family transaction reads`

## Notes
- The only conflict was in `AGENTS.md`: the merge context pulled in unrelated notes (the backup restore/shared-lock rewrite and the disk-space preflight item) that live on `main` but are not part of #717. Resolved by keeping the v2.4.0 text and adding only #717's new note, renumbered to item 8 to fit the v2.4.x list.
- No `package.json` version bump — the release script handles that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
