### PR TITLE
Configurable RocksDB compression

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,6 +85,18 @@ N-API surface remains covered by Vitest (`test/*.test.ts`). Native tests live in
    (`src/binding/database/backup.cpp`). Creating a backup is the `Database::Backup` instance
    method (needs the open DB); restore/list/delete/purge/verify are module-level functions
    operating on a backup directory with no open DB.
+6. **Compression**: a per-column-family open option (`compression`), resolved in the TS Store layer
+   (`normalizeCompression`) to a native string + level and applied in the native CF-options builders
+   (`applyCompression` in `napi/helpers.cpp`, used by both `DBDescriptor::open` and
+   `createRocksDBColumnFamily`). Two non-obvious points: (a) the algorithm is applied to **both**
+   `ColumnFamilyOptions::compression` (SST blocks) **and** `blob_compression_type` — this codebase
+   enables blob files for values ≥ 2KB, and blob compression defaults to none, so setting only the
+   block compression would leave large values uncompressed; (b) the default is **LZ4** (overriding
+   RocksDB's own Snappy default), but the set of algorithms is build-dependent, so the default
+   falls back to RocksDB's default when LZ4 isn't linked. `supportedCompression` (a module constant
+   built from `rocksdb::GetSupportedCompressions()`) is the source of truth; name↔enum mapping and
+   the supported list live in the Node-free `core/compression.{h,cpp}` (GoogleTest-covered). The
+   `db.compression` getter reads the live value via `DB::GetOptions`.
 
 ### Transaction Architecture
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,14 +99,23 @@ N-API surface remains covered by Vitest (`test/*.test.ts`). Native tests live in
      the caller's request **only** to the target CF (`options.name`) — and only when it was
      _explicitly_ requested. A cold open of one CF must never restamp the others (that was the bug
      Kris caught: first-open order used to dictate every CF's algorithm). New CFs
-     (`createRocksDBColumnFamily`) get the request/default.
+     (`createRocksDBColumnFamily`) get the request/default. Because the OPTIONS file is the _only_
+     authoritative source, a non-OK `LoadLatestOptions` for an **existing** DB (missing/corrupt
+     OPTIONS) **fails the open** rather than falling back to defaults — falling back would reopen the
+     non-target CFs with the base default and silently restamp them. Applying an explicit algorithm
+     **without** a level resets `compression_opts.level` to `kDefaultCompressionLevel` (it must not
+     inherit the target CF's persisted level, e.g. cold-reopening a zstd-level-19 CF as zlib).
    - The default is **LZ4** (overriding RocksDB's Snappy default), applied natively in
      `Database::Open` when unset; build-dependent, so it falls back to RocksDB's default when LZ4
      isn't linked. The default is marked **non-explicit** (`DBOptions::compressionExplicit`) so it
      never overrides an existing CF and a plain reopen inherits the live value.
    - A second in-process open of an already-open CF (the `DBDescriptor` is process-global, shared
-     across handles/`worker_threads`) with an **explicitly different** algorithm _or_ level is
-     **rejected** (throws in `DBRegistry::OpenDB`, comparing both against the live `GetOptions`).
+     across handles/`worker_threads`) with an **explicitly different** algorithm, blob algorithm, _or_
+     level is **rejected** (throws in `DBRegistry::OpenDB`, comparing all three against the live
+     `GetOptions`). The level compared is the _effective_ request — omitting a level means
+     `kDefaultCompressionLevel`, not "inherit" — and the blob check catches a legacy CF opened plainly
+     with `block=snappy`/`blob=none` that a later explicit `snappy` open would otherwise leave with
+     uncompressed blobs.
    - `supportedCompression` (module constant from `rocksdb::GetSupportedCompressions()`) is the
      source of truth; name↔enum mapping lives in the Node-free `core/compression.{h,cpp}`
      (GoogleTest-covered). The `db.compression` getter returns `{ algorithm, level? }` read live via

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,18 +85,22 @@ N-API surface remains covered by Vitest (`test/*.test.ts`). Native tests live in
    (`src/binding/database/backup.cpp`). Creating a backup is the `Database::Backup` instance
    method (needs the open DB); restore/list/delete/purge/verify are module-level functions
    operating on a backup directory with no open DB.
-6. **Compression**: a per-column-family open option (`compression`), resolved in the TS Store layer
-   (`normalizeCompression`) to a native string + level and applied in the native CF-options builders
-   (`applyCompression` in `napi/helpers.cpp`, used by both `DBDescriptor::open` and
-   `createRocksDBColumnFamily`). Two non-obvious points: (a) the algorithm is applied to **both**
-   `ColumnFamilyOptions::compression` (SST blocks) **and** `blob_compression_type` — this codebase
-   enables blob files for values ≥ 2KB, and blob compression defaults to none, so setting only the
-   block compression would leave large values uncompressed; (b) the default is **LZ4** (overriding
-   RocksDB's own Snappy default), but the set of algorithms is build-dependent, so the default
-   falls back to RocksDB's default when LZ4 isn't linked. `supportedCompression` (a module constant
-   built from `rocksdb::GetSupportedCompressions()`) is the source of truth; name↔enum mapping and
-   the supported list live in the Node-free `core/compression.{h,cpp}` (GoogleTest-covered). The
-   `db.compression` getter reads the live value via `DB::GetOptions`.
+6. **Compression**: a per-column-family open option (`compression`), normalized in the TS Store layer
+   (`normalizeCompression`) to a native string + level, then applied to the column-family options in
+   both CF-build sites (`DBDescriptor::open` for existing/first CFs and `createRocksDBColumnFamily`
+   for later ones — the small apply block is inlined verbatim in each). Non-obvious points: (a) the
+   algorithm is applied to **both** `ColumnFamilyOptions::compression` (SST blocks) **and**
+   `blob_compression_type` — this codebase enables blob files for values ≥ 2KB, and blob compression
+   defaults to none, so setting only the block compression would leave large values uncompressed;
+   (b) the default is **LZ4** (overriding RocksDB's own Snappy default), applied natively in
+   `Database::Open` when the option is unset — but the set of algorithms is build-dependent, so the
+   default falls back to RocksDB's default when LZ4 isn't linked. The native default is marked
+   non-explicit (`DBOptions::compressionExplicit`) so a second in-process open of an already-open
+   column family only rejects (throws in `DBRegistry::OpenDB`) when the caller _explicitly_ requests
+   a different algorithm — a plain reopen inherits the live setting. `supportedCompression` (a module
+   constant built from `rocksdb::GetSupportedCompressions()`) is the source of truth; name↔enum
+   mapping and the supported list live in the Node-free `core/compression.{h,cpp}` (GoogleTest-
+   covered). The `db.compression` getter reads the live value via `DB::GetOptions`.
 
 ### Transaction Architecture
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,22 +85,36 @@ N-API surface remains covered by Vitest (`test/*.test.ts`). Native tests live in
    (`src/binding/database/backup.cpp`). Creating a backup is the `Database::Backup` instance
    method (needs the open DB); restore/list/delete/purge/verify are module-level functions
    operating on a backup directory with no open DB.
-6. **Compression**: a per-column-family open option (`compression`), normalized in the TS Store layer
-   (`normalizeCompression`) to a native string + level, then applied to the column-family options in
-   both CF-build sites (`DBDescriptor::open` for existing/first CFs and `createRocksDBColumnFamily`
-   for later ones — the small apply block is inlined verbatim in each). Non-obvious points: (a) the
-   algorithm is applied to **both** `ColumnFamilyOptions::compression` (SST blocks) **and**
-   `blob_compression_type` — this codebase enables blob files for values ≥ 2KB, and blob compression
-   defaults to none, so setting only the block compression would leave large values uncompressed;
-   (b) the default is **LZ4** (overriding RocksDB's own Snappy default), applied natively in
-   `Database::Open` when the option is unset — but the set of algorithms is build-dependent, so the
-   default falls back to RocksDB's default when LZ4 isn't linked. The native default is marked
-   non-explicit (`DBOptions::compressionExplicit`) so a second in-process open of an already-open
-   column family only rejects (throws in `DBRegistry::OpenDB`) when the caller _explicitly_ requests
-   a different algorithm — a plain reopen inherits the live setting. `supportedCompression` (a module
-   constant built from `rocksdb::GetSupportedCompressions()`) is the source of truth; name↔enum
-   mapping and the supported list live in the Node-free `core/compression.{h,cpp}` (GoogleTest-
-   covered). The `db.compression` getter reads the live value via `DB::GetOptions`.
+6. **Compression**: a **per-column-family** open option (`compression`), normalized in the TS Store
+   layer (`normalizeCompression` — string | `{algorithm, level}` → native string + validated int32
+   level) and applied to the target CF's options. Non-obvious points:
+   - The algorithm is applied to **both** `ColumnFamilyOptions::compression` (SST blocks) **and**
+     `blob_compression_type` — this codebase enables blob files for values ≥ 2KB, and blob
+     compression defaults to none, so setting only block compression leaves large values
+     uncompressed. `compression_opts.level` carries an optional level.
+   - **Per-CF preservation is load-bearing and easy to get wrong.** RocksDB requires opening _every_
+     CF at once with the options you pass, and does **not** restore persisted per-CF options on its
+     own. So `DBDescriptor::open` calls `LoadLatestOptions` (`rocksdb/utilities/options_util.h`) to
+     read each existing CF's persisted compression, opens each CF with _its own_ value, and applies
+     the caller's request **only** to the target CF (`options.name`) — and only when it was
+     _explicitly_ requested. A cold open of one CF must never restamp the others (that was the bug
+     Kris caught: first-open order used to dictate every CF's algorithm). New CFs
+     (`createRocksDBColumnFamily`) get the request/default.
+   - The default is **LZ4** (overriding RocksDB's Snappy default), applied natively in
+     `Database::Open` when unset; build-dependent, so it falls back to RocksDB's default when LZ4
+     isn't linked. The default is marked **non-explicit** (`DBOptions::compressionExplicit`) so it
+     never overrides an existing CF and a plain reopen inherits the live value.
+   - A second in-process open of an already-open CF (the `DBDescriptor` is process-global, shared
+     across handles/`worker_threads`) with an **explicitly different** algorithm _or_ level is
+     **rejected** (throws in `DBRegistry::OpenDB`, comparing both against the live `GetOptions`).
+   - `supportedCompression` (module constant from `rocksdb::GetSupportedCompressions()`) is the
+     source of truth; name↔enum mapping lives in the Node-free `core/compression.{h,cpp}`
+     (GoogleTest-covered). The `db.compression` getter returns `{ algorithm, level? }` read live via
+     `DB::GetOptions` (level omitted when it is the default sentinel).
+   - `scripts/configure-rocksdb.mjs` (run by `binding.gyp` at configure) provisions the pinned
+     prebuild then emits the compression libs to link as **whitespace-free** `-l` flags / `.lib`
+     names (never absolute paths), resolved via a single `library_dirs` entry — so a repo checked
+     out under a path with spaces still links (gyp `<!@()` splits output on whitespace).
 
 ### Transaction Architecture
 

--- a/README.md
+++ b/README.md
@@ -120,15 +120,16 @@ const db2 = new RocksDatabase('path/to/db', { name: 'users' });
 console.log(db.columns); // ['default', 'users']
 ```
 
-### `db.compression: string`
+### `db.compression: { algorithm: string, level?: number }`
 
-Returns the compression algorithm currently in effect for this database's column family, read live
-from RocksDB (e.g. `'lz4'`, `'zstd'`, `'none'`). The database must be open. See
+Returns the compression currently in effect for this database's column family, read live from
+RocksDB. `algorithm` is a friendly name (e.g. `'lz4'`, `'zstd'`, `'none'`); `level` is present only
+when a non-default compression level is set. The database must be open. See
 [Compression](#compression).
 
 ```typescript
-const db = RocksDatabase.open('path/to/db', { compression: 'zstd' });
-console.log(db.compression); // 'zstd'
+const db = RocksDatabase.open('path/to/db', { compression: { algorithm: 'zstd', level: 3 } });
+console.log(db.compression); // { algorithm: 'zstd', level: 3 }
 ```
 
 ### `db.config(options)`
@@ -969,18 +970,25 @@ const db3 = RocksDatabase.open('/path/to/db3', { compression: 'none' });
 supports it. LZ4 is fast with a modest compression ratio, making it a good general-purpose default.
 If LZ4 is not compiled in, the default falls back to RocksDB's own default — Snappy when it is
 linked, otherwise no compression. (RocksDB's stock default is Snappy; `rocksdb-js` overrides it to
-LZ4.) Read the algorithm actually in effect with the [`db.compression`](#dbcompression-string)
-getter.
+LZ4.) Read the algorithm actually in effect with the `db.compression` getter.
 
 **Availability.** The set of algorithms depends on which compression libraries the native binding
 was compiled against, so it varies by build. Always check
 [`supportedCompression`](#supportedcompression) at runtime — opening with an unavailable algorithm
 throws. `'none'` is always available.
 
-**Scope and mutability.** Compression is a per-column-family, dynamically-changeable setting.
-Reopening a database with a different algorithm governs files written afterward; existing SST/blob
-files keep their original compression until they are rewritten by compaction. It also applies to
-blob files (large values), whose compression otherwise defaults to none.
+**Scope and mutability.** Compression is genuinely **per-column-family**. Each `RocksDatabase`
+targets one column family (`name`), and its `compression` applies only to that CF — opening one CF
+never changes another's algorithm, regardless of open order. A column family keeps its own
+compression across a close/reopen (a plain reopen inherits it); the algorithm is dynamically
+changeable, so an explicit change governs files written afterward while existing SST/blob files keep
+their original compression until rewritten by compaction. It also applies to blob files (large
+values), whose compression otherwise defaults to none.
+
+Because a column family's compression is fixed while it is open, if the same column family is opened
+a second time in the same process (another `RocksDatabase` on the same path/`name`, including from a
+`worker_thread`) with an **explicitly different** algorithm or level, the second open **throws** — a
+plain reopen (no `compression`) instead inherits the live setting.
 
 ### `supportedCompression`
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Creates a new database instance.
 - `options: object` [optional]
   - `compression: string | { algorithm: string, level?: number }` The block/blob compression
     algorithm for this column family. Pass an algorithm name — one of `'none'`, `'snappy'`,
-    `'zlib'`, `'bzip2'`, `'lz4'`, `'lz4hc'`, `'xpress'`, or `'zstd'` — or an object with an
+    `'zlib'`, `'bzip2'`, `'lz4'`, `'lz4hc'`, or `'zstd'` — or an object with an
     `algorithm` and an optional `level` (forwarded to RocksDB's `compression_opts.level`; the
     meaning is algorithm-specific). Applies to both SST data blocks and blob files (large values).
     Defaults to `'lz4'` when the native build supports it, otherwise RocksDB's own default (Snappy
@@ -950,7 +950,6 @@ build — see **Availability** below.
 | `bzip2`  | High ratio, slow; rarely worth it over zstd.                                  |
 | `lz4`    | Very fast, modest ratio. `rocksdb-js` default when available.                 |
 | `lz4hc`  | LZ4 high-compression variant: better ratio, slower writes, same fast reads.   |
-| `xpress` | Windows-only (Microsoft Xpress).                                              |
 | `zstd`   | Best ratio-for-speed of the set; supports `level` (higher = smaller, slower). |
 
 Set the algorithm per column family with the `compression` option when opening a database:

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A Node.js binding for the RocksDB library.
 - Transaction log system for recording transaction related data
 - Custom stores provide ability to override default database interactions
 - Efficient binary key and value encoding
+- Configurable block/blob compression (LZ4, Zstd, Zlib, and more)
 - Access to internal RocksDB statistics
 - Designed for Node.js and Bun on Linux, macOS, and Windows
 
@@ -43,6 +44,15 @@ Creates a new database instance.
 - `path: string` The path to write the database files to. This path does not need to exist, but the
   parent directories do.
 - `options: object` [optional]
+  - `compression: string | { algorithm: string, level?: number }` The block/blob compression
+    algorithm for this column family. Pass an algorithm name — one of `'none'`, `'snappy'`,
+    `'zlib'`, `'bzip2'`, `'lz4'`, `'lz4hc'`, `'xpress'`, or `'zstd'` — or an object with an
+    `algorithm` and an optional `level` (forwarded to RocksDB's `compression_opts.level`; the
+    meaning is algorithm-specific). Applies to both SST data blocks and blob files (large values).
+    Defaults to `'lz4'` when the native build supports it, otherwise RocksDB's own default (Snappy
+    when linked, else no compression). See [Compression](#compression). Throws if the algorithm is
+    not compiled into the native build — check [`supportedCompression`](#supportedcompression) for
+    the available list.
   - `disableWAL: boolean` Whether to disable the RocksDB write ahead log. Defaults to `false`.
   - `enableStats: boolean` When `true` and the database is open, RocksDB will captures stats that
     are retrieved by calling `db.getStats()`. Enabling statistics imposes 5-10% in overhead.
@@ -108,6 +118,17 @@ console.log(db.columns); // ['default']
 
 const db2 = new RocksDatabase('path/to/db', { name: 'users' });
 console.log(db.columns); // ['default', 'users']
+```
+
+### `db.compression: string`
+
+Returns the compression algorithm currently in effect for this database's column family, read live
+from RocksDB (e.g. `'lz4'`, `'zstd'`, `'none'`). The database must be open. See
+[Compression](#compression).
+
+```typescript
+const db = RocksDatabase.open('path/to/db', { compression: 'zstd' });
+console.log(db.compression); // 'zstd'
 ```
 
 ### `db.config(options)`
@@ -911,6 +932,71 @@ An object is a record with the following properties:
 - `percentile99: number` A double containing the 99th percentile value.
 - `standardDeviation: number` A double containing the standard deviation.
 - `sum: number` An unsigned 64-bit integer containing the sum of all values.
+
+## Compression
+
+RocksDB compresses data blocks in SST files (and, in `rocksdb-js`, blob files that hold large
+values) using a configurable algorithm. Compression trades CPU for disk space and, because it
+reduces bytes read from disk, often improves read throughput on I/O-bound workloads.
+
+The following algorithm names are recognized. Which ones are actually usable depends on the native
+build — see **Availability** below.
+
+| Name     | Notes                                                                         |
+| -------- | ----------------------------------------------------------------------------- |
+| `none`   | No compression. Always available.                                             |
+| `snappy` | Fast, modest ratio. RocksDB's own stock default when linked.                  |
+| `zlib`   | Higher ratio, slower. Supports `level` (see zlib's manual).                   |
+| `bzip2`  | High ratio, slow; rarely worth it over zstd.                                  |
+| `lz4`    | Very fast, modest ratio. `rocksdb-js` default when available.                 |
+| `lz4hc`  | LZ4 high-compression variant: better ratio, slower writes, same fast reads.   |
+| `xpress` | Windows-only (Microsoft Xpress).                                              |
+| `zstd`   | Best ratio-for-speed of the set; supports `level` (higher = smaller, slower). |
+
+Set the algorithm per column family with the `compression` option when opening a database:
+
+```typescript
+// Algorithm name
+const db = RocksDatabase.open('/path/to/db', { compression: 'zstd' });
+
+// Or an object with an explicit level
+const db2 = RocksDatabase.open('/path/to/db2', { compression: { algorithm: 'zstd', level: 3 } });
+
+// Disable compression entirely
+const db3 = RocksDatabase.open('/path/to/db3', { compression: 'none' });
+```
+
+**Default.** When `compression` is omitted, `rocksdb-js` defaults to **LZ4** if the native build
+supports it. LZ4 is fast with a modest compression ratio, making it a good general-purpose default.
+If LZ4 is not compiled in, the default falls back to RocksDB's own default — Snappy when it is
+linked, otherwise no compression. (RocksDB's stock default is Snappy; `rocksdb-js` overrides it to
+LZ4.) Read the algorithm actually in effect with the [`db.compression`](#dbcompression-string)
+getter.
+
+**Availability.** The set of algorithms depends on which compression libraries the native binding
+was compiled against, so it varies by build. Always check
+[`supportedCompression`](#supportedcompression) at runtime — opening with an unavailable algorithm
+throws. `'none'` is always available.
+
+**Scope and mutability.** Compression is a per-column-family, dynamically-changeable setting.
+Reopening a database with a different algorithm governs files written afterward; existing SST/blob
+files keep their original compression until they are rewritten by compaction. It also applies to
+blob files (large values), whose compression otherwise defaults to none.
+
+### `supportedCompression`
+
+A module-level, frozen array of the compression algorithm names compiled into the loaded native
+binding. The set is fixed for a given binary. `'none'` is always present.
+
+```typescript
+import { supportedCompression } from '@harperfast/rocksdb-js';
+
+console.log(supportedCompression); // e.g. ['none', 'snappy', 'lz4', 'zstd']
+
+if (supportedCompression.includes('zstd')) {
+	// safe to open with { compression: 'zstd' }
+}
+```
 
 ## Exclusive Locking
 

--- a/benchmark/compression.bench.ts
+++ b/benchmark/compression.bench.ts
@@ -1,0 +1,80 @@
+import { type CompressionAlgorithm, supportedCompression } from '../dist/index.mjs';
+import { benchmark } from './setup.js';
+import { describe } from 'vitest';
+
+/**
+ * RocksDB-only benchmark comparing the write/read throughput of each
+ * compression algorithm compiled into the native build. The set of algorithms
+ * varies by build (see `supportedCompression`), so the benchmark iterates over
+ * whatever is available — e.g. a minimal build may only expose `none` and
+ * `zlib`, while a full build adds `snappy`, `lz4`, `zstd`, etc.
+ *
+ * Pair the timings here with the on-disk size assertions in
+ * `test/compression.test.ts` to reason about the space/speed tradeoff.
+ */
+
+const RECORD_COUNT = 5000;
+
+type Record = { key: number; value: unknown };
+
+// Compressible, realistic-ish JSON records: repetitive text compresses well,
+// which is what makes the algorithm differences observable. Values exceed the
+// 2 KB blob threshold so blob-file compression is exercised alongside SST
+// block compression.
+function makeRecords(count: number): Record[] {
+	const filler = 'the quick brown fox jumps over the lazy dog '.repeat(48);
+	const records: Record[] = [];
+	for (let i = 0; i < count; i++) {
+		records.push({
+			key: i,
+			value: {
+				id: i,
+				name: `record-${i}`,
+				note: filler,
+				tags: ['alpha', 'beta', 'gamma', 'delta'],
+			},
+		});
+	}
+	return records;
+}
+
+describe(`compression - write ${RECORD_COUNT} compressible records`, () => {
+	for (const algorithm of supportedCompression as readonly CompressionAlgorithm[]) {
+		benchmark('rocksdb', {
+			name: algorithm,
+			dbOptions: { compression: algorithm },
+			setup(ctx) {
+				ctx.records = makeRecords(RECORD_COUNT);
+			},
+			bench({ db, records }) {
+				for (const r of records as Record[]) {
+					db.putSync(r.key, r.value);
+				}
+				db.flushSync();
+			},
+		});
+	}
+});
+
+describe(`compression - read ${RECORD_COUNT} compressible records`, () => {
+	for (const algorithm of supportedCompression as readonly CompressionAlgorithm[]) {
+		benchmark('rocksdb', {
+			name: algorithm,
+			dbOptions: { compression: algorithm },
+			setup(ctx) {
+				const records = makeRecords(RECORD_COUNT);
+				for (const r of records) {
+					ctx.db.putSync(r.key, r.value);
+				}
+				ctx.db.flushSync();
+				ctx.db.compactSync();
+				ctx.keys = records.map((r) => r.key);
+			},
+			bench({ db, keys }) {
+				for (const k of keys as number[]) {
+					db.getSync(k);
+				}
+			},
+		});
+	}
+});

--- a/binding.gyp
+++ b/binding.gyp
@@ -123,11 +123,6 @@
 					'link_settings': {
 						'libraries': [
 							'<(module_root_dir)/deps/rocksdb/lib/librocksdb.a',
-							# Compression libs the prebuild actually ships (zlib only on older
-							# prebuilds; snappy/lz4/zstd/bzip2 too on compression-enabled ones),
-							# enumerated by scripts/rocksdb-link-libs.mjs. Spliced after
-							# librocksdb.a because GNU ld is order-sensitive (it references their
-							# symbols).
 							'<@(rocksdb_compression_libs)'
 						]
 					},
@@ -172,7 +167,6 @@
 							],
 							'AdditionalDependencies': [
 								'rocksdb.lib',
-								# Compression libs the prebuild ships (see rocksdb-link-libs.mjs).
 								'<@(rocksdb_compression_libs)'
 							]
 						}
@@ -199,7 +193,6 @@
 							'AdditionalDependencies': [
 								# 'rocksdbd.lib',
 								'rocksdb.lib',
-								# Compression libs the prebuild ships (see rocksdb-link-libs.mjs).
 								'<@(rocksdb_compression_libs)'
 							]
 						}
@@ -279,7 +272,6 @@
 							],
 							'AdditionalDependencies': [
 								'rocksdb.lib',
-								# Compression libs the prebuild ships (see rocksdb-link-libs.mjs).
 								'<@(rocksdb_compression_libs)'
 							]
 						}
@@ -291,11 +283,6 @@
 					'link_settings': {
 						'libraries': [
 							'<(module_root_dir)/deps/rocksdb/lib/librocksdb.a',
-							# Compression libs the prebuild actually ships (zlib only on older
-							# prebuilds; snappy/lz4/zstd/bzip2 too on compression-enabled ones),
-							# enumerated by scripts/rocksdb-link-libs.mjs. Spliced after
-							# librocksdb.a because GNU ld is order-sensitive (it references their
-							# symbols).
 							'<@(rocksdb_compression_libs)'
 						]
 					},
@@ -334,7 +321,6 @@
 							],
 							'AdditionalDependencies': [
 								'rocksdb.lib',
-								# Compression libs the prebuild ships (see rocksdb-link-libs.mjs).
 								'<@(rocksdb_compression_libs)'
 							]
 						}
@@ -355,7 +341,6 @@
 							],
 							'AdditionalDependencies': [
 								'rocksdb.lib',
-								# Compression libs the prebuild ships (see rocksdb-link-libs.mjs).
 								'<@(rocksdb_compression_libs)'
 							]
 						}

--- a/binding.gyp
+++ b/binding.gyp
@@ -6,16 +6,17 @@
 	#   ROCKSDB_ASAN=1 node-gyp rebuild
 	'variables': {
 		"rocksdb_asan%": "<!(node -p \"process.env.ROCKSDB_ASAN==='1'?1:0\")",
-		# Compression libraries the resolved RocksDB prebuild actually ships (as
-		# `-l` flags / `.lib` names, not absolute paths — see configure-rocksdb.mjs
-		# for why), resolved against the library search dir configured in each
-		# target's link settings. Older prebuilds ship only zlib; a compression-
-		# enabled prebuild adds snappy/lz4/zstd/bzip2. Linking exactly what is
-		# present lets both build (a missing lib errors "no such file"; an unlinked
-		# one the prebuild needs errors "undefined symbols"). The script also
-		# provisions the pinned prebuild first. The script path is quoted so a
-		# repo checkout under a path with spaces still launches it.
-		'rocksdb_compression_libs': ['<!@(node "<(module_root_dir)/scripts/configure-rocksdb.mjs")'],
+		# RocksDB link libraries — the core `librocksdb` archive plus the compression
+		# libs the resolved prebuild actually ships — emitted as `-l` flags / `.lib`
+		# names (not absolute paths — see configure-rocksdb.mjs for why), resolved
+		# against the library search dir configured in each target's link settings.
+		# Older prebuilds ship only zlib; a compression-enabled prebuild adds
+		# snappy/lz4/zstd/bzip2. Linking exactly what is present lets both build (a
+		# missing lib errors "no such file"; an unlinked one the prebuild needs
+		# errors "undefined symbols"). The script also provisions the pinned prebuild
+		# first. The script path is quoted so a repo checkout under a path with
+		# spaces still launches it.
+		'rocksdb_link_libs': ['<!@(node "<(module_root_dir)/scripts/configure-rocksdb.mjs")'],
 	},
 	# Node 26's Windows headers (common.gypi) inject Clang ThinLTO options
 	# (-flto=thin and /opt:lldltojobs=N) into every Release target. The official
@@ -123,12 +124,19 @@
 					'cflags+': ['-fexceptions'],
 					'cflags_cc+': ['-fexceptions'],
 					'link_settings': {
+						# All link libraries (core librocksdb + the compression libs) come
+						# from configure-rocksdb.mjs as `-l` tokens, not absolute paths,
+						# resolved against this search dir. The search dir is module-relative
+						# (not <(module_root_dir)/...) so GYP rebases it to a ../-only path
+						# under the build dir: an absolute path carrying a spaced
+						# module_root_dir is emitted unquoted into LDFLAGS/LIBS and the link
+						# shell splits it, while a ../-relative path has no space to split
+						# (fixes a checkout under e.g. /tmp/rocks db).
 						'library_dirs': [
-							'<(module_root_dir)/deps/rocksdb/lib'
+							'deps/rocksdb/lib'
 						],
 						'libraries': [
-							'<(module_root_dir)/deps/rocksdb/lib/librocksdb.a',
-							'<@(rocksdb_compression_libs)'
+							'<@(rocksdb_link_libs)'
 						]
 					},
 					'xcode_settings': {
@@ -171,8 +179,7 @@
 								'<(module_root_dir)/deps/rocksdb/lib'
 							],
 							'AdditionalDependencies': [
-								'rocksdb.lib',
-								'<@(rocksdb_compression_libs)'
+								'<@(rocksdb_link_libs)'
 							]
 						}
 					}
@@ -196,9 +203,7 @@
 								'<(module_root_dir)/deps/rocksdb/lib'
 							],
 							'AdditionalDependencies': [
-								# 'rocksdbd.lib',
-								'rocksdb.lib',
-								'<@(rocksdb_compression_libs)'
+								'<@(rocksdb_link_libs)'
 							]
 						}
 					},
@@ -276,8 +281,7 @@
 								'<(module_root_dir)/deps/rocksdb/lib'
 							],
 							'AdditionalDependencies': [
-								'rocksdb.lib',
-								'<@(rocksdb_compression_libs)'
+								'<@(rocksdb_link_libs)'
 							]
 						}
 					}
@@ -286,12 +290,19 @@
 					'cflags+': ['-fexceptions'],
 					'cflags_cc+': ['-fexceptions'],
 					'link_settings': {
+						# All link libraries (core librocksdb + the compression libs) come
+						# from configure-rocksdb.mjs as `-l` tokens, not absolute paths,
+						# resolved against this search dir. The search dir is module-relative
+						# (not <(module_root_dir)/...) so GYP rebases it to a ../-only path
+						# under the build dir: an absolute path carrying a spaced
+						# module_root_dir is emitted unquoted into LDFLAGS/LIBS and the link
+						# shell splits it, while a ../-relative path has no space to split
+						# (fixes a checkout under e.g. /tmp/rocks db).
 						'library_dirs': [
-							'<(module_root_dir)/deps/rocksdb/lib'
+							'deps/rocksdb/lib'
 						],
 						'libraries': [
-							'<(module_root_dir)/deps/rocksdb/lib/librocksdb.a',
-							'<@(rocksdb_compression_libs)'
+							'<@(rocksdb_link_libs)'
 						]
 					},
 					'xcode_settings': {
@@ -328,8 +339,7 @@
 								'<(module_root_dir)/deps/rocksdb/lib'
 							],
 							'AdditionalDependencies': [
-								'rocksdb.lib',
-								'<@(rocksdb_compression_libs)'
+								'<@(rocksdb_link_libs)'
 							]
 						}
 					}
@@ -348,8 +358,7 @@
 								'<(module_root_dir)/deps/rocksdb/lib'
 							],
 							'AdditionalDependencies': [
-								'rocksdb.lib',
-								'<@(rocksdb_compression_libs)'
+								'<@(rocksdb_link_libs)'
 							]
 						}
 					},

--- a/binding.gyp
+++ b/binding.gyp
@@ -6,13 +6,16 @@
 	#   ROCKSDB_ASAN=1 node-gyp rebuild
 	'variables': {
 		"rocksdb_asan%": "<!(node -p \"process.env.ROCKSDB_ASAN==='1'?1:0\")",
-		# Compression static libs the resolved RocksDB prebuild actually ships,
-		# enumerated at configure time. Older prebuilds ship only zlib; a
-		# compression-enabled prebuild adds snappy/lz4/zstd/bzip2. Linking exactly
-		# what is present lets both build (a missing lib errors "no such file"; an
-		# unlinked one the prebuild needs errors "undefined symbols"). The script
-		# also provisions the pinned prebuild first (see scripts/configure-rocksdb.mjs).
-		'rocksdb_compression_libs': ['<!@(node <(module_root_dir)/scripts/configure-rocksdb.mjs)'],
+		# Compression libraries the resolved RocksDB prebuild actually ships (as
+		# `-l` flags / `.lib` names, not absolute paths — see configure-rocksdb.mjs
+		# for why), resolved against the library search dir configured in each
+		# target's link settings. Older prebuilds ship only zlib; a compression-
+		# enabled prebuild adds snappy/lz4/zstd/bzip2. Linking exactly what is
+		# present lets both build (a missing lib errors "no such file"; an unlinked
+		# one the prebuild needs errors "undefined symbols"). The script also
+		# provisions the pinned prebuild first. The script path is quoted so a
+		# repo checkout under a path with spaces still launches it.
+		'rocksdb_compression_libs': ['<!@(node "<(module_root_dir)/scripts/configure-rocksdb.mjs")'],
 	},
 	# Node 26's Windows headers (common.gypi) inject Clang ThinLTO options
 	# (-flto=thin and /opt:lldltojobs=N) into every Release target. The official
@@ -120,6 +123,9 @@
 					'cflags+': ['-fexceptions'],
 					'cflags_cc+': ['-fexceptions'],
 					'link_settings': {
+						'library_dirs': [
+							'<(module_root_dir)/deps/rocksdb/lib'
+						],
 						'libraries': [
 							'<(module_root_dir)/deps/rocksdb/lib/librocksdb.a',
 							'<@(rocksdb_compression_libs)'
@@ -280,6 +286,9 @@
 					'cflags+': ['-fexceptions'],
 					'cflags_cc+': ['-fexceptions'],
 					'link_settings': {
+						'library_dirs': [
+							'<(module_root_dir)/deps/rocksdb/lib'
+						],
 						'libraries': [
 							'<(module_root_dir)/deps/rocksdb/lib/librocksdb.a',
 							'<@(rocksdb_compression_libs)'

--- a/binding.gyp
+++ b/binding.gyp
@@ -40,6 +40,7 @@
 			],
 			'sources': [
 				'src/binding/binding.cpp',
+				'src/binding/core/compression.cpp',
 				'src/binding/core/debug.cpp',
 				'src/binding/core/platform.cpp',
 				'src/binding/core/file_lock.cpp',
@@ -209,6 +210,7 @@
 				'deps/googletest/googlemock/include',
 			],
 			'sources': [
+				'src/binding/core/compression.cpp',
 				'src/binding/core/debug.cpp',
 				'src/binding/core/platform.cpp',
 				'src/binding/core/file_lock.cpp',
@@ -220,6 +222,7 @@
 				'test/native/event_emitter_stub.cc',
 				'test/native/rocksdb_version_test.cc',
 				'test/native/backup_disk_space_test.cc',
+				'test/native/compression_test.cc',
 				'test/native/encoding_test.cc',
 				'test/native/file_lock_test.cc',
 				'test/native/json_test.cc',

--- a/binding.gyp
+++ b/binding.gyp
@@ -10,9 +10,9 @@
 		# enumerated at configure time. Older prebuilds ship only zlib; a
 		# compression-enabled prebuild adds snappy/lz4/zstd/bzip2. Linking exactly
 		# what is present lets both build (a missing lib errors "no such file"; an
-		# unlinked one the prebuild needs errors "undefined symbols"). See
-		# scripts/rocksdb-link-libs.mjs.
-		'rocksdb_compression_libs': ['<!@(node <(module_root_dir)/scripts/rocksdb-link-libs.mjs)'],
+		# unlinked one the prebuild needs errors "undefined symbols"). The script
+		# also provisions the pinned prebuild first (see scripts/configure-rocksdb.mjs).
+		'rocksdb_compression_libs': ['<!@(node <(module_root_dir)/scripts/configure-rocksdb.mjs)'],
 	},
 	# Node 26's Windows headers (common.gypi) inject Clang ThinLTO options
 	# (-flto=thin and /opt:lldltojobs=N) into every Release target. The official

--- a/binding.gyp
+++ b/binding.gyp
@@ -4,7 +4,16 @@
 	# do not reliably override a target-scoped default under node-gyp's make
 	# generator, so an explicit env read is used instead. Enable with:
 	#   ROCKSDB_ASAN=1 node-gyp rebuild
-	'variables': { "rocksdb_asan%": "<!(node -p \"process.env.ROCKSDB_ASAN==='1'?1:0\")" },
+	'variables': {
+		"rocksdb_asan%": "<!(node -p \"process.env.ROCKSDB_ASAN==='1'?1:0\")",
+		# Compression static libs the resolved RocksDB prebuild actually ships,
+		# enumerated at configure time. Older prebuilds ship only zlib; a
+		# compression-enabled prebuild adds snappy/lz4/zstd/bzip2. Linking exactly
+		# what is present lets both build (a missing lib errors "no such file"; an
+		# unlinked one the prebuild needs errors "undefined symbols"). See
+		# scripts/rocksdb-link-libs.mjs.
+		'rocksdb_compression_libs': ['<!@(node <(module_root_dir)/scripts/rocksdb-link-libs.mjs)'],
+	},
 	# Node 26's Windows headers (common.gypi) inject Clang ThinLTO options
 	# (-flto=thin and /opt:lldltojobs=N) into every Release target. The official
 	# Node Windows build is now compiled with ClangCL + ThinLTO, but this addon
@@ -114,11 +123,12 @@
 					'link_settings': {
 						'libraries': [
 							'<(module_root_dir)/deps/rocksdb/lib/librocksdb.a',
-							# librocksdb.a references zlib (BuiltinZlibCompressor) but does not
-							# bundle it; link the zlib static lib shipped alongside it in the
-							# RocksDB prebuild so the compressor object resolves when the linker
-							# pulls it in. Must come after librocksdb.a (GNU ld is order-sensitive).
-							'<(module_root_dir)/deps/rocksdb/lib/libz.a'
+							# Compression libs the prebuild actually ships (zlib only on older
+							# prebuilds; snappy/lz4/zstd/bzip2 too on compression-enabled ones),
+							# enumerated by scripts/rocksdb-link-libs.mjs. Spliced after
+							# librocksdb.a because GNU ld is order-sensitive (it references their
+							# symbols).
+							'<@(rocksdb_compression_libs)'
 						]
 					},
 					'xcode_settings': {
@@ -161,7 +171,9 @@
 								'<(module_root_dir)/deps/rocksdb/lib'
 							],
 							'AdditionalDependencies': [
-								'rocksdb.lib'
+								'rocksdb.lib',
+								# Compression libs the prebuild ships (see rocksdb-link-libs.mjs).
+								'<@(rocksdb_compression_libs)'
 							]
 						}
 					}
@@ -186,7 +198,9 @@
 							],
 							'AdditionalDependencies': [
 								# 'rocksdbd.lib',
-								'rocksdb.lib'
+								'rocksdb.lib',
+								# Compression libs the prebuild ships (see rocksdb-link-libs.mjs).
+								'<@(rocksdb_compression_libs)'
 							]
 						}
 					},
@@ -264,7 +278,9 @@
 								'<(module_root_dir)/deps/rocksdb/lib'
 							],
 							'AdditionalDependencies': [
-								'rocksdb.lib'
+								'rocksdb.lib',
+								# Compression libs the prebuild ships (see rocksdb-link-libs.mjs).
+								'<@(rocksdb_compression_libs)'
 							]
 						}
 					}
@@ -275,11 +291,12 @@
 					'link_settings': {
 						'libraries': [
 							'<(module_root_dir)/deps/rocksdb/lib/librocksdb.a',
-							# librocksdb.a references zlib (BuiltinZlibCompressor) but does not
-							# bundle it; link the zlib static lib shipped alongside it in the
-							# RocksDB prebuild so the compressor object resolves when the linker
-							# pulls it in. Must come after librocksdb.a (GNU ld is order-sensitive).
-							'<(module_root_dir)/deps/rocksdb/lib/libz.a'
+							# Compression libs the prebuild actually ships (zlib only on older
+							# prebuilds; snappy/lz4/zstd/bzip2 too on compression-enabled ones),
+							# enumerated by scripts/rocksdb-link-libs.mjs. Spliced after
+							# librocksdb.a because GNU ld is order-sensitive (it references their
+							# symbols).
+							'<@(rocksdb_compression_libs)'
 						]
 					},
 					'xcode_settings': {
@@ -316,7 +333,9 @@
 								'<(module_root_dir)/deps/rocksdb/lib'
 							],
 							'AdditionalDependencies': [
-								'rocksdb.lib'
+								'rocksdb.lib',
+								# Compression libs the prebuild ships (see rocksdb-link-libs.mjs).
+								'<@(rocksdb_compression_libs)'
 							]
 						}
 					}
@@ -335,7 +354,9 @@
 								'<(module_root_dir)/deps/rocksdb/lib'
 							],
 							'AdditionalDependencies': [
-								'rocksdb.lib'
+								'rocksdb.lib',
+								# Compression libs the prebuild ships (see rocksdb-link-libs.mjs).
+								'<@(rocksdb_compression_libs)'
 							]
 						}
 					},

--- a/binding.gyp
+++ b/binding.gyp
@@ -42,7 +42,6 @@
 	'targets': [
 		{
 			'target_name': 'rocksdb-js',
-			'dependencies': ['prepare-rocksdb'],
 			'include_dirs': [
 				'deps/rocksdb/include',
 				'src/binding',
@@ -209,7 +208,7 @@
 		{
 			'target_name': 'rocksdb-js-native-tests',
 			'type': 'executable',
-			'dependencies': ['prepare-rocksdb', 'deps/gtest.gyp:gtest_main'],
+			'dependencies': ['deps/gtest.gyp:gtest_main'],
 			'include_dirs': [
 				'deps/rocksdb/include',
 				'src/binding',
@@ -353,26 +352,6 @@
 					}
 				}
 			}
-		},
-		{
-			'target_name': 'prepare-rocksdb',
-			'type': 'none',
-			'actions': [
-				{
-					'action_name': 'prepare_rocksdb',
-					'message': 'Preparing RocksDB...',
-					'action': [
-						'<(module_root_dir)/node_modules/.bin/tsx',
-						'<(module_root_dir)/scripts/init-rocksdb/main.ts',
-					],
-					'inputs': [
-						'<(module_root_dir)/scripts/init-rocksdb/main.ts',
-					],
-					'outputs': [
-						'deps/rocksdb/include',
-					],
-				}
-			]
 		},
 	]
 }

--- a/deps/gtest.gyp
+++ b/deps/gtest.gyp
@@ -5,7 +5,11 @@
 		# resolves implicit pattern rules at startup, so the source .cc files
 		# must already exist when the makefile is loaded - an order-only dep
 		# on a download action is too late.
-		'_init_gtest': '<!(<(module_root_dir)/node_modules/.bin/tsx <(module_root_dir)/scripts/init-gtest/main.ts)',
+		# Paths are quoted (and tsx is launched via `node <cli.mjs>` rather than the
+		# `.bin/tsx` shim) so a repo checkout under a path with spaces still runs:
+		# GYP passes this through a shell, which would otherwise split an unquoted
+		# `<(module_root_dir)` at the space (`/bin/sh: /path/to/rocksdb: not found`).
+		'_init_gtest': '<!(node "<(module_root_dir)/node_modules/tsx/dist/cli.mjs" "<(module_root_dir)/scripts/init-gtest/main.ts")',
 	},
 	# See binding.gyp: Node 26's Windows headers inject Clang ThinLTO options
 	# (-flto=thin / /opt:lldltojobs=N) into every Release target, which MSVC's

--- a/scripts/configure-rocksdb.mjs
+++ b/scripts/configure-rocksdb.mjs
@@ -6,8 +6,9 @@
  *      failing the build hard if that cannot be done — configure runs before the
  *      `prepare-rocksdb` build action, so the prebuild must be present here for
  *      the enumeration below to be correct.
- *   2. Emits the compression static libraries to link, one per line, for the
- *      current platform; gyp splices them into the link settings.
+ *   2. Emits the RocksDB link libraries — the core `librocksdb` archive plus the
+ *      compression static libs — one per line, for the current platform; gyp
+ *      splices them into the link settings.
  *
  * RocksDB prebuilds vary in which compression libraries they were compiled
  * with: an older prebuild may ship only zlib, while a compression-enabled one
@@ -17,8 +18,12 @@
  * a lib the prebuild doesn't ship fails with "no such file"; omitting one it
  * needs fails with "undefined symbols". So we link precisely the files present.
  *
- * `librocksdb` itself is linked unconditionally by `binding.gyp`; only the
- * optional compression libs are enumerated here.
+ * The core `librocksdb` is emitted first (static link order: it depends on the
+ * compression libs, so it must precede them) as a `-l` flag / `.lib` name rather
+ * than an absolute path — a repo checked out under a path with spaces (e.g.
+ * `/tmp/rocks db`) would otherwise emit a whitespace-bearing library entry that
+ * gyp's `<!@()` split and the link shell both break on. All tokens resolve
+ * against the (single, gyp-supplied, space-safe) library search dir.
  */
 
 import { spawnSync } from 'node:child_process';
@@ -27,8 +32,12 @@ import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const isWin = process.platform === 'win32';
+const isLinux = process.platform === 'linux';
 const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const libDir = join(root, 'deps', 'rocksdb', 'lib');
+
+// The core RocksDB archive. Always present after provisioning; linked first.
+const coreLib = isWin ? 'rocksdb.lib' : 'librocksdb.a';
 
 const candidates = isWin
 	? ['snappy.lib', 'lz4.lib', 'zstd.lib', 'bz2.lib', 'zs.lib']
@@ -76,6 +85,12 @@ try {
 	console.error(`init-rocksdb succeeded but ${libDir} is missing: ${error.message}`);
 	process.exit(1);
 }
+// The core archive is a hard invariant post-provision — its absence means a
+// broken prebuild, so fail loudly rather than emit a link set that omits it.
+if (!files.has(coreLib)) {
+	console.error(`init-rocksdb succeeded but ${join(libDir, coreLib)} is missing`);
+	process.exit(1);
+}
 const present = candidates.filter((name) => files.has(name));
 
 // One token per line; gyp's `<!@()` splits the output on whitespace into a list,
@@ -83,12 +98,11 @@ const present = candidates.filter((name) => files.has(name));
 // out to `/tmp/rocks db` would otherwise be split into broken entries. We emit
 // only names/flags and let `binding.gyp` supply the (single, gyp-quoted, so
 // space-safe) library search directory:
-//   - Windows: bare `snappy.lib` names, resolved via `AdditionalLibraryDirectories`.
-//   - Linux:   `-l:libsnappy.a` — force the exact static archive from the search dir.
-//   - macOS:   `-lsnappy` — ld64 has no `-l:`, but the search dir holds only the
+//   - Windows: bare `rocksdb.lib`/`snappy.lib` names, resolved via `AdditionalLibraryDirectories`.
+//   - Linux:   `-l:librocksdb.a` — force the exact static archive from the search dir.
+//   - macOS:   `-lrocksdb` — ld64 has no `-l:`, but the search dir holds only the
 //              `.a` (no dylib), so the static archive is selected.
-const isLinux = process.platform === 'linux';
-const tokens = present.map((name) => {
+const toToken = (name) => {
 	if (isWin) {
 		return name;
 	}
@@ -97,5 +111,7 @@ const tokens = present.map((name) => {
 	}
 	// libsnappy.a -> -lsnappy
 	return '-l' + name.replace(/^lib/, '').replace(/\.a$/, '');
-});
+};
+// Core first (it depends on the compression libs), then the present compression libs.
+const tokens = [coreLib, ...present].map(toToken);
 process.stdout.write(tokens.join('\n'));

--- a/scripts/configure-rocksdb.mjs
+++ b/scripts/configure-rocksdb.mjs
@@ -78,8 +78,24 @@ try {
 }
 const present = candidates.filter((name) => files.has(name));
 
-// One path per line; gyp's `<!@()` splits on whitespace into a list. POSIX
-// needs full paths (used directly in `libraries`); Windows uses bare names
-// resolved via `AdditionalLibraryDirectories`.
-const tokens = present.map((name) => (isWin ? name : join(libDir, name)));
+// One token per line; gyp's `<!@()` splits the output on whitespace into a list,
+// so every token MUST be whitespace-free — an absolute path under a repo checked
+// out to `/tmp/rocks db` would otherwise be split into broken entries. We emit
+// only names/flags and let `binding.gyp` supply the (single, gyp-quoted, so
+// space-safe) library search directory:
+//   - Windows: bare `snappy.lib` names, resolved via `AdditionalLibraryDirectories`.
+//   - Linux:   `-l:libsnappy.a` — force the exact static archive from the search dir.
+//   - macOS:   `-lsnappy` — ld64 has no `-l:`, but the search dir holds only the
+//              `.a` (no dylib), so the static archive is selected.
+const isLinux = process.platform === 'linux';
+const tokens = present.map((name) => {
+	if (isWin) {
+		return name;
+	}
+	if (isLinux) {
+		return `-l:${name}`;
+	}
+	// libsnappy.a -> -lsnappy
+	return '-l' + name.replace(/^lib/, '').replace(/\.a$/, '');
+});
 process.stdout.write(tokens.join('\n'));

--- a/scripts/configure-rocksdb.mjs
+++ b/scripts/configure-rocksdb.mjs
@@ -34,13 +34,20 @@ const candidates = isWin
 	? ['snappy.lib', 'lz4.lib', 'zstd.lib', 'bz2.lib', 'zs.lib']
 	: ['libsnappy.a', 'liblz4.a', 'libzstd.a', 'libbz2.a', 'libz.a'];
 
+// Run tsx via `node <tsx-cli> <script>` rather than the `.bin/tsx` shim. On
+// Windows the shim is a `.cmd`/`.ps1` wrapper that requires `shell: true` to
+// launch (slower, and mis-parses a repo path containing spaces); invoking the
+// current Node executable against tsx's CLI entry avoids the shell entirely and
+// is identical across platforms.
 const result = spawnSync(
-	join(root, 'node_modules', '.bin', 'tsx'),
-	[join(root, 'scripts', 'init-rocksdb', 'main.ts')],
+	process.execPath,
+	[
+		join(root, 'node_modules', 'tsx', 'dist', 'cli.mjs'),
+		join(root, 'scripts', 'init-rocksdb', 'main.ts'),
+	],
 	{
 		cwd: root,
 		stdio: ['ignore', 'ignore', 'inherit'],
-		shell: isWin,
 	}
 );
 

--- a/scripts/configure-rocksdb.mjs
+++ b/scripts/configure-rocksdb.mjs
@@ -1,7 +1,13 @@
 /**
- * Emits the compression static libraries to link against the RocksDB prebuild,
- * one per line, for the current platform. `binding.gyp` runs this at configure
- * time via `<!@()` and splices the result into the link settings.
+ * Configure-time RocksDB step for the native build. `binding.gyp` runs this via
+ * `<!@()` and does two things with it:
+ *
+ *   1. Provisions the pinned RocksDB prebuild (delegates to scripts/init-rocksdb),
+ *      failing the build hard if that cannot be done — configure runs before the
+ *      `prepare-rocksdb` build action, so the prebuild must be present here for
+ *      the enumeration below to be correct.
+ *   2. Emits the compression static libraries to link, one per line, for the
+ *      current platform; gyp splices them into the link settings.
  *
  * RocksDB prebuilds vary in which compression libraries they were compiled
  * with: an older prebuild may ship only zlib, while a compression-enabled one
@@ -24,25 +30,10 @@ const isWin = process.platform === 'win32';
 const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const libDir = join(root, 'deps', 'rocksdb', 'lib');
 
-// Compression archives a prebuild MAY ship. `zs.lib` is zlib on the Windows
-// builds (the POSIX counterpart is `libz.a`).
 const candidates = isWin
 	? ['snappy.lib', 'lz4.lib', 'zstd.lib', 'bz2.lib', 'zs.lib']
 	: ['libsnappy.a', 'liblz4.a', 'libzstd.a', 'libbz2.a', 'libz.a'];
 
-// Reconcile deps/rocksdb to the pinned version BEFORE enumerating. This runs at
-// gyp configure time — before any target compiles or links — and is the sole
-// step that provisions the prebuild (there is no separate build-time action, so
-// every node-gyp invocation self-provisions via this configure-time spawn). It
-// must always run: the installed prebuild may be absent OR a different version
-// than package.json pins — either way the lib set on disk would be stale.
-// init-rocksdb downloads (or builds) the pinned version on a mismatch and no-ops
-// when already correct, so the enumeration below reflects the version that will
-// actually be linked. We must always run it, not just when librocksdb is
-// missing: a wrong-version librocksdb is present but has the wrong compression
-// lib set. Its stdout is discarded — only the library list may reach gyp on our
-// stdout. `shell` on Windows so the `.cmd` shim resolves (mirrors
-// scripts/native-test/run.mjs).
 const result = spawnSync(
 	join(root, 'node_modules', '.bin', 'tsx'),
 	[join(root, 'scripts', 'init-rocksdb', 'main.ts')],

--- a/scripts/init-rocksdb/version-check.ts
+++ b/scripts/init-rocksdb/version-check.ts
@@ -34,11 +34,14 @@ export function installedSatisfiesPin(
 		isExactVersionPin(desiredVersion) &&
 		!!installed?.version &&
 		// Guard against a corrupted rocksdb.json or a non-semver ROCKSDB_VERSION:
-		// semver.eq throws on invalid input. Treating them as "not satisfied"
-		// falls through to getPrebuild, which fails with a clear "not found".
+		// the semver comparators throw on invalid input. Treating them as "not
+		// satisfied" falls through to getPrebuild, which fails with a clear "not
+		// found". Use compareBuild (not eq) so build metadata is part of the
+		// identity — an exact pin like 11.1.2+rev2 must not be satisfied by an
+		// installed 11.1.2+rev1 (eq ignores everything after `+`).
 		!!semver.valid(installed.version) &&
 		!!semver.valid(desiredVersion) &&
-		semver.eq(installed.version, desiredVersion) &&
+		semver.compareBuild(installed.version, desiredVersion) === 0 &&
 		runtimeMatches(installed, runtime)
 	);
 }

--- a/scripts/native-test/build-identity.mjs
+++ b/scripts/native-test/build-identity.mjs
@@ -1,0 +1,21 @@
+/**
+ * Resolves the effective RocksDB build selection for the native-test runner.
+ *
+ * Mirrors init-rocksdb's precedence (the caller loads `.env` with override first):
+ * a `ROCKSDB_PATH` source build wins, else `ROCKSDB_VERSION`, else the package pin
+ * (`pkg.rocksdb.version`); the Linux runtime suffix (glibc/musl) is appended.
+ *
+ * - `expectedVersion` feeds `ROCKSDB_EXPECTED_VERSION` (the native
+ *   `RocksDBVersion.MatchesPackagePin` check).
+ * - `identity` is the rebuild marker: it must change whenever the linked artifact
+ *   would change — a different env override, runtime, or source — even if the
+ *   package pin is unchanged, so the runner never reuses a stale binary. (This is
+ *   why the pin alone was insufficient: a build under `ROCKSDB_VERSION=11.1.2-1`
+ *   must not be recorded as the pin `11.1.2-2`.)
+ */
+export function resolveBuildSelection(env, pkg, platform) {
+	const runtime = platform === 'linux' ? `-${env.ROCKSDB_LIBC || 'glibc'}` : '';
+	const expectedVersion = env.ROCKSDB_VERSION || pkg.rocksdb?.version || '';
+	const identity = env.ROCKSDB_PATH ? `source:${env.ROCKSDB_PATH}` : `${expectedVersion}${runtime}`;
+	return { expectedVersion, identity, runtime };
+}

--- a/scripts/native-test/run.mjs
+++ b/scripts/native-test/run.mjs
@@ -2,6 +2,8 @@
  * Build and run native GoogleTest binaries.
  */
 
+import { resolveBuildSelection } from './build-identity.mjs';
+import { config as loadEnv } from 'dotenv';
 import { spawnSync } from 'node:child_process';
 import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
@@ -27,35 +29,47 @@ if (!existsSync(gtestMarker)) {
 }
 
 const pkg = JSON.parse(readFileSync(join(root, 'package.json'), 'utf8'));
-const expectedVersion = pkg.rocksdb?.version ?? '';
 
-const config = process.env.NATIVE_TEST_DEBUG === '1' ? 'Debug' : 'Release';
+// Resolve the effective RocksDB build selection the SAME way init-rocksdb does
+// (.env override, then ROCKSDB_VERSION, then the package pin; or a source build
+// via ROCKSDB_PATH). The compiled binary is only valid for the artifact it was
+// actually linked against, so both the rebuild marker and ROCKSDB_EXPECTED_VERSION
+// must derive from this selection — not the package pin alone. Otherwise a build
+// made under `ROCKSDB_VERSION=11.1.2-1` (env wins over the pin) would be recorded
+// as the pin `11.1.2-2`; a later run that drops the override would then treat the
+// stale `-1` binary as current (`MatchesPackagePin` also ignores the `-N`
+// revision, so it can't catch it either).
+loadEnv({ path: ['.env'], override: true });
+// `identity` is the rebuild marker; `expectedVersion` feeds ROCKSDB_EXPECTED_VERSION.
+// A `latest`/source selection is compared verbatim (not re-resolved) — the same
+// pre-existing limitation a `latest` package pin already had.
+const { expectedVersion, identity: buildIdentity } = resolveBuildSelection(
+	process.env,
+	pkg,
+	process.platform
+);
+
+const buildType = process.env.NATIVE_TEST_DEBUG === '1' ? 'Debug' : 'Release';
 const binaryName =
 	process.platform === 'win32' ? 'rocksdb-js-native-tests.exe' : 'rocksdb-js-native-tests';
-const binary = join(root, 'build', config, binaryName);
+const binary = join(root, 'build', buildType, binaryName);
 
-// The compiled binary is only valid for the RocksDB version it was built
-// against. `RocksDBVersion.MatchesPackagePin` checks the base MAJOR.MINOR.PATCH
-// (a `-N` revision suffix isn't in RocksDB's version.h), so a stale binary from
-// an earlier revision (e.g. 11.1.2-1 when the pin is now 11.1.2-2) would still
-// pass. Record the pinned version alongside the binary and force a rebuild when
-// it changes, so the runner never reuses a binary built for a different pin.
-const versionMarker = join(root, 'build', config, '.rocksdb-test-version');
-const builtVersion = existsSync(versionMarker) ? readFileSync(versionMarker, 'utf8').trim() : '';
+const versionMarker = join(root, 'build', buildType, '.rocksdb-test-version');
+const builtIdentity = existsSync(versionMarker) ? readFileSync(versionMarker, 'utf8').trim() : '';
 
 if (
 	!existsSync(binary) ||
 	process.env.NATIVE_TEST_REBUILD === '1' ||
-	builtVersion !== expectedVersion
+	builtIdentity !== buildIdentity
 ) {
 	const gypArgs = ['rebuild'];
 	if (process.env.NATIVE_TEST_DEBUG === '1') {
 		gypArgs.push('--debug');
 	}
 	run('pnpm', ['exec', 'node-gyp', ...gypArgs]);
-	// Record the pin this binary was built against (node-gyp's prepare-rocksdb
-	// action has reconciled deps/rocksdb to it by now).
-	writeFileSync(versionMarker, expectedVersion);
+	// Record the selection this binary was built against (node-gyp's configure
+	// step has reconciled deps/rocksdb to it by now).
+	writeFileSync(versionMarker, buildIdentity);
 }
 
 if (!existsSync(binary)) {

--- a/scripts/native-test/run.mjs
+++ b/scripts/native-test/run.mjs
@@ -3,8 +3,7 @@
  */
 
 import { spawnSync } from 'node:child_process';
-import { existsSync } from 'node:fs';
-import { readFileSync } from 'node:fs';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -35,12 +34,28 @@ const binaryName =
 	process.platform === 'win32' ? 'rocksdb-js-native-tests.exe' : 'rocksdb-js-native-tests';
 const binary = join(root, 'build', config, binaryName);
 
-if (!existsSync(binary) || process.env.NATIVE_TEST_REBUILD === '1') {
+// The compiled binary is only valid for the RocksDB version it was built
+// against. `RocksDBVersion.MatchesPackagePin` checks the base MAJOR.MINOR.PATCH
+// (a `-N` revision suffix isn't in RocksDB's version.h), so a stale binary from
+// an earlier revision (e.g. 11.1.2-1 when the pin is now 11.1.2-2) would still
+// pass. Record the pinned version alongside the binary and force a rebuild when
+// it changes, so the runner never reuses a binary built for a different pin.
+const versionMarker = join(root, 'build', config, '.rocksdb-test-version');
+const builtVersion = existsSync(versionMarker) ? readFileSync(versionMarker, 'utf8').trim() : '';
+
+if (
+	!existsSync(binary) ||
+	process.env.NATIVE_TEST_REBUILD === '1' ||
+	builtVersion !== expectedVersion
+) {
 	const gypArgs = ['rebuild'];
 	if (process.env.NATIVE_TEST_DEBUG === '1') {
 		gypArgs.push('--debug');
 	}
 	run('pnpm', ['exec', 'node-gyp', ...gypArgs]);
+	// Record the pin this binary was built against (node-gyp's prepare-rocksdb
+	// action has reconciled deps/rocksdb to it by now).
+	writeFileSync(versionMarker, expectedVersion);
 }
 
 if (!existsSync(binary)) {

--- a/scripts/rocksdb-link-libs.mjs
+++ b/scripts/rocksdb-link-libs.mjs
@@ -1,0 +1,66 @@
+/**
+ * Emits the compression static libraries to link against the RocksDB prebuild,
+ * one per line, for the current platform. `binding.gyp` runs this at configure
+ * time via `<!@()` and splices the result into the link settings.
+ *
+ * RocksDB prebuilds vary in which compression libraries they were compiled
+ * with: an older prebuild may ship only zlib, while a compression-enabled one
+ * ships snappy/lz4/zstd/bzip2 as well. `librocksdb` references whichever it was
+ * built with but (being a static archive) does not bundle them, so the consumer
+ * must link exactly the ones the prebuild provides — no more, no less. Linking
+ * a lib the prebuild doesn't ship fails with "no such file"; omitting one it
+ * needs fails with "undefined symbols". So we link precisely the files present.
+ *
+ * `librocksdb` itself is linked unconditionally by `binding.gyp`; only the
+ * optional compression libs are enumerated here.
+ */
+
+import { spawnSync } from 'node:child_process';
+import { readdirSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const isWin = process.platform === 'win32';
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const libDir = join(root, 'deps', 'rocksdb', 'lib');
+
+// Compression archives a prebuild MAY ship. `zs.lib` is zlib on the Windows
+// builds (the POSIX counterpart is `libz.a`).
+const candidates = isWin
+	? ['snappy.lib', 'lz4.lib', 'zstd.lib', 'bz2.lib', 'zs.lib']
+	: ['libsnappy.a', 'liblz4.a', 'libzstd.a', 'libbz2.a', 'libz.a'];
+
+// Reconcile deps/rocksdb to the pinned version BEFORE enumerating. This runs at
+// gyp configure time, which is before the prepare-rocksdb build action, so the
+// installed prebuild may be absent OR a different version than package.json
+// pins — either way the lib set on disk would be stale. init-rocksdb downloads
+// (or builds) the pinned version on a mismatch and no-ops when already correct,
+// so the enumeration below reflects the version that will actually be linked.
+// We must always run it, not just when librocksdb is missing: a wrong-version
+// librocksdb is present but has the wrong compression lib set. Its stdout is
+// discarded — only the library list may reach gyp on our stdout. `shell` on
+// Windows so the `.cmd` shim resolves (mirrors scripts/native-test/run.mjs).
+spawnSync(
+	join(root, 'node_modules', '.bin', 'tsx'),
+	[join(root, 'scripts', 'init-rocksdb', 'main.ts')],
+	{
+		cwd: root,
+		stdio: ['ignore', 'ignore', 'inherit'],
+		shell: isWin,
+	}
+);
+
+let present = [];
+try {
+	const files = new Set(readdirSync(libDir));
+	present = candidates.filter((name) => files.has(name));
+} catch {
+	// deps/rocksdb/lib still missing (prep failed); emit nothing. The static
+	// librocksdb path in binding.gyp will surface a clear link error.
+}
+
+// One path per line; gyp's `<!@()` splits on whitespace into a list. POSIX
+// needs full paths (used directly in `libraries`); Windows uses bare names
+// resolved via `AdditionalLibraryDirectories`.
+const tokens = present.map((name) => (isWin ? name : join(libDir, name)));
+process.stdout.write(tokens.join('\n'));

--- a/scripts/rocksdb-link-libs.mjs
+++ b/scripts/rocksdb-link-libs.mjs
@@ -31,16 +31,19 @@ const candidates = isWin
 	: ['libsnappy.a', 'liblz4.a', 'libzstd.a', 'libbz2.a', 'libz.a'];
 
 // Reconcile deps/rocksdb to the pinned version BEFORE enumerating. This runs at
-// gyp configure time, which is before the prepare-rocksdb build action, so the
-// installed prebuild may be absent OR a different version than package.json
-// pins — either way the lib set on disk would be stale. init-rocksdb downloads
-// (or builds) the pinned version on a mismatch and no-ops when already correct,
-// so the enumeration below reflects the version that will actually be linked.
-// We must always run it, not just when librocksdb is missing: a wrong-version
-// librocksdb is present but has the wrong compression lib set. Its stdout is
-// discarded — only the library list may reach gyp on our stdout. `shell` on
-// Windows so the `.cmd` shim resolves (mirrors scripts/native-test/run.mjs).
-spawnSync(
+// gyp configure time — before any target compiles or links — and is the sole
+// step that provisions the prebuild (there is no separate build-time action, so
+// every node-gyp invocation self-provisions via this configure-time spawn). It
+// must always run: the installed prebuild may be absent OR a different version
+// than package.json pins — either way the lib set on disk would be stale.
+// init-rocksdb downloads (or builds) the pinned version on a mismatch and no-ops
+// when already correct, so the enumeration below reflects the version that will
+// actually be linked. We must always run it, not just when librocksdb is
+// missing: a wrong-version librocksdb is present but has the wrong compression
+// lib set. Its stdout is discarded — only the library list may reach gyp on our
+// stdout. `shell` on Windows so the `.cmd` shim resolves (mirrors
+// scripts/native-test/run.mjs).
+const result = spawnSync(
 	join(root, 'node_modules', '.bin', 'tsx'),
 	[join(root, 'scripts', 'init-rocksdb', 'main.ts')],
 	{
@@ -50,14 +53,32 @@ spawnSync(
 	}
 );
 
-let present = [];
-try {
-	const files = new Set(readdirSync(libDir));
-	present = candidates.filter((name) => files.has(name));
-} catch {
-	// deps/rocksdb/lib still missing (prep failed); emit nothing. The static
-	// librocksdb path in binding.gyp will surface a clear link error.
+// Provisioning is a hard prerequisite: if it failed, enumerating below would
+// emit a stale or empty lib set and defer the failure to a confusing link
+// error. A non-zero exit here aborts gyp configure. init-rocksdb prints its own
+// diagnostics to inherited stderr.
+if (result.error) {
+	// tsx itself could not be launched (e.g. ENOENT / missing dependency).
+	console.error(`Failed to run init-rocksdb: ${result.error.message}`);
+	process.exit(1);
 }
+if (result.status !== 0) {
+	process.exit(result.status ?? 1);
+}
+
+// init-rocksdb succeeded, so deps/rocksdb/lib exists (both the download and
+// build-from-source paths create it). An empty enumeration is legitimate — a
+// build-from-source tree ships only librocksdb.a, and a none-only prebuild has
+// no compression archives — but a missing dir despite a successful prep is an
+// invariant violation, so fail loudly rather than emit a misleading empty list.
+let files;
+try {
+	files = new Set(readdirSync(libDir));
+} catch (error) {
+	console.error(`init-rocksdb succeeded but ${libDir} is missing: ${error.message}`);
+	process.exit(1);
+}
+const present = candidates.filter((name) => files.has(name));
 
 // One path per line; gyp's `<!@()` splits on whitespace into a list. POSIX
 // needs full paths (used directly in `libraries`); Windows uses bare names

--- a/src/binding/binding.cpp
+++ b/src/binding/binding.cpp
@@ -16,6 +16,7 @@
 #include "transaction_log/transaction_log_validation_napi.h"
 #include "core/platform.h"
 #include "core/file_lock.h"
+#include "core/compression.h"
 #include "core/test_seam.h"
 #include "napi/helpers.h"
 #include "napi/async.h"
@@ -160,6 +161,18 @@ NAPI_MODULE_INIT() {
 	napi_value version;
 	napi_create_string_utf8(env, rocksdb::GetRocksVersionAsString().c_str(), NAPI_AUTO_LENGTH, &version);
 	napi_set_named_property(env, exports, "version", version);
+
+	// supportedCompression: friendly names of the compression algorithms compiled
+	// into this RocksDB build. Static for the binary (see supportedCompressionNames).
+	const std::vector<std::string>& compressionNames = supportedCompressionNames();
+	napi_value supportedCompression;
+	NAPI_STATUS_THROWS(::napi_create_array_with_length(env, compressionNames.size(), &supportedCompression));
+	for (size_t i = 0; i < compressionNames.size(); ++i) {
+		napi_value name;
+		NAPI_STATUS_THROWS(::napi_create_string_utf8(env, compressionNames[i].c_str(), NAPI_AUTO_LENGTH, &name));
+		NAPI_STATUS_THROWS(::napi_set_element(env, supportedCompression, static_cast<uint32_t>(i), name));
+	}
+	NAPI_STATUS_THROWS(::napi_set_named_property(env, exports, "supportedCompression", supportedCompression));
 
 	[[maybe_unused]] int32_t refCount = ++moduleRefCount;
 	DEBUG_LOG("Binding::Init Module ref count: %d\n", refCount);

--- a/src/binding/core/compression.cpp
+++ b/src/binding/core/compression.cpp
@@ -1,0 +1,77 @@
+#include "core/compression.h"
+#include <algorithm>
+#include <cctype>
+#include "rocksdb/convenience.h"
+
+namespace rocksdb_js {
+
+namespace {
+
+struct CompressionEntry {
+	const char* name;
+	rocksdb::CompressionType type;
+};
+
+// Friendly names for the built-in RocksDB compression algorithms. The names
+// are the public API surface; the enum values are the persisted on-disk format
+// and must not change. Custom compressors (0x80+) are intentionally omitted.
+constexpr CompressionEntry kCompressionTable[] = {
+	{ "none", rocksdb::kNoCompression },
+	{ "snappy", rocksdb::kSnappyCompression },
+	{ "zlib", rocksdb::kZlibCompression },
+	{ "bzip2", rocksdb::kBZip2Compression },
+	{ "lz4", rocksdb::kLZ4Compression },
+	{ "lz4hc", rocksdb::kLZ4HCCompression },
+	{ "xpress", rocksdb::kXpressCompression },
+	{ "zstd", rocksdb::kZSTD },
+};
+
+} // namespace
+
+std::optional<rocksdb::CompressionType> compressionTypeFromName(const std::string& name) {
+	std::string lowered = name;
+	std::transform(lowered.begin(), lowered.end(), lowered.begin(), [](unsigned char c) {
+		return static_cast<char>(std::tolower(c));
+	});
+	for (const auto& entry : kCompressionTable) {
+		if (lowered == entry.name) {
+			return entry.type;
+		}
+	}
+	return std::nullopt;
+}
+
+std::string compressionNameFromType(rocksdb::CompressionType type) {
+	for (const auto& entry : kCompressionTable) {
+		if (entry.type == type) {
+			return entry.name;
+		}
+	}
+	return "unknown";
+}
+
+bool isCompressionSupported(rocksdb::CompressionType type) {
+	if (type == rocksdb::kNoCompression) {
+		return true;
+	}
+	const std::vector<rocksdb::CompressionType>& supported = rocksdb::GetSupportedCompressions();
+	return std::find(supported.begin(), supported.end(), type) != supported.end();
+}
+
+const std::vector<std::string>& supportedCompressionNames() {
+	// Computed once: the linked RocksDB's compiled-in compressors don't change
+	// over the process lifetime.
+	static const std::vector<std::string> names = [] {
+		std::vector<std::string> result;
+		for (rocksdb::CompressionType type : rocksdb::GetSupportedCompressions()) {
+			std::string name = compressionNameFromType(type);
+			if (name != "unknown") {
+				result.push_back(name);
+			}
+		}
+		return result;
+	}();
+	return names;
+}
+
+} // namespace rocksdb_js

--- a/src/binding/core/compression.h
+++ b/src/binding/core/compression.h
@@ -1,0 +1,40 @@
+#ifndef __CORE_COMPRESSION_H__
+#define __CORE_COMPRESSION_H__
+
+#include <optional>
+#include <string>
+#include <vector>
+#include "rocksdb/compression_type.h"
+
+namespace rocksdb_js {
+
+/**
+ * Maps a friendly compression name (e.g. "lz4", "zstd", "none") to a RocksDB
+ * `CompressionType`. Case-insensitive. Returns `std::nullopt` for an unknown
+ * name.
+ */
+std::optional<rocksdb::CompressionType> compressionTypeFromName(const std::string& name);
+
+/**
+ * Maps a RocksDB `CompressionType` back to its friendly name (the inverse of
+ * `compressionTypeFromName`). Returns "unknown" for a type this binding does
+ * not surface (e.g. custom compressors).
+ */
+std::string compressionNameFromType(rocksdb::CompressionType type);
+
+/**
+ * Whether the given compression type is compiled into the linked RocksDB
+ * build. `kNoCompression` is always supported.
+ */
+bool isCompressionSupported(rocksdb::CompressionType type);
+
+/**
+ * The friendly names of every compression algorithm compiled into the linked
+ * RocksDB build, derived from `rocksdb::GetSupportedCompressions()`. The set is
+ * fixed for a given binary, so the result is computed once and cached.
+ */
+const std::vector<std::string>& supportedCompressionNames();
+
+} // namespace rocksdb_js
+
+#endif

--- a/src/binding/database/database.cpp
+++ b/src/binding/database/database.cpp
@@ -781,14 +781,15 @@ napi_value Database::Get(napi_env env, napi_callback_info info) {
 }
 
 /**
- * Returns the compression algorithm currently in effect for this database's
- * column family as a friendly name (e.g. "lz4", "zstd", "none"), read live from
- * the open RocksDB via `GetOptions`.
+ * Returns the compression currently in effect for this database's column family,
+ * read live from the open RocksDB via `GetOptions`, as an object
+ * `{ algorithm, level? }`. `algorithm` is a friendly name (e.g. "lz4", "zstd",
+ * "none"); `level` is included only when a non-default compression level is set.
  *
  * @example
  * ```typescript
  * const db = NativeDatabase.open('path/to/db');
- * db.getCompression(); // 'lz4'
+ * db.getCompression(); // { algorithm: 'zstd', level: 3 }
  * ```
  */
 napi_value Database::GetCompression(napi_env env, napi_callback_info info) {
@@ -799,7 +800,21 @@ napi_value Database::GetCompression(napi_env env, napi_callback_info info) {
 	std::string name = compressionNameFromType(opts.compression);
 
 	napi_value result;
-	NAPI_STATUS_THROWS(::napi_create_string_utf8(env, name.c_str(), NAPI_AUTO_LENGTH, &result));
+	NAPI_STATUS_THROWS(::napi_create_object(env, &result));
+
+	napi_value algorithm;
+	NAPI_STATUS_THROWS(::napi_create_string_utf8(env, name.c_str(), NAPI_AUTO_LENGTH, &algorithm));
+	NAPI_STATUS_THROWS(::napi_set_named_property(env, result, "algorithm", algorithm));
+
+	// compression_opts.level defaults to kDefaultCompressionLevel (a sentinel
+	// meaning "use the algorithm's own default"); only surface a level that was
+	// explicitly configured.
+	if (opts.compression_opts.level != rocksdb::CompressionOptions::kDefaultCompressionLevel) {
+		napi_value level;
+		NAPI_STATUS_THROWS(::napi_create_int32(env, opts.compression_opts.level, &level));
+		NAPI_STATUS_THROWS(::napi_set_named_property(env, result, "level", level));
+	}
+
 	return result;
 }
 
@@ -1428,15 +1443,32 @@ napi_value Database::Open(napi_env env, napi_callback_info info) {
 		dbHandleOptions.compression = *type;
 		dbHandleOptions.compressionExplicit = true;
 
-		double compressionLevel = 0;
-		if (rocksdb_js::getProperty(env, options, "compressionLevel", compressionLevel, true) == napi_ok) {
-			if (std::isnan(compressionLevel) || compressionLevel != std::trunc(compressionLevel) ||
-				compressionLevel < -2147483648.0 || compressionLevel > 2147483647.0
-			) {
-				::napi_throw_error(env, nullptr, "compressionLevel must be a 32-bit integer");
-				return nullptr;
+		// compressionLevel is optional, but a present value must be a valid 32-bit
+		// integer. Distinguish "absent" (leave RocksDB's per-algorithm default)
+		// from "present but wrong type" (throw) so a malformed level is never
+		// silently ignored — the TS layer validates too; this is the backstop.
+		bool hasLevel = false;
+		NAPI_STATUS_THROWS(::napi_has_named_property(env, options, "compressionLevel", &hasLevel));
+		if (hasLevel) {
+			napi_value levelValue;
+			NAPI_STATUS_THROWS(::napi_get_named_property(env, options, "compressionLevel", &levelValue));
+			napi_valuetype levelType;
+			NAPI_STATUS_THROWS(::napi_typeof(env, levelValue, &levelType));
+			if (levelType != napi_undefined && levelType != napi_null) {
+				if (levelType != napi_number) {
+					::napi_throw_error(env, nullptr, "compressionLevel must be a number");
+					return nullptr;
+				}
+				double compressionLevel = 0;
+				NAPI_STATUS_THROWS(::napi_get_value_double(env, levelValue, &compressionLevel));
+				if (std::isnan(compressionLevel) || compressionLevel != std::trunc(compressionLevel) ||
+					compressionLevel < -2147483648.0 || compressionLevel > 2147483647.0
+				) {
+					::napi_throw_error(env, nullptr, "compressionLevel must be a 32-bit integer");
+					return nullptr;
+				}
+				dbHandleOptions.compressionLevel = static_cast<int>(compressionLevel);
 			}
-			dbHandleOptions.compressionLevel = static_cast<int>(compressionLevel);
 		}
 	} else if (isCompressionSupported(rocksdb::kLZ4Compression)) {
 		dbHandleOptions.compression = rocksdb::kLZ4Compression;

--- a/src/binding/database/database.cpp
+++ b/src/binding/database/database.cpp
@@ -15,6 +15,7 @@
 #include "napi/helpers.h"
 #include "napi/async.h"
 #include "core/verification_table.h"
+#include "core/compression.h"
 
 namespace rocksdb_js {
 
@@ -780,6 +781,29 @@ napi_value Database::Get(napi_env env, napi_callback_info info) {
 }
 
 /**
+ * Returns the compression algorithm currently in effect for this database's
+ * column family as a friendly name (e.g. "lz4", "zstd", "none"), read live from
+ * the open RocksDB via `GetOptions`.
+ *
+ * @example
+ * ```typescript
+ * const db = NativeDatabase.open('path/to/db');
+ * db.getCompression(); // 'lz4'
+ * ```
+ */
+napi_value Database::GetCompression(napi_env env, napi_callback_info info) {
+	NAPI_METHOD();
+	UNWRAP_DB_HANDLE_AND_OPEN();
+
+	rocksdb::Options opts = (*dbHandle)->descriptor->db->GetOptions((*dbHandle)->getColumnFamilyHandle());
+	std::string name = compressionNameFromType(opts.compression);
+
+	napi_value result;
+	NAPI_STATUS_THROWS(::napi_create_string_utf8(env, name.c_str(), NAPI_AUTO_LENGTH, &result));
+	return result;
+}
+
+/**
  * Gets the number of keys within a range or in the entire RocksDB database.
  *
  * @example
@@ -1384,6 +1408,33 @@ napi_value Database::Open(napi_env env, napi_callback_info info) {
 	NAPI_STATUS_THROWS(rocksdb_js::getProperty(env, options, "disableWAL", dbHandleOptions.disableWAL));
 	NAPI_STATUS_THROWS(rocksdb_js::getProperty(env, options, "verificationTable", dbHandleOptions.verificationTable));
 
+	// compression: a friendly algorithm name (e.g. "lz4", "zstd", "none"). The
+	// TypeScript layer normalizes the string|object public option and validates
+	// against the supported list before we get here; this is the defensive
+	// backstop for a name that isn't recognized or isn't compiled in.
+	std::string compressionName;
+	NAPI_STATUS_THROWS(rocksdb_js::getProperty(env, options, "compression", compressionName));
+	if (!compressionName.empty()) {
+		std::optional<rocksdb::CompressionType> type = compressionTypeFromName(compressionName);
+		if (!type || !isCompressionSupported(*type)) {
+			std::string errorMsg = "Unsupported compression algorithm: " + compressionName;
+			::napi_throw_error(env, nullptr, errorMsg.c_str());
+			return nullptr;
+		}
+		dbHandleOptions.compression = *type;
+
+		double compressionLevel = 0;
+		if (rocksdb_js::getProperty(env, options, "compressionLevel", compressionLevel, true) == napi_ok) {
+			if (std::isnan(compressionLevel) || compressionLevel != std::trunc(compressionLevel) ||
+				compressionLevel < -2147483648.0 || compressionLevel > 2147483647.0
+			) {
+				::napi_throw_error(env, nullptr, "compressionLevel must be a 32-bit integer");
+				return nullptr;
+			}
+			dbHandleOptions.compressionLevel = static_cast<int>(compressionLevel);
+		}
+	}
+
 	// statistics
 	NAPI_STATUS_THROWS(rocksdb_js::getProperty(env, options, "enableStats", dbHandleOptions.enableStats));
 	if (dbHandleOptions.enableStats) {
@@ -1751,6 +1802,7 @@ void Database::Init(napi_env env, napi_value exports) {
 		{ "flush", nullptr, Flush, nullptr, nullptr, nullptr, napi_default, nullptr },
 		{ "flushSync", nullptr, FlushSync, nullptr, nullptr, nullptr, napi_default, nullptr },
 		{ "get", nullptr, Get, nullptr, nullptr, nullptr, napi_default, nullptr },
+		{ "getCompression", nullptr, GetCompression, nullptr, nullptr, nullptr, napi_default, nullptr },
 		{ "getCount", nullptr, GetCount, nullptr, nullptr, nullptr, napi_default, nullptr },
 		{ "getDBIntProperty", nullptr, GetDBIntProperty, nullptr, nullptr, nullptr, napi_default, nullptr },
 		{ "getDBProperty", nullptr, GetDBProperty, nullptr, nullptr, nullptr, napi_default, nullptr },

--- a/src/binding/database/database.cpp
+++ b/src/binding/database/database.cpp
@@ -1411,7 +1411,11 @@ napi_value Database::Open(napi_env env, napi_callback_info info) {
 	// compression: a friendly algorithm name (e.g. "lz4", "zstd", "none"). The
 	// TypeScript layer normalizes the string|object public option and validates
 	// against the supported list before we get here; this is the defensive
-	// backstop for a name that isn't recognized or isn't compiled in.
+	// backstop for a name that isn't recognized or isn't compiled in. When the
+	// caller does not specify one, default to LZ4 where the build supports it
+	// (otherwise leave RocksDB's own default). The default is not marked
+	// explicit, so a plain reopen of an already-open column family does not
+	// conflict with its live algorithm (see DBRegistry::OpenDB).
 	std::string compressionName;
 	NAPI_STATUS_THROWS(rocksdb_js::getProperty(env, options, "compression", compressionName));
 	if (!compressionName.empty()) {
@@ -1422,6 +1426,7 @@ napi_value Database::Open(napi_env env, napi_callback_info info) {
 			return nullptr;
 		}
 		dbHandleOptions.compression = *type;
+		dbHandleOptions.compressionExplicit = true;
 
 		double compressionLevel = 0;
 		if (rocksdb_js::getProperty(env, options, "compressionLevel", compressionLevel, true) == napi_ok) {
@@ -1433,6 +1438,8 @@ napi_value Database::Open(napi_env env, napi_callback_info info) {
 			}
 			dbHandleOptions.compressionLevel = static_cast<int>(compressionLevel);
 		}
+	} else if (isCompressionSupported(rocksdb::kLZ4Compression)) {
+		dbHandleOptions.compression = rocksdb::kLZ4Compression;
 	}
 
 	// statistics

--- a/src/binding/database/database.h
+++ b/src/binding/database/database.h
@@ -284,6 +284,7 @@ struct Database final {
 	static napi_value Flush(napi_env env, napi_callback_info info);
 	static napi_value FlushSync(napi_env env, napi_callback_info info);
 	static napi_value Get(napi_env env, napi_callback_info info);
+	static napi_value GetCompression(napi_env env, napi_callback_info info);
 	static napi_value GetCount(napi_env env, napi_callback_info info);
 	static napi_value GetDBIntProperty(napi_env env, napi_callback_info info);
 	static napi_value GetDBProperty(napi_env env, napi_callback_info info);

--- a/src/binding/database/db_descriptor.cpp
+++ b/src/binding/database/db_descriptor.cpp
@@ -836,7 +836,17 @@ std::shared_ptr<DBDescriptor> DBDescriptor::open(const std::string& path, const 
 	cfOptions.write_buffer_size = static_cast<size_t>(options.writeBufferSize);
 	cfOptions.max_write_buffer_number = options.maxWriteBufferNumber;
 	cfOptions.max_write_buffer_size_to_maintain = options.maxWriteBufferSizeToMaintain;
-	applyCompression(cfOptions, options.compression, options.compressionLevel);
+	if (options.compression) {
+		cfOptions.compression = *options.compression;
+		// Large values are stored in blob files (enable_blob_files), which have
+		// their own compression setting that defaults to none. Apply the same
+		// algorithm there so the option compresses the whole dataset, not just the
+		// inline (< min_blob_size) portion.
+		cfOptions.blob_compression_type = *options.compression;
+		if (options.compressionLevel) {
+			cfOptions.compression_opts.level = *options.compressionLevel;
+		}
+	}
 	cfOptions.table_factory.reset(rocksdb::NewBlockBasedTableFactory(tableOptions));
 
 	// create a shared pointer to hold the weak descriptor reference for the event listener

--- a/src/binding/database/db_descriptor.cpp
+++ b/src/binding/database/db_descriptor.cpp
@@ -3,9 +3,12 @@
 #include "database/db_settings.h"
 #include "napi/helpers.h"
 #include "transaction_log/transaction_log_store_registry.h"
+#include "rocksdb/convenience.h"
 #include "rocksdb/listener.h"
+#include "rocksdb/utilities/options_util.h"
 #include <algorithm>
 #include <memory>
+#include <unordered_map>
 
 namespace rocksdb_js {
 
@@ -19,6 +22,61 @@ static std::atomic<uint64_t> vtEpochCounter{1};
 
 static uint64_t nextVtEpoch() {
 	return vtEpochCounter.fetch_add(1, std::memory_order_relaxed);
+}
+
+// A column family's persisted compression, recovered from the on-disk OPTIONS
+// file so a cold open of one CF does not clobber the others (compression is
+// per-CF).
+struct PersistedCompression {
+	rocksdb::CompressionType compression;
+	rocksdb::CompressionType blobCompression;
+	rocksdb::CompressionOptions compressionOpts;
+};
+
+// Applies a compression algorithm (and optional level) to both the SST block
+// compression and the blob-file compression of the given column family options.
+static void applyCompression(
+	rocksdb::ColumnFamilyOptions& cfOptions,
+	rocksdb::CompressionType compression,
+	const std::optional<int>& level
+) {
+	cfOptions.compression = compression;
+	// Large values are stored in blob files (enable_blob_files), which have their
+	// own compression that defaults to none; apply the same algorithm so the
+	// whole dataset is compressed, not just the inline (< min_blob_size) portion.
+	cfOptions.blob_compression_type = compression;
+	if (level) {
+		cfOptions.compression_opts.level = *level;
+	}
+}
+
+// Reads each existing column family's persisted compression from the database's
+// latest OPTIONS file. Returns an empty map when the DB has no OPTIONS file yet
+// (fresh DB) or the file cannot be parsed — callers then fall back to RocksDB's
+// defaults for CFs they are not explicitly configuring.
+static std::unordered_map<std::string, PersistedCompression> loadPersistedCompression(
+	const std::string& path
+) {
+	std::unordered_map<std::string, PersistedCompression> result;
+	rocksdb::ConfigOptions configOptions;
+	// Be permissive: we only read compression fields, so unknown/unsupported
+	// options in the persisted file must not fail the load.
+	configOptions.ignore_unknown_options = true;
+	configOptions.ignore_unsupported_options = true;
+	rocksdb::DBOptions loadedDbOptions;
+	std::vector<rocksdb::ColumnFamilyDescriptor> loadedCfDescriptors;
+	rocksdb::Status status =
+		rocksdb::LoadLatestOptions(configOptions, path, &loadedDbOptions, &loadedCfDescriptors);
+	if (status.ok()) {
+		for (const auto& descriptor : loadedCfDescriptors) {
+			result[descriptor.name] = PersistedCompression{
+				descriptor.options.compression,
+				descriptor.options.blob_compression_type,
+				descriptor.options.compression_opts,
+			};
+		}
+	}
+	return result;
 }
 
 struct JobTracker final {
@@ -828,7 +886,9 @@ std::shared_ptr<DBDescriptor> DBDescriptor::open(const std::string& path, const 
 		dbOptions.statistics = nullptr;
 	}
 
-	// Define base ColumnFamilyOptions that include blob settings
+	// Base ColumnFamilyOptions (blob + write-buffer + table settings) shared by
+	// every column family. Compression is intentionally NOT set here: it is
+	// per-CF, so it is applied per descriptor below.
 	rocksdb::ColumnFamilyOptions cfOptions;
 	cfOptions.enable_blob_files = true;
 	cfOptions.min_blob_size = 2048;
@@ -836,17 +896,6 @@ std::shared_ptr<DBDescriptor> DBDescriptor::open(const std::string& path, const 
 	cfOptions.write_buffer_size = static_cast<size_t>(options.writeBufferSize);
 	cfOptions.max_write_buffer_number = options.maxWriteBufferNumber;
 	cfOptions.max_write_buffer_size_to_maintain = options.maxWriteBufferSizeToMaintain;
-	if (options.compression) {
-		cfOptions.compression = *options.compression;
-		// Large values are stored in blob files (enable_blob_files), which have
-		// their own compression setting that defaults to none. Apply the same
-		// algorithm there so the option compresses the whole dataset, not just the
-		// inline (< min_blob_size) portion.
-		cfOptions.blob_compression_type = *options.compression;
-		if (options.compressionLevel) {
-			cfOptions.compression_opts.level = *options.compressionLevel;
-		}
-	}
 	cfOptions.table_factory.reset(rocksdb::NewBlockBasedTableFactory(tableOptions));
 
 	// create a shared pointer to hold the weak descriptor reference for the event listener
@@ -862,17 +911,38 @@ std::shared_ptr<DBDescriptor> DBDescriptor::open(const std::string& path, const 
 	DEBUG_LOG("DBDescriptor::open Listing column families for \"%s\"\n", path.c_str());
 	rocksdb::Status listStatus = rocksdb::DB::ListColumnFamilies(rocksdb::DBOptions(), path, &columnFamilyNames);
 	if (listStatus.ok() && !columnFamilyNames.empty()) {
-		// database exists, use existing column families
+		// Database exists. Compression is per-CF: opening one column family must
+		// not change another's algorithm, and RocksDB requires opening every CF
+		// at once with the options we supply (it does not restore persisted
+		// per-CF options on its own). So preserve each CF's persisted compression,
+		// and apply the caller's request ONLY to the target CF (options.name), and
+		// only when it was explicitly requested — the LZ4 default must never
+		// override an existing CF's stored algorithm (a plain reopen inherits it).
+		std::unordered_map<std::string, PersistedCompression> persisted = loadPersistedCompression(path);
 		for (const auto& cfName : columnFamilyNames) {
 			DEBUG_LOG("DBDescriptor::open Opening column family \"%s\"\n", cfName.c_str());
-			cfDescriptors.emplace_back(cfName, cfOptions); // Use cfOptions here
+			rocksdb::ColumnFamilyOptions cfo = cfOptions;
+			auto it = persisted.find(cfName);
+			if (it != persisted.end()) {
+				cfo.compression = it->second.compression;
+				cfo.blob_compression_type = it->second.blobCompression;
+				cfo.compression_opts = it->second.compressionOpts;
+			}
+			if (cfName == name && options.compression && options.compressionExplicit) {
+				applyCompression(cfo, *options.compression, options.compressionLevel);
+			}
+			cfDescriptors.emplace_back(cfName, cfo);
 		}
 	} else {
-		// database doesn't exist or no column families found, use default
+		// Database doesn't exist or no column families found. Create the default
+		// column family; apply the requested compression to it only when it is the
+		// target (a freshly-created CF gets the request — default or explicit).
 		DEBUG_LOG("DBDescriptor::open Database doesn't exist or no column families found, using default\n");
-		cfDescriptors = {
-			rocksdb::ColumnFamilyDescriptor(rocksdb::kDefaultColumnFamilyName, cfOptions) // Use cfOptions here
-		};
+		rocksdb::ColumnFamilyOptions cfo = cfOptions;
+		if (options.compression && name == rocksdb::kDefaultColumnFamilyName) {
+			applyCompression(cfo, *options.compression, options.compressionLevel);
+		}
+		cfDescriptors = { rocksdb::ColumnFamilyDescriptor(rocksdb::kDefaultColumnFamilyName, cfo) };
 	}
 
 	std::vector<rocksdb::ColumnFamilyHandle*> cfHandles;

--- a/src/binding/database/db_descriptor.cpp
+++ b/src/binding/database/db_descriptor.cpp
@@ -45,19 +45,27 @@ static void applyCompression(
 	// own compression that defaults to none; apply the same algorithm so the
 	// whole dataset is compressed, not just the inline (< min_blob_size) portion.
 	cfOptions.blob_compression_type = compression;
-	if (level) {
-		cfOptions.compression_opts.level = *level;
-	}
+	// An explicit request is "algorithm + optional level"; omitting the level
+	// means the algorithm's default. When applied over a CF that inherited a
+	// persisted level (e.g. cold-reopening a zstd-level-19 CF as zlib), that
+	// inherited level must NOT carry over — reset it to the default sentinel so
+	// the effective request matches what the API documents (and what the registry
+	// warm-reopen check compares against).
+	cfOptions.compression_opts.level =
+		level ? *level : rocksdb::CompressionOptions::kDefaultCompressionLevel;
 }
 
 // Reads each existing column family's persisted compression from the database's
-// latest OPTIONS file. Returns an empty map when the DB has no OPTIONS file yet
-// (fresh DB) or the file cannot be parsed — callers then fall back to RocksDB's
-// defaults for CFs they are not explicitly configuring.
-static std::unordered_map<std::string, PersistedCompression> loadPersistedCompression(
-	const std::string& path
+// latest OPTIONS file into `result`, returning the RocksDB status. The OPTIONS
+// file is the ONLY authoritative source for a CF's stored compression (RocksDB
+// does not restore per-CF options on open), so callers must treat a non-OK
+// status as fatal for an existing DB rather than falling back to defaults —
+// doing so would open the non-target CFs with the base default and silently
+// restamp their compression on the next OPTIONS write.
+static rocksdb::Status loadPersistedCompression(
+	const std::string& path,
+	std::unordered_map<std::string, PersistedCompression>& result
 ) {
-	std::unordered_map<std::string, PersistedCompression> result;
 	rocksdb::ConfigOptions configOptions;
 	// Be permissive: we only read compression fields, so unknown/unsupported
 	// options in the persisted file must not fail the load.
@@ -76,7 +84,7 @@ static std::unordered_map<std::string, PersistedCompression> loadPersistedCompre
 			};
 		}
 	}
-	return result;
+	return status;
 }
 
 struct JobTracker final {
@@ -918,7 +926,18 @@ std::shared_ptr<DBDescriptor> DBDescriptor::open(const std::string& path, const 
 		// and apply the caller's request ONLY to the target CF (options.name), and
 		// only when it was explicitly requested — the LZ4 default must never
 		// override an existing CF's stored algorithm (a plain reopen inherits it).
-		std::unordered_map<std::string, PersistedCompression> persisted = loadPersistedCompression(path);
+		std::unordered_map<std::string, PersistedCompression> persisted;
+		rocksdb::Status persistedStatus = loadPersistedCompression(path, persisted);
+		if (!persistedStatus.ok()) {
+			// The DB exists (we just listed its column families), so a missing or
+			// unparseable OPTIONS file is NOT the fresh-DB case — we cannot recover
+			// each CF's persisted compression, and opening them with the base
+			// defaults would silently restamp the non-target CFs. Fail loudly.
+			throw rocksdb_js::DBException(
+				"Failed to load persisted column family options for \"" + path +
+				"\": " + persistedStatus.ToString()
+			);
+		}
 		for (const auto& cfName : columnFamilyNames) {
 			DEBUG_LOG("DBDescriptor::open Opening column family \"%s\"\n", cfName.c_str());
 			rocksdb::ColumnFamilyOptions cfo = cfOptions;

--- a/src/binding/database/db_descriptor.cpp
+++ b/src/binding/database/db_descriptor.cpp
@@ -1,6 +1,7 @@
 #include "core/platform.h"
 #include "database/db_descriptor.h"
 #include "database/db_settings.h"
+#include "napi/helpers.h"
 #include "transaction_log/transaction_log_store_registry.h"
 #include "rocksdb/listener.h"
 #include <algorithm>
@@ -835,6 +836,7 @@ std::shared_ptr<DBDescriptor> DBDescriptor::open(const std::string& path, const 
 	cfOptions.write_buffer_size = static_cast<size_t>(options.writeBufferSize);
 	cfOptions.max_write_buffer_number = options.maxWriteBufferNumber;
 	cfOptions.max_write_buffer_size_to_maintain = options.maxWriteBufferSizeToMaintain;
+	applyCompression(cfOptions, options.compression, options.compressionLevel);
 	cfOptions.table_factory.reset(rocksdb::NewBlockBasedTableFactory(tableOptions));
 
 	// create a shared pointer to hold the weak descriptor reference for the event listener
@@ -918,7 +920,7 @@ std::shared_ptr<DBDescriptor> DBDescriptor::open(const std::string& path, const 
 		}
 	}
 	if (!columnExists) {
-		auto column = rocksdb_js::createRocksDBColumnFamily(db, options.name);
+		auto column = rocksdb_js::createRocksDBColumnFamily(db, options.name, options.compression, options.compressionLevel);
 		auto columnDescriptor = std::make_shared<ColumnFamilyDescriptor>(column);
 		columns[options.name] = columnDescriptor;
 	}

--- a/src/binding/database/db_registry.cpp
+++ b/src/binding/database/db_registry.cpp
@@ -333,7 +333,7 @@ std::unique_ptr<DBHandleParams> DBRegistry::OpenDB(const std::string& path, cons
 				throw rocksdb_js::DBException("Column family \"" + name + "\" not found: cannot create column family in read-only mode");
 			}
 			DEBUG_LOG("%p DBRegistry::OpenDB Creating column family \"%s\"\n", instance.get(), name.c_str());
-			auto column = rocksdb_js::createRocksDBColumnFamily(entry.descriptor->db, name);
+			auto column = rocksdb_js::createRocksDBColumnFamily(entry.descriptor->db, name, options.compression, options.compressionLevel);
 			auto columnDescriptor = std::make_shared<ColumnFamilyDescriptor>(column);
 			columns[name] = columnDescriptor;
 			entry.descriptor->columns[name] = columnDescriptor;

--- a/src/binding/database/db_registry.cpp
+++ b/src/binding/database/db_registry.cpp
@@ -342,17 +342,25 @@ std::unique_ptr<DBHandleParams> DBRegistry::OpenDB(const std::string& path, cons
 			// The column family is already open in this process (the DBDescriptor
 			// is process-global and shared across handles/envs). Compression is
 			// fixed per column family at creation, so a second open explicitly
-			// asking for a different algorithm cannot take effect on the reused
-			// handle — reject it rather than silently ignore the request. A plain
-			// reopen (compression defaulted, not explicit) inherits the live
+			// asking for a different algorithm or level cannot take effect on the
+			// reused handle — reject it rather than silently ignore the request. A
+			// plain reopen (compression defaulted, not explicit) inherits the live
 			// setting and skips this check.
 			rocksdb::ColumnFamilyHandle* cf = columns[name]->column.get();
-			rocksdb::CompressionType current = entry.descriptor->db->GetOptions(cf).compression;
-			if (current != *options.compression) {
+			rocksdb::Options current = entry.descriptor->db->GetOptions(cf);
+			bool algorithmDiffers = current.compression != *options.compression;
+			bool levelDiffers = options.compressionLevel &&
+				current.compression_opts.level != *options.compressionLevel;
+			if (algorithmDiffers || levelDiffers) {
+				std::string requested = rocksdb_js::compressionNameFromType(*options.compression);
+				if (options.compressionLevel) {
+					requested += " (level " + std::to_string(*options.compressionLevel) + ")";
+				}
 				throw rocksdb_js::DBException(
 					"Column family \"" + name + "\" is already open with compression \"" +
-					rocksdb_js::compressionNameFromType(current) + "\"; cannot reopen it with \"" +
-					rocksdb_js::compressionNameFromType(*options.compression) + "\""
+					rocksdb_js::compressionNameFromType(current.compression) + " (level " +
+					std::to_string(current.compression_opts.level) + ")\"; cannot reopen it with \"" +
+					requested + "\""
 				);
 			}
 		}

--- a/src/binding/database/db_registry.cpp
+++ b/src/binding/database/db_registry.cpp
@@ -1,6 +1,7 @@
 #include "database/db_registry.h"
 #include "napi/macros.h"
 #include "core/platform.h"
+#include "core/compression.h"
 #include "napi/helpers.h"
 #include "napi/async.h"
 #include "rocksdb/table.h"
@@ -337,6 +338,23 @@ std::unique_ptr<DBHandleParams> DBRegistry::OpenDB(const std::string& path, cons
 			auto columnDescriptor = std::make_shared<ColumnFamilyDescriptor>(column);
 			columns[name] = columnDescriptor;
 			entry.descriptor->columns[name] = columnDescriptor;
+		} else if (options.compressionExplicit && options.compression) {
+			// The column family is already open in this process (the DBDescriptor
+			// is process-global and shared across handles/envs). Compression is
+			// fixed per column family at creation, so a second open explicitly
+			// asking for a different algorithm cannot take effect on the reused
+			// handle — reject it rather than silently ignore the request. A plain
+			// reopen (compression defaulted, not explicit) inherits the live
+			// setting and skips this check.
+			rocksdb::ColumnFamilyHandle* cf = columns[name]->column.get();
+			rocksdb::CompressionType current = entry.descriptor->db->GetOptions(cf).compression;
+			if (current != *options.compression) {
+				throw rocksdb_js::DBException(
+					"Column family \"" + name + "\" is already open with compression \"" +
+					rocksdb_js::compressionNameFromType(current) + "\"; cannot reopen it with \"" +
+					rocksdb_js::compressionNameFromType(*options.compression) + "\""
+				);
+			}
 		}
 	} else {
 		try {

--- a/src/binding/database/db_registry.cpp
+++ b/src/binding/database/db_registry.cpp
@@ -348,17 +348,29 @@ std::unique_ptr<DBHandleParams> DBRegistry::OpenDB(const std::string& path, cons
 			// setting and skips this check.
 			rocksdb::ColumnFamilyHandle* cf = columns[name]->column.get();
 			rocksdb::Options current = entry.descriptor->db->GetOptions(cf);
+			// The effective request omitting a level is "the algorithm's default
+			// level" (see applyCompression in db_descriptor.cpp), so compare against
+			// the default sentinel rather than skipping the level check — otherwise
+			// reopening a zstd-level-19 CF as plain zstd would silently inherit 19.
+			int requestedLevel = options.compressionLevel
+				? *options.compressionLevel
+				: rocksdb::CompressionOptions::kDefaultCompressionLevel;
 			bool algorithmDiffers = current.compression != *options.compression;
-			bool levelDiffers = options.compressionLevel &&
-				current.compression_opts.level != *options.compressionLevel;
-			if (algorithmDiffers || levelDiffers) {
+			// The request applies the algorithm to blob files too, so a live CF whose
+			// blobs are at a different algorithm (e.g. a legacy CF opened plainly with
+			// block=snappy but blob=none) is also a conflict — otherwise values at the
+			// 2KB blob threshold would stay uncompressed while the open appears to succeed.
+			bool blobDiffers = current.blob_compression_type != *options.compression;
+			bool levelDiffers = current.compression_opts.level != requestedLevel;
+			if (algorithmDiffers || blobDiffers || levelDiffers) {
 				std::string requested = rocksdb_js::compressionNameFromType(*options.compression);
 				if (options.compressionLevel) {
 					requested += " (level " + std::to_string(*options.compressionLevel) + ")";
 				}
 				throw rocksdb_js::DBException(
 					"Column family \"" + name + "\" is already open with compression \"" +
-					rocksdb_js::compressionNameFromType(current.compression) + " (level " +
+					rocksdb_js::compressionNameFromType(current.compression) + " (blob " +
+					rocksdb_js::compressionNameFromType(current.blob_compression_type) + ", level " +
 					std::to_string(current.compression_opts.level) + ")\"; cannot reopen it with \"" +
 					requested + "\""
 				);

--- a/src/binding/napi/helpers.cpp
+++ b/src/binding/napi/helpers.cpp
@@ -229,7 +229,31 @@ std::string getNapiExtendedError(napi_env env, napi_status& status, const char* 
 	return std::string(errorStr);
 }
 
-std::shared_ptr<rocksdb::ColumnFamilyHandle> createRocksDBColumnFamily(const std::shared_ptr<rocksdb::DB> db, const std::string& name) {
+void applyCompression(
+	rocksdb::ColumnFamilyOptions& cfOptions,
+	const std::optional<rocksdb::CompressionType>& compression,
+	const std::optional<int>& compressionLevel
+) {
+	if (!compression) {
+		return;
+	}
+	cfOptions.compression = *compression;
+	// Large values are stored in blob files (enable_blob_files), which have
+	// their own compression setting that defaults to none. Apply the same
+	// algorithm there so the option compresses the whole dataset, not just the
+	// inline (< min_blob_size) portion.
+	cfOptions.blob_compression_type = *compression;
+	if (compressionLevel) {
+		cfOptions.compression_opts.level = *compressionLevel;
+	}
+}
+
+std::shared_ptr<rocksdb::ColumnFamilyHandle> createRocksDBColumnFamily(
+	const std::shared_ptr<rocksdb::DB> db,
+	const std::string& name,
+	const std::optional<rocksdb::CompressionType>& compression,
+	const std::optional<int>& compressionLevel
+) {
 	rocksdb::ColumnFamilyHandle* cfHandle;
 	rocksdb::BlockBasedTableOptions tableOptions;
 	DBSettings& settings = DBSettings::getInstance();
@@ -238,6 +262,7 @@ std::shared_ptr<rocksdb::ColumnFamilyHandle> createRocksDBColumnFamily(const std
 	cfOptions.enable_blob_files = true;
 	cfOptions.min_blob_size = 2048;
 	cfOptions.enable_blob_garbage_collection = true;
+	applyCompression(cfOptions, compression, compressionLevel);
 	cfOptions.table_factory.reset(rocksdb::NewBlockBasedTableFactory(tableOptions));
 
 	rocksdb::Status status = db->CreateColumnFamily(cfOptions, name, &cfHandle);

--- a/src/binding/napi/helpers.cpp
+++ b/src/binding/napi/helpers.cpp
@@ -229,25 +229,6 @@ std::string getNapiExtendedError(napi_env env, napi_status& status, const char* 
 	return std::string(errorStr);
 }
 
-void applyCompression(
-	rocksdb::ColumnFamilyOptions& cfOptions,
-	const std::optional<rocksdb::CompressionType>& compression,
-	const std::optional<int>& compressionLevel
-) {
-	if (!compression) {
-		return;
-	}
-	cfOptions.compression = *compression;
-	// Large values are stored in blob files (enable_blob_files), which have
-	// their own compression setting that defaults to none. Apply the same
-	// algorithm there so the option compresses the whole dataset, not just the
-	// inline (< min_blob_size) portion.
-	cfOptions.blob_compression_type = *compression;
-	if (compressionLevel) {
-		cfOptions.compression_opts.level = *compressionLevel;
-	}
-}
-
 std::shared_ptr<rocksdb::ColumnFamilyHandle> createRocksDBColumnFamily(
 	const std::shared_ptr<rocksdb::DB> db,
 	const std::string& name,
@@ -262,7 +243,17 @@ std::shared_ptr<rocksdb::ColumnFamilyHandle> createRocksDBColumnFamily(
 	cfOptions.enable_blob_files = true;
 	cfOptions.min_blob_size = 2048;
 	cfOptions.enable_blob_garbage_collection = true;
-	applyCompression(cfOptions, compression, compressionLevel);
+	if (compression) {
+		cfOptions.compression = *compression;
+		// Large values are stored in blob files (enable_blob_files), which have
+		// their own compression setting that defaults to none. Apply the same
+		// algorithm there so the option compresses the whole dataset, not just the
+		// inline (< min_blob_size) portion.
+		cfOptions.blob_compression_type = *compression;
+		if (compressionLevel) {
+			cfOptions.compression_opts.level = *compressionLevel;
+		}
+	}
 	cfOptions.table_factory.reset(rocksdb::NewBlockBasedTableFactory(tableOptions));
 
 	rocksdb::Status status = db->CreateColumnFamily(cfOptions, name, &cfHandle);

--- a/src/binding/napi/helpers.h
+++ b/src/binding/napi/helpers.h
@@ -25,7 +25,24 @@ namespace rocksdb_js {
 
 void createJSError(napi_env env, const char* code, const char* message, napi_value& error);
 
-std::shared_ptr<rocksdb::ColumnFamilyHandle> createRocksDBColumnFamily(const std::shared_ptr<rocksdb::DB> db, const std::string& name);
+/**
+ * Applies a compression algorithm and optional level to column family options.
+ * When `compression` is set, it governs both SST block compression and blob
+ * file compression (`blob_compression_type`), which otherwise defaults to no
+ * compression. A `nullopt` compression leaves RocksDB's own defaults in place.
+ */
+void applyCompression(
+	rocksdb::ColumnFamilyOptions& cfOptions,
+	const std::optional<rocksdb::CompressionType>& compression,
+	const std::optional<int>& compressionLevel
+);
+
+std::shared_ptr<rocksdb::ColumnFamilyHandle> createRocksDBColumnFamily(
+	const std::shared_ptr<rocksdb::DB> db,
+	const std::string& name,
+	const std::optional<rocksdb::CompressionType>& compression = std::nullopt,
+	const std::optional<int>& compressionLevel = std::nullopt
+);
 
 void createRocksDBError(napi_env env, rocksdb::Status status, const char* msg, napi_value& error);
 

--- a/src/binding/napi/helpers.h
+++ b/src/binding/napi/helpers.h
@@ -25,18 +25,6 @@ namespace rocksdb_js {
 
 void createJSError(napi_env env, const char* code, const char* message, napi_value& error);
 
-/**
- * Applies a compression algorithm and optional level to column family options.
- * When `compression` is set, it governs both SST block compression and blob
- * file compression (`blob_compression_type`), which otherwise defaults to no
- * compression. A `nullopt` compression leaves RocksDB's own defaults in place.
- */
-void applyCompression(
-	rocksdb::ColumnFamilyOptions& cfOptions,
-	const std::optional<rocksdb::CompressionType>& compression,
-	const std::optional<int>& compressionLevel
-);
-
 std::shared_ptr<rocksdb::ColumnFamilyHandle> createRocksDBColumnFamily(
 	const std::shared_ptr<rocksdb::DB> db,
 	const std::string& name,

--- a/src/binding/options/db_options.h
+++ b/src/binding/options/db_options.h
@@ -61,17 +61,21 @@ struct DBOptions final {
 	// Opt-in per-CF flag enabling Verification Table slot locking/tracking for
 	// this column family's writes (see core/verification_table.h).
 	bool verificationTable = false;
-	// Block/blob compression algorithm for this column family. `std::nullopt`
-	// leaves RocksDB's own default in place (Snappy when linked, else none). The
-	// TypeScript layer defaults this to LZ4 when supported, so an unset value
-	// here reaching the native layer means "use RocksDB's default". Applied to
-	// both `ColumnFamilyOptions::compression` (SST blocks) and
-	// `blob_compression_type` (large values stored as blobs), which otherwise
-	// defaults to no compression. Compression is a dynamically-changeable
-	// option: on reopen the new algorithm governs subsequently written SST/blob
-	// files; existing files keep their original compression until rewritten by
-	// compaction.
+	// Block/blob compression algorithm for this column family. `Database::Open`
+	// fills this in: the caller's explicit choice, or the LZ4 default when the
+	// build supports it (else `std::nullopt` = RocksDB's own default, Snappy when
+	// linked else none). Applied to both `ColumnFamilyOptions::compression` (SST
+	// blocks) and `blob_compression_type` (large values stored as blobs), which
+	// otherwise defaults to no compression. Compression is a dynamically-
+	// changeable option: on reopen the new algorithm governs subsequently written
+	// SST/blob files; existing files keep their original compression until
+	// rewritten by compaction.
 	std::optional<rocksdb::CompressionType> compression;
+	// Whether `compression` came from an explicit caller request (vs the LZ4
+	// default). Used by `DBRegistry::OpenDB` to reject a second in-process open of
+	// an already-open column family that explicitly asks for a *different*
+	// algorithm, while letting a plain reopen inherit the live setting.
+	bool compressionExplicit = false;
 	// Compression level passed to `compression_opts.level`. `std::nullopt` keeps
 	// RocksDB's per-algorithm default level. Meaning is algorithm-specific (see
 	// CompressionOptions::level).

--- a/src/binding/options/db_options.h
+++ b/src/binding/options/db_options.h
@@ -2,8 +2,10 @@
 #define __DB_OPTIONS_H__
 
 #include <cstdint>
+#include <optional>
 #include <string>
 #include <thread>
+#include "rocksdb/compression_type.h"
 
 namespace rocksdb_js {
 
@@ -59,6 +61,21 @@ struct DBOptions final {
 	// Opt-in per-CF flag enabling Verification Table slot locking/tracking for
 	// this column family's writes (see core/verification_table.h).
 	bool verificationTable = false;
+	// Block/blob compression algorithm for this column family. `std::nullopt`
+	// leaves RocksDB's own default in place (Snappy when linked, else none). The
+	// TypeScript layer defaults this to LZ4 when supported, so an unset value
+	// here reaching the native layer means "use RocksDB's default". Applied to
+	// both `ColumnFamilyOptions::compression` (SST blocks) and
+	// `blob_compression_type` (large values stored as blobs), which otherwise
+	// defaults to no compression. Compression is a dynamically-changeable
+	// option: on reopen the new algorithm governs subsequently written SST/blob
+	// files; existing files keep their original compression until rewritten by
+	// compaction.
+	std::optional<rocksdb::CompressionType> compression;
+	// Compression level passed to `compression_opts.level`. `std::nullopt` keeps
+	// RocksDB's per-algorithm default level. Meaning is algorithm-specific (see
+	// CompressionOptions::level).
+	std::optional<int> compressionLevel;
 };
 
 } // namespace rocksdb_js

--- a/src/database.ts
+++ b/src/database.ts
@@ -17,7 +17,7 @@ import type { StatsAll, StatsDefault, StatsValue } from './stats.js';
 import {
 	type ArrayBufferWithNotify,
 	CompactOptions,
-	type CompressionAlgorithm,
+	type CompressionInfo,
 	ITERATOR_STATE_BUFFER,
 	KEY_BUFFER,
 	Store,
@@ -270,18 +270,20 @@ export class RocksDatabase extends DBI<DBITransactional> {
 	}
 
 	/**
-	 * The compression algorithm currently in effect for this database's column
-	 * family, read live from RocksDB (e.g. `'lz4'`, `'zstd'`, `'none'`). The
-	 * database must be open. Defaults to LZ4 when the native build supports it.
+	 * The compression currently in effect for this database's column family, read
+	 * live from RocksDB, as `{ algorithm, level? }`. `algorithm` is a friendly
+	 * name (e.g. `'lz4'`, `'zstd'`, `'none'`); `level` is present only when a
+	 * non-default compression level is set. The database must be open. Defaults to
+	 * LZ4 when the native build supports it.
 	 *
 	 * @example
 	 * ```typescript
-	 * const db = RocksDatabase.open('/path/to/db', { compression: 'zstd' });
-	 * db.compression; // 'zstd'
+	 * const db = RocksDatabase.open('/path/to/db', { compression: { algorithm: 'zstd', level: 3 } });
+	 * db.compression; // { algorithm: 'zstd', level: 3 }
 	 * ```
 	 */
-	get compression(): CompressionAlgorithm {
-		return this.store.db.getCompression() as CompressionAlgorithm;
+	get compression(): CompressionInfo {
+		return this.store.db.getCompression() as CompressionInfo;
 	}
 
 	/**

--- a/src/database.ts
+++ b/src/database.ts
@@ -17,6 +17,7 @@ import type { StatsAll, StatsDefault, StatsValue } from './stats.js';
 import {
 	type ArrayBufferWithNotify,
 	CompactOptions,
+	type CompressionAlgorithm,
 	ITERATOR_STATE_BUFFER,
 	KEY_BUFFER,
 	Store,
@@ -266,6 +267,21 @@ export class RocksDatabase extends DBI<DBITransactional> {
 	 */
 	get columns(): string[] {
 		return this.store.db.columns;
+	}
+
+	/**
+	 * The compression algorithm currently in effect for this database's column
+	 * family, read live from RocksDB (e.g. `'lz4'`, `'zstd'`, `'none'`). The
+	 * database must be open. Defaults to LZ4 when the native build supports it.
+	 *
+	 * @example
+	 * ```typescript
+	 * const db = RocksDatabase.open('/path/to/db', { compression: 'zstd' });
+	 * db.compression; // 'zstd'
+	 * ```
+	 */
+	get compression(): CompressionAlgorithm {
+		return this.store.getCompression();
 	}
 
 	/**

--- a/src/database.ts
+++ b/src/database.ts
@@ -281,7 +281,7 @@ export class RocksDatabase extends DBI<DBITransactional> {
 	 * ```
 	 */
 	get compression(): CompressionAlgorithm {
-		return this.store.getCompression();
+		return this.store.db.getCompression() as CompressionAlgorithm;
 	}
 
 	/**

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,6 +42,7 @@ export {
 } from './validate-transaction-log.js';
 export {
 	type CompressionAlgorithm,
+	type CompressionInfo,
 	type CompressionOption,
 	Store,
 	type StoreContext,

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,7 @@ export {
 	registryStatus,
 	stats,
 	shutdown,
+	supportedCompression,
 	TransactionLog,
 	type TransactionEntry,
 	type TransactionLogPosition,
@@ -40,6 +41,8 @@ export {
 	type ValidateTransactionLogStoreOptions,
 } from './validate-transaction-log.js';
 export {
+	type CompressionAlgorithm,
+	type CompressionOption,
 	Store,
 	type StoreContext,
 	type StoreGetOptions,

--- a/src/load-binding.ts
+++ b/src/load-binding.ts
@@ -297,7 +297,7 @@ export type NativeDatabase = {
 		txnId?: number,
 		expectedVersion?: number
 	): number;
-	getCompression(): string;
+	getCompression(): { algorithm: string; level?: number };
 	getCount(options?: RangeOptions, txnId?: number): number;
 	getDBIntProperty(propertyName: string): number | undefined;
 	getDBProperty(propertyName: string): string | undefined;

--- a/src/load-binding.ts
+++ b/src/load-binding.ts
@@ -194,6 +194,18 @@ export declare class NativeIteratorCls {
 export type NativeDatabaseMode = 'optimistic' | 'pessimistic';
 
 export type NativeDatabaseOptions = {
+	/**
+	 * The friendly name of a compression algorithm compiled into this RocksDB
+	 * build (see `supportedCompression`), e.g. `'lz4'`, `'zstd'`, `'none'`. The
+	 * higher-level `StoreOptions.compression` (which also accepts an object with
+	 * a level) is normalized down to this string plus `compressionLevel`.
+	 */
+	compression?: string;
+	/**
+	 * Compression level forwarded to RocksDB's `compression_opts.level`. Meaning
+	 * is algorithm-specific; omit to use the algorithm's default.
+	 */
+	compressionLevel?: number;
 	dbWriteBufferSize?: number;
 	disableWAL?: boolean;
 	enableStats?: boolean;
@@ -285,6 +297,7 @@ export type NativeDatabase = {
 		txnId?: number,
 		expectedVersion?: number
 	): number;
+	getCompression(): string;
 	getCount(options?: RangeOptions, txnId?: number): number;
 	getDBIntProperty(propertyName: string): number | undefined;
 	getDBProperty(propertyName: string): string | undefined;
@@ -498,6 +511,17 @@ export const constants: {
 	ITERATOR_RESULT_DONE: number;
 	ITERATOR_RESULT_FAST: number;
 } = binding.constants;
+/**
+ * The friendly names of every compression algorithm compiled into the loaded
+ * RocksDB native binding, e.g. `['none', 'snappy', 'lz4', 'zstd']`. The set is
+ * fixed for a given binary (it depends on which compression libraries RocksDB
+ * was linked against), so this is a static list. `'none'` (no compression) is
+ * always present. Use it to validate a `compression` option or to pick an
+ * algorithm that is actually available at runtime.
+ */
+export const supportedCompression: readonly string[] = Object.freeze(
+	binding.supportedCompression as string[]
+);
 export const NativeDatabase: NativeDatabase = binding.Database;
 export const NativeIterator: typeof NativeIteratorCls = binding.Iterator;
 export const NativeTransaction: NativeTransaction = binding.Transaction;

--- a/src/store.ts
+++ b/src/store.ts
@@ -153,12 +153,12 @@ export interface StoreOptions extends Omit<
 	 * files (large values). Which algorithms are available depends on the native
 	 * build — see `supportedCompression`.
 	 *
-	 * When omitted, defaults to LZ4 if the build supports it, otherwise RocksDB's
-	 * own default (Snappy when linked, else no compression). Compression is a
-	 * dynamically-changeable option: reopening with a different algorithm governs
-	 * subsequently written files; existing files keep their compression until
-	 * rewritten by compaction. Use the `compression` getter to read the value
-	 * currently in effect.
+	 * When omitted, defaults to `lz4` if the build supports it, otherwise
+	 * RocksDB's own default (Snappy when linked, else no compression).
+	 * Compression is a dynamically-changeable option: reopening with a
+	 * different algorithm governs subsequently written files; existing files
+	 * keep their compression until rewritten by compaction. Use the
+	 * `compression` getter to read the value currently in effect.
 	 *
 	 * @default 'lz4'
 	 */
@@ -253,8 +253,7 @@ export class Store {
 
 	/**
 	 * The compression algorithm (or `{ algorithm, level }`) requested for this
-	 * store's column family. Normalized and applied when the database opens; use
-	 * the `getCompression()` method to read the algorithm actually in effect.
+	 * store's column family. Normalized and applied when the database opens.
 	 */
 	compression?: CompressionOption;
 
@@ -949,19 +948,6 @@ export class Store {
 	 */
 	isOpen(): boolean {
 		return this.db.opened;
-	}
-
-	/**
-	 * Returns the compression algorithm currently in effect for this store's
-	 * column family, read live from the open RocksDB. The database must be open.
-	 *
-	 * @returns the algorithm name (e.g. `'lz4'`, `'zstd'`, `'none'`).
-	 */
-	getCompression(): CompressionAlgorithm {
-		if (!this.db.opened) {
-			throw new Error('Database not open');
-		}
-		return this.db.getCompression() as CompressionAlgorithm;
 	}
 
 	/**

--- a/src/store.ts
+++ b/src/store.ts
@@ -101,6 +101,13 @@ export type CompressionOption =
 	| { algorithm: CompressionAlgorithm; level?: number };
 
 /**
+ * The compression currently in effect for a column family, as returned by the
+ * `compression` getter. `level` is present only when a non-default compression
+ * level is configured.
+ */
+export type CompressionInfo = { algorithm: CompressionAlgorithm; level?: number };
+
+/**
  * Normalizes the public `compression` option into the primitive fields the
  * native layer expects. When `option` is omitted, returns an empty object and
  * lets the native layer apply the default (LZ4 when the build supports it, else
@@ -124,7 +131,19 @@ export function normalizeCompression(option: CompressionOption | undefined): {
 		algorithm = option;
 	} else if (typeof option === 'object' && option.algorithm !== undefined) {
 		algorithm = option.algorithm;
-		level = option.level;
+		if (option.level !== undefined && option.level !== null) {
+			// TypeScript types `level` as a number, but coerce defensively (e.g. a
+			// numeric string from loosely-typed config) and reject anything that is
+			// not a finite 32-bit integer rather than letting the native layer
+			// silently drop it.
+			const coerced = Number(option.level);
+			if (!Number.isInteger(coerced) || coerced < -2147483648 || coerced > 2147483647) {
+				throw new TypeError(
+					`compression level must be a 32-bit integer, got ${JSON.stringify(option.level)}`
+				);
+			}
+			level = coerced;
+		}
 	} else {
 		throw new TypeError('compression must be an algorithm name or an { algorithm, level } object');
 	}

--- a/src/store.ts
+++ b/src/store.ts
@@ -132,11 +132,18 @@ export function normalizeCompression(option: CompressionOption | undefined): {
 	} else if (typeof option === 'object' && option.algorithm !== undefined) {
 		algorithm = option.algorithm;
 		if (option.level !== undefined && option.level !== null) {
-			// TypeScript types `level` as a number, but coerce defensively (e.g. a
-			// numeric string from loosely-typed config) and reject anything that is
-			// not a finite 32-bit integer rather than letting the native layer
-			// silently drop it.
-			const coerced = Number(option.level);
+			// TypeScript types `level` as a number. Accept a numeric string too (a
+			// common shape from loosely-typed config), but do NOT let bare `Number()`
+			// coerce other loose inputs — `true`, `[]`, `[6]`, and `''`/whitespace all
+			// become numbers and would silently mis-tune or drop compression. Anything
+			// that is not a number or a non-blank numeric string is rejected.
+			const raw = option.level as unknown;
+			const coerced =
+				typeof raw === 'number'
+					? raw
+					: typeof raw === 'string' && raw.trim() !== ''
+						? Number(raw)
+						: Number.NaN;
 			if (!Number.isInteger(coerced) || coerced < -2147483648 || coerced > 2147483647) {
 				throw new TypeError(
 					`compression level must be a 32-bit integer, got ${JSON.stringify(option.level)}`

--- a/src/store.ts
+++ b/src/store.ts
@@ -102,32 +102,31 @@ export type CompressionOption =
 
 /**
  * Normalizes the public `compression` option into the primitive fields the
- * native layer expects. When `option` is omitted, defaults to LZ4 if that
- * algorithm is compiled into the binding, otherwise leaves RocksDB's own
- * default in place (Snappy when linked, else no compression). Throws for an
- * algorithm that isn't supported by this build.
+ * native layer expects. When `option` is omitted, returns an empty object and
+ * lets the native layer apply the default (LZ4 when the build supports it, else
+ * RocksDB's own default). Throws a `TypeError` for a malformed option and an
+ * `Error` for an algorithm that isn't supported by this build.
  */
 export function normalizeCompression(option: CompressionOption | undefined): {
 	compression?: string;
 	compressionLevel?: number;
 } {
-	let algorithm: string | undefined;
+	// When unset, leave compression to the native layer, which defaults to LZ4
+	// when the build supports it (see Database::Open).
+	if (option === undefined || option === null) {
+		return {};
+	}
+
+	let algorithm: string;
 	let level: number | undefined;
 
-	if (option === undefined || option === null) {
-		// Project default: LZ4 when available (RocksDB's own default is Snappy).
-		algorithm = supportedCompression.includes('lz4') ? 'lz4' : undefined;
-	} else if (typeof option === 'string') {
+	if (typeof option === 'string') {
 		algorithm = option;
-	} else if (typeof option === 'object') {
+	} else if (typeof option === 'object' && option.algorithm !== undefined) {
 		algorithm = option.algorithm;
 		level = option.level;
 	} else {
-		throw new TypeError('compression must be a string or an { algorithm, level } object');
-	}
-
-	if (algorithm === undefined) {
-		return {};
+		throw new TypeError('compression must be an algorithm name or an { algorithm, level } object');
 	}
 
 	if (!supportedCompression.includes(algorithm)) {

--- a/src/store.ts
+++ b/src/store.ts
@@ -20,6 +20,7 @@ import {
 	NativeIterator,
 	NativeTransaction,
 	stats,
+	supportedCompression,
 	type TransactionLog,
 	type UserSharedBufferCallback,
 } from './load-binding.js';
@@ -75,12 +76,94 @@ export type CompactOptions = {
 };
 
 /**
+ * A RocksDB block/blob compression algorithm. Which algorithms are actually
+ * available depends on the libraries the native binding was compiled with —
+ * check `supportedCompression` at runtime. `'none'` disables compression and
+ * is always available.
+ */
+export type CompressionAlgorithm =
+	| 'none'
+	| 'snappy'
+	| 'zlib'
+	| 'bzip2'
+	| 'lz4'
+	| 'lz4hc'
+	| 'xpress'
+	| 'zstd';
+
+/**
+ * The `compression` open option: either an algorithm name, or an object with
+ * an algorithm and an optional level (forwarded to RocksDB's
+ * `compression_opts.level`; meaning is algorithm-specific).
+ */
+export type CompressionOption =
+	| CompressionAlgorithm
+	| { algorithm: CompressionAlgorithm; level?: number };
+
+/**
+ * Normalizes the public `compression` option into the primitive fields the
+ * native layer expects. When `option` is omitted, defaults to LZ4 if that
+ * algorithm is compiled into the binding, otherwise leaves RocksDB's own
+ * default in place (Snappy when linked, else no compression). Throws for an
+ * algorithm that isn't supported by this build.
+ */
+export function normalizeCompression(option: CompressionOption | undefined): {
+	compression?: string;
+	compressionLevel?: number;
+} {
+	let algorithm: string | undefined;
+	let level: number | undefined;
+
+	if (option === undefined || option === null) {
+		// Project default: LZ4 when available (RocksDB's own default is Snappy).
+		algorithm = supportedCompression.includes('lz4') ? 'lz4' : undefined;
+	} else if (typeof option === 'string') {
+		algorithm = option;
+	} else if (typeof option === 'object') {
+		algorithm = option.algorithm;
+		level = option.level;
+	} else {
+		throw new TypeError('compression must be a string or an { algorithm, level } object');
+	}
+
+	if (algorithm === undefined) {
+		return {};
+	}
+
+	if (!supportedCompression.includes(algorithm)) {
+		throw new Error(
+			`Unsupported compression algorithm "${algorithm}". This build supports: ${supportedCompression.join(', ')}`
+		);
+	}
+
+	return { compression: algorithm, compressionLevel: level };
+}
+
+/**
  * Options for the `Store` class.
  */
 export interface StoreOptions extends Omit<
 	NativeDatabaseOptions,
-	'mode' | 'transactionLogRetentionMs'
+	'compression' | 'compressionLevel' | 'mode' | 'transactionLogRetentionMs'
 > {
+	/**
+	 * The block/blob compression algorithm for this column family. Accepts an
+	 * algorithm name (`'lz4'`, `'zstd'`, `'none'`, ...) or an object with an
+	 * `algorithm` and optional `level`. Applies to both SST blocks and blob
+	 * files (large values). Which algorithms are available depends on the native
+	 * build — see `supportedCompression`.
+	 *
+	 * When omitted, defaults to LZ4 if the build supports it, otherwise RocksDB's
+	 * own default (Snappy when linked, else no compression). Compression is a
+	 * dynamically-changeable option: reopening with a different algorithm governs
+	 * subsequently written files; existing files keep their compression until
+	 * rewritten by compaction. Use the `compression` getter to read the value
+	 * currently in effect.
+	 *
+	 * @default 'lz4'
+	 */
+	compression?: CompressionOption;
+
 	decoder?: Encoder | null;
 	encoder?: Encoder | null;
 	encoding?: Encoding;
@@ -167,6 +250,13 @@ export class Store {
 	 * Whether the decoder copies the buffer when encoding values.
 	 */
 	decoderCopies: boolean = false;
+
+	/**
+	 * The compression algorithm (or `{ algorithm, level }`) requested for this
+	 * store's column family. Normalized and applied when the database opens; use
+	 * the `getCompression()` method to read the algorithm actually in effect.
+	 */
+	compression?: CompressionOption;
 
 	/**
 	 * Whether to disable the write ahead log.
@@ -366,6 +456,7 @@ export class Store {
 		);
 
 		this.db = new NativeDatabase();
+		this.compression = options?.compression;
 		this.dbWriteBufferSize = options?.dbWriteBufferSize;
 		this.decoder = options?.decoder ?? null;
 		this.disableWAL = options?.disableWAL ?? false;
@@ -861,6 +952,19 @@ export class Store {
 	}
 
 	/**
+	 * Returns the compression algorithm currently in effect for this store's
+	 * column family, read live from the open RocksDB. The database must be open.
+	 *
+	 * @returns the algorithm name (e.g. `'lz4'`, `'zstd'`, `'none'`).
+	 */
+	getCompression(): CompressionAlgorithm {
+		if (!this.db.opened) {
+			throw new Error('Database not open');
+		}
+		return this.db.getCompression() as CompressionAlgorithm;
+	}
+
+	/**
 	 * Lists all transaction log names.
 	 *
 	 * @returns an array of transaction log names.
@@ -878,7 +982,11 @@ export class Store {
 			return true;
 		}
 
+		const { compression, compressionLevel } = normalizeCompression(this.compression);
+
 		this.db.open(this.path, {
+			compression,
+			compressionLevel,
 			dbWriteBufferSize: this.dbWriteBufferSize,
 			disableWAL: this.disableWAL,
 			enableStats: this.enableStats,

--- a/test/compression.test.ts
+++ b/test/compression.test.ts
@@ -290,6 +290,26 @@ describe('Compression', () => {
 				}
 			}
 		);
+
+		it.skipIf(!levelCompressor)(
+			'throws when a second open omits the level but the CF is live at a non-default level',
+			() => {
+				// Omitting the level means "the algorithm's default level", which differs
+				// from the live level 4 — so an explicit reopen must conflict rather than
+				// silently inherit 4.
+				const path = tempPath();
+				const dbA = RocksDatabase.open(path, {
+					compression: { algorithm: levelCompressor!, level: 4 },
+				});
+				try {
+					expect(() => RocksDatabase.open(path, { compression: levelCompressor! })).toThrow(
+						/already open with compression/
+					);
+				} finally {
+					dbA.close();
+				}
+			}
+		);
 	});
 
 	describe('per-column-family', () => {
@@ -327,6 +347,56 @@ describe('Compression', () => {
 				}
 			}
 		);
+
+		it.skipIf(!levelCompressor)(
+			'a cold reopen with an explicit algorithm and no level resets the persisted level',
+			() => {
+				// A CF persisted at level 4, cold-reopened as the same algorithm without
+				// a level, must fall back to the algorithm's default level (getter omits
+				// it) — not silently inherit the persisted 4.
+				const path = tempPath();
+				const dbA = RocksDatabase.open(path, {
+					compression: { algorithm: levelCompressor!, level: 4 },
+				});
+				dbA.putSync(1, 'x');
+				dbA.flushSync();
+				dbA.close();
+
+				const dbB = RocksDatabase.open(path, { compression: levelCompressor! });
+				try {
+					expect(dbB.compression).toEqual({ algorithm: levelCompressor });
+				} finally {
+					dbB.close();
+				}
+			}
+		);
+
+		it('fails the open when an existing DB’s OPTIONS file cannot be read', () => {
+			// The persisted OPTIONS file is the only authoritative source for each
+			// CF's compression. If it is missing/corrupt for a DB that already exists,
+			// opening every CF with the base defaults would silently restamp the
+			// non-target CFs — so the open must fail loudly instead.
+			const path = tempPath();
+			const db = RocksDatabase.open(path, { name: 'plain', compression: 'none' });
+			db.putSync(1, 'x');
+			db.close();
+
+			// Remove every OPTIONS-* file. RocksDB still opens the DB (it does not
+			// require OPTIONS) and ListColumnFamilies still succeeds from the MANIFEST,
+			// but LoadLatestOptions can no longer recover the persisted compression.
+			let removed = 0;
+			for (const entry of readdirSync(path)) {
+				if (entry.startsWith('OPTIONS-')) {
+					rmSync(join(path, entry));
+					removed++;
+				}
+			}
+			expect(removed).toBeGreaterThan(0);
+
+			expect(() => RocksDatabase.open(path, { name: 'plain', compression: 'none' })).toThrow(
+				/persisted column family options/
+			);
+		});
 	});
 
 	describe('normalizeCompression', () => {
@@ -377,6 +447,22 @@ describe('Compression', () => {
 				TypeError
 			);
 			expect(() => normalizeCompression({ algorithm: 'none', level: 1e10 })).toThrow(TypeError);
+		});
+
+		it('rejects loose non-number levels instead of silently coercing them', () => {
+			// `Number()` would turn all of these into a number (true→1, ''→0, []→0,
+			// [6]→6) and quietly mis-tune or drop compression. Only a number or a
+			// non-blank numeric string is accepted.
+			for (const bad of [true, false, '', '   ', [], [6], {}]) {
+				expect(() => normalizeCompression({ algorithm: 'none', level: bad as never })).toThrow(
+					TypeError
+				);
+			}
+			// A whitespace-padded numeric string is still coerced.
+			expect(normalizeCompression({ algorithm: 'none', level: '  6  ' as never })).toEqual({
+				compression: 'none',
+				compressionLevel: 6,
+			});
 		});
 	});
 

--- a/test/compression.test.ts
+++ b/test/compression.test.ts
@@ -124,6 +124,11 @@ describe('Compression', () => {
 				db.close();
 			}
 		});
+
+		it('should error if database is not open', () => {
+			const db = new RocksDatabase(tempPath());
+			expect(() => db.compression).toThrow('Database not open');
+		});
 	});
 
 	describe('validation', () => {

--- a/test/compression.test.ts
+++ b/test/compression.test.ts
@@ -1,8 +1,18 @@
 import { type CompressionAlgorithm, RocksDatabase, supportedCompression } from '../src/index.js';
 import { normalizeCompression } from '../src/store.js';
 import { generateDBPath } from './lib/util.js';
-import { execFileSync } from 'node:child_process';
-import { readdirSync, rmSync, statSync } from 'node:fs';
+import { execFileSync, spawnSync } from 'node:child_process';
+import {
+	cpSync,
+	existsSync,
+	mkdirSync,
+	readFileSync,
+	readdirSync,
+	rmSync,
+	statSync,
+	symlinkSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { afterEach, describe, expect, it } from 'vitest';
@@ -393,6 +403,72 @@ describe('Compression', () => {
 					expect(token.startsWith('-l') || token.endsWith('.lib')).toBe(true);
 				}
 			}
+		);
+
+		// A real `node-gyp configure` from a checkout whose path contains a space.
+		// The whitespace-free-token check above only exercises the helper; this
+		// drives gyp end-to-end so it also covers the gtest.gyp command quoting
+		// and binding.gyp's module-relative link inputs — both of which break a
+		// spaced checkout differently (a shell-split `<!()` command vs. an
+		// unquoted absolute path emitted into LDFLAGS/LIBS).
+		const gypBin = join(repoRoot, 'node_modules', 'node-gyp', 'bin', 'node-gyp.js');
+		const spacedConfigureRunnable =
+			!nonNodeRuntime &&
+			process.platform !== 'win32' && // spaces break the make generator; MSVS quotes
+			existsSync(join(repoRoot, 'deps', 'rocksdb', 'lib', 'librocksdb.a')) &&
+			existsSync(gypBin);
+
+		it.skipIf(!spacedConfigureRunnable)(
+			'configures cleanly from a checkout path containing a space',
+			() => {
+				// A spaced "checkout" that symlinks the heavy trees back to the real
+				// repo (nothing copied or downloaded), but keeps the two .gyp files as
+				// REAL files: a symlinked .gyp resolves to its real, unspaced path and
+				// would defeat the test. module_root_dir becomes the spaced path.
+				const spaced = join(tmpdir(), `rocksdb js gyp ${process.pid}`);
+				rmSync(spaced, { recursive: true, force: true });
+				mkdirSync(join(spaced, 'deps'), { recursive: true });
+				try {
+					for (const entry of readdirSync(repoRoot)) {
+						if (entry === 'deps' || entry === 'build' || entry === '.git') {
+							continue;
+						}
+						if (entry === 'binding.gyp') {
+							cpSync(join(repoRoot, entry), join(spaced, entry));
+						} else {
+							symlinkSync(join(repoRoot, entry), join(spaced, entry));
+						}
+					}
+					for (const entry of readdirSync(join(repoRoot, 'deps'))) {
+						const dst = join(spaced, 'deps', entry);
+						if (entry === 'gtest.gyp') {
+							cpSync(join(repoRoot, 'deps', entry), dst);
+						} else {
+							symlinkSync(join(repoRoot, 'deps', entry), dst);
+						}
+					}
+
+					const res = spawnSync(process.execPath, [gypBin, 'configure'], {
+						cwd: spaced,
+						encoding: 'utf8',
+					});
+					// A shell-split gtest.gyp command aborts configure here (exit != 0).
+					expect(res.stderr + res.stdout).not.toMatch(/No such file or directory/);
+					expect(res.status).toBe(0);
+
+					// The generated link settings must carry no absolute path bearing the
+					// spaced root (which the link shell would split), and must link
+					// rocksdb via a search-dir-resolved `-l` token rather than a path.
+					for (const target of ['rocksdb-js.target.mk', 'rocksdb-js-native-tests.target.mk']) {
+						const mk = readFileSync(join(spaced, 'build', target), 'utf8');
+						expect(mk).not.toContain(spaced);
+						expect(mk).toMatch(/-l:?(lib)?rocksdb(\.a)?\b/);
+					}
+				} finally {
+					rmSync(spaced, { recursive: true, force: true });
+				}
+			},
+			120_000
 		);
 	});
 

--- a/test/compression.test.ts
+++ b/test/compression.test.ts
@@ -1,0 +1,197 @@
+import { type CompressionAlgorithm, RocksDatabase, supportedCompression } from '../src/index.js';
+import { generateDBPath } from './lib/util.js';
+import { readdirSync, rmSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const tempPaths: string[] = [];
+
+function tempPath(): string {
+	const p = generateDBPath();
+	tempPaths.push(p);
+	return p;
+}
+
+afterEach(() => {
+	while (tempPaths.length) {
+		rmSync(tempPaths.pop()!, { recursive: true, force: true });
+	}
+});
+
+/** Total size in bytes of every file under a directory (recursively). */
+function dirSize(dir: string): number {
+	let total = 0;
+	for (const entry of readdirSync(dir, { withFileTypes: true })) {
+		const p = join(dir, entry.name);
+		if (entry.isDirectory()) {
+			total += dirSize(p);
+		} else {
+			try {
+				total += statSync(p).size;
+			} catch {
+				// file may vanish during background compaction; ignore
+			}
+		}
+	}
+	return total;
+}
+
+/**
+ * Writes highly compressible records, then flushes and compacts so the data is
+ * materialized into SST/blob files using the column family's compression.
+ */
+function populate(db: RocksDatabase, count: number): void {
+	const filler = 'the quick brown fox jumps over the lazy dog '.repeat(24);
+	for (let i = 0; i < count; ++i) {
+		db.putSync(i, {
+			id: i,
+			name: `record-${i}`,
+			note: filler,
+			tags: ['alpha', 'beta', 'gamma', 'delta'],
+		});
+	}
+	db.flushSync();
+	db.compactSync();
+}
+
+// A real (non-"none") compressor available in this build, if any. The local
+// dev prebuild may link only a subset (e.g. none + zlib), so size-comparison
+// tests are conditional on one being present.
+const algorithms = supportedCompression as readonly CompressionAlgorithm[];
+const realCompressor = algorithms.find((name) => name !== 'none');
+
+describe('Compression', () => {
+	describe('supportedCompression', () => {
+		it('is a non-empty, frozen list that always includes "none"', () => {
+			expect(Array.isArray(supportedCompression)).toBe(true);
+			expect(supportedCompression.length).toBeGreaterThan(0);
+			expect(supportedCompression).toContain('none');
+			expect(Object.isFrozen(supportedCompression)).toBe(true);
+		});
+	});
+
+	describe('compression getter / defaults', () => {
+		it('reports a supported algorithm by default', () => {
+			const db = RocksDatabase.open(tempPath());
+			try {
+				expect(supportedCompression).toContain(db.compression);
+			} finally {
+				db.close();
+			}
+		});
+
+		it('defaults to LZ4 when the build supports it', () => {
+			const db = RocksDatabase.open(tempPath());
+			try {
+				if (supportedCompression.includes('lz4')) {
+					expect(db.compression).toBe('lz4');
+				} else {
+					// No LZ4: falls back to RocksDB's own default (snappy if linked,
+					// otherwise none). Either way it must be a supported value.
+					expect(supportedCompression).toContain(db.compression);
+				}
+			} finally {
+				db.close();
+			}
+		});
+
+		it('round-trips every supported algorithm through the getter', () => {
+			for (const algorithm of algorithms) {
+				const db = RocksDatabase.open(tempPath(), { compression: algorithm });
+				try {
+					expect(db.compression).toBe(algorithm);
+				} finally {
+					db.close();
+				}
+			}
+		});
+
+		it('accepts the object form with an explicit level', () => {
+			const algorithm = realCompressor ?? 'none';
+			const db = RocksDatabase.open(tempPath(), { compression: { algorithm, level: 6 } });
+			try {
+				expect(db.compression).toBe(algorithm);
+			} finally {
+				db.close();
+			}
+		});
+
+		it('can explicitly disable compression', () => {
+			const db = RocksDatabase.open(tempPath(), { compression: 'none' });
+			try {
+				expect(db.compression).toBe('none');
+			} finally {
+				db.close();
+			}
+		});
+	});
+
+	describe('validation', () => {
+		it('throws for an unsupported algorithm name', () => {
+			expect(() => RocksDatabase.open(tempPath(), { compression: 'gzip' as never })).toThrow(
+				/Unsupported compression algorithm "gzip"/
+			);
+		});
+
+		it('throws for an unsupported algorithm in the object form', () => {
+			expect(() =>
+				RocksDatabase.open(tempPath(), { compression: { algorithm: 'brotli' as never } })
+			).toThrow(/Unsupported compression algorithm "brotli"/);
+		});
+	});
+
+	describe('on-disk size', () => {
+		it.skipIf(!realCompressor)(
+			`compresses data smaller than "none" (using ${realCompressor})`,
+			() => {
+				const nonePath = tempPath();
+				const compressedPath = tempPath();
+
+				const noneDb = RocksDatabase.open(nonePath, { compression: 'none' });
+				populate(noneDb, 10_000);
+				noneDb.close();
+
+				const compressedDb = RocksDatabase.open(compressedPath, {
+					compression: realCompressor,
+				});
+				populate(compressedDb, 10_000);
+				expect(compressedDb.compression).toBe(realCompressor);
+				compressedDb.close();
+
+				const noneSize = dirSize(nonePath);
+				const compressedSize = dirSize(compressedPath);
+				expect(compressedSize).toBeLessThan(noneSize);
+			}
+		);
+
+		it.skipIf(!realCompressor)(
+			'keeps multiple databases with different compression settings independent',
+			() => {
+				// The issue explicitly asks to verify multiple databases with
+				// different settings populated and compared side by side.
+				const paths = {
+					none: tempPath(),
+					compressed: tempPath(),
+				};
+
+				const dbNone = RocksDatabase.open(paths.none, { compression: 'none' });
+				const dbCompressed = RocksDatabase.open(paths.compressed, {
+					compression: realCompressor,
+				});
+
+				// Populate both while they are open simultaneously to prove the
+				// per-database setting is not shared global state.
+				populate(dbNone, 10_000);
+				populate(dbCompressed, 10_000);
+
+				expect(dbNone.compression).toBe('none');
+				expect(dbCompressed.compression).toBe(realCompressor);
+
+				dbNone.close();
+				dbCompressed.close();
+
+				expect(dirSize(paths.compressed)).toBeLessThan(dirSize(paths.none));
+			}
+		);
+	});
+});

--- a/test/compression.test.ts
+++ b/test/compression.test.ts
@@ -1,4 +1,5 @@
 import { type CompressionAlgorithm, RocksDatabase, supportedCompression } from '../src/index.js';
+import { normalizeCompression } from '../src/store.js';
 import { generateDBPath } from './lib/util.js';
 import { readdirSync, rmSync, statSync } from 'node:fs';
 import { join } from 'node:path';
@@ -198,5 +199,83 @@ describe('Compression', () => {
 				expect(dirSize(paths.compressed)).toBeLessThan(dirSize(paths.none));
 			}
 		);
+	});
+
+	describe('already-open column family', () => {
+		it.skipIf(!realCompressor)(
+			'throws when a second open explicitly requests a different compression',
+			() => {
+				const path = tempPath();
+				const dbA = RocksDatabase.open(path, { compression: 'none' });
+				try {
+					expect(() => RocksDatabase.open(path, { compression: realCompressor })).toThrow(
+						/already open with compression/
+					);
+				} finally {
+					dbA.close();
+				}
+			}
+		);
+
+		it.skipIf(!realCompressor)('allows a second open requesting the same compression', () => {
+			const path = tempPath();
+			const dbA = RocksDatabase.open(path, { compression: realCompressor });
+			let dbB: RocksDatabase | undefined;
+			try {
+				dbB = RocksDatabase.open(path, { compression: realCompressor });
+				expect(dbB.compression).toBe(realCompressor);
+			} finally {
+				dbA.close();
+				dbB?.close();
+			}
+		});
+
+		it.skipIf(!realCompressor)(
+			'allows a plain reopen without specifying compression (inherits the live setting)',
+			() => {
+				// The default compression is not "explicit", so a plain reopen must
+				// not conflict with the already-open column family's algorithm.
+				const path = tempPath();
+				const dbA = RocksDatabase.open(path, { compression: realCompressor });
+				let dbB: RocksDatabase | undefined;
+				try {
+					dbB = RocksDatabase.open(path);
+					expect(dbB.compression).toBe(realCompressor);
+				} finally {
+					dbA.close();
+					dbB?.close();
+				}
+			}
+		);
+	});
+
+	describe('normalizeCompression', () => {
+		it('returns empty (native default) for an unset option', () => {
+			expect(normalizeCompression(undefined)).toEqual({});
+			expect(normalizeCompression(null as never)).toEqual({});
+		});
+
+		it('throws for an object without an algorithm', () => {
+			expect(() => normalizeCompression({ level: 3 } as never)).toThrow(TypeError);
+			expect(() => normalizeCompression({} as never)).toThrow(TypeError);
+			expect(() => normalizeCompression([] as never)).toThrow(TypeError);
+		});
+
+		it('throws for an unsupported algorithm as string or object', () => {
+			expect(() => normalizeCompression('gzip' as never)).toThrow(/Unsupported/);
+			expect(() => normalizeCompression({ algorithm: 'gzip' as never })).toThrow(/Unsupported/);
+		});
+
+		it('passes through a supported algorithm and level', () => {
+			expect(normalizeCompression('none')).toEqual({
+				compression: 'none',
+				compressionLevel: undefined,
+			});
+			const algorithm = realCompressor ?? 'none';
+			expect(normalizeCompression({ algorithm, level: 6 })).toEqual({
+				compression: algorithm,
+				compressionLevel: 6,
+			});
+		});
 	});
 });

--- a/test/compression.test.ts
+++ b/test/compression.test.ts
@@ -371,22 +371,29 @@ describe('Compression', () => {
 	});
 
 	describe('configure-rocksdb.mjs (build script)', () => {
-		it('emits only whitespace-free link tokens (safe for gyp <!@() under spaced paths)', () => {
-			// binding.gyp splices the script's stdout via <!@(), which splits on
-			// whitespace. Every emitted token must therefore be whitespace-free — no
-			// absolute path that could carry a space from a spaced checkout dir.
-			const out = execFileSync(
-				process.execPath,
-				[join(repoRoot, 'scripts', 'configure-rocksdb.mjs')],
-				{ cwd: repoRoot, encoding: 'utf8' }
-			).trim();
-			const tokens = out ? out.split('\n') : [];
-			for (const token of tokens) {
-				expect(token).not.toMatch(/\s/);
-				// POSIX: `-l:libX.a` / `-lX`; Windows: `X.lib`.
-				expect(token.startsWith('-l') || token.endsWith('.lib')).toBe(true);
+		// node-gyp always runs this script with `node`; under Bun/Deno the test's
+		// `process.execPath` would be the wrong runtime (and tsx's CLI isn't
+		// Bun-compatible), so only exercise it on the runtime the build uses.
+		const nonNodeRuntime = !!process.versions.bun || !!process.versions.deno;
+		it.skipIf(nonNodeRuntime)(
+			'emits only whitespace-free link tokens (safe for gyp <!@() under spaced paths)',
+			() => {
+				// binding.gyp splices the script's stdout via <!@(), which splits on
+				// whitespace. Every emitted token must therefore be whitespace-free — no
+				// absolute path that could carry a space from a spaced checkout dir.
+				const out = execFileSync(
+					process.execPath,
+					[join(repoRoot, 'scripts', 'configure-rocksdb.mjs')],
+					{ cwd: repoRoot, encoding: 'utf8' }
+				).trim();
+				const tokens = out ? out.split('\n') : [];
+				for (const token of tokens) {
+					expect(token).not.toMatch(/\s/);
+					// POSIX: `-l:libX.a` / `-lX`; Windows: `X.lib`.
+					expect(token.startsWith('-l') || token.endsWith('.lib')).toBe(true);
+				}
 			}
-		});
+		);
 	});
 
 	describe('compression getter shape', () => {

--- a/test/compression.test.ts
+++ b/test/compression.test.ts
@@ -1,9 +1,13 @@
 import { type CompressionAlgorithm, RocksDatabase, supportedCompression } from '../src/index.js';
 import { normalizeCompression } from '../src/store.js';
 import { generateDBPath } from './lib/util.js';
+import { execFileSync } from 'node:child_process';
 import { readdirSync, rmSync, statSync } from 'node:fs';
-import { join } from 'node:path';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { afterEach, describe, expect, it } from 'vitest';
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 
 const tempPaths: string[] = [];
 
@@ -60,6 +64,10 @@ function populate(db: RocksDatabase, count: number): void {
 // tests are conditional on one being present.
 const algorithms = supportedCompression as readonly CompressionAlgorithm[];
 const realCompressor = algorithms.find((name) => name !== 'none');
+// A compressor that honors a compression level, if the build has one.
+const levelCompressor = algorithms.find((name) =>
+	(['zstd', 'zlib', 'lz4', 'lz4hc', 'bzip2'] as const).includes(name as never)
+);
 
 describe('Compression', () => {
 	describe('supportedCompression', () => {
@@ -75,7 +83,7 @@ describe('Compression', () => {
 		it('reports a supported algorithm by default', () => {
 			const db = RocksDatabase.open(tempPath());
 			try {
-				expect(supportedCompression).toContain(db.compression);
+				expect(supportedCompression).toContain(db.compression.algorithm);
 			} finally {
 				db.close();
 			}
@@ -85,11 +93,11 @@ describe('Compression', () => {
 			const db = RocksDatabase.open(tempPath());
 			try {
 				if (supportedCompression.includes('lz4')) {
-					expect(db.compression).toBe('lz4');
+					expect(db.compression.algorithm).toBe('lz4');
 				} else {
 					// No LZ4: falls back to RocksDB's own default (snappy if linked,
 					// otherwise none). Either way it must be a supported value.
-					expect(supportedCompression).toContain(db.compression);
+					expect(supportedCompression).toContain(db.compression.algorithm);
 				}
 			} finally {
 				db.close();
@@ -100,7 +108,7 @@ describe('Compression', () => {
 			for (const algorithm of algorithms) {
 				const db = RocksDatabase.open(tempPath(), { compression: algorithm });
 				try {
-					expect(db.compression).toBe(algorithm);
+					expect(db.compression.algorithm).toBe(algorithm);
 				} finally {
 					db.close();
 				}
@@ -111,7 +119,7 @@ describe('Compression', () => {
 			const algorithm = realCompressor ?? 'none';
 			const db = RocksDatabase.open(tempPath(), { compression: { algorithm, level: 6 } });
 			try {
-				expect(db.compression).toBe(algorithm);
+				expect(db.compression.algorithm).toBe(algorithm);
 			} finally {
 				db.close();
 			}
@@ -120,7 +128,7 @@ describe('Compression', () => {
 		it('can explicitly disable compression', () => {
 			const db = RocksDatabase.open(tempPath(), { compression: 'none' });
 			try {
-				expect(db.compression).toBe('none');
+				expect(db.compression.algorithm).toBe('none');
 			} finally {
 				db.close();
 			}
@@ -161,7 +169,7 @@ describe('Compression', () => {
 					compression: realCompressor,
 				});
 				populate(compressedDb, 10_000);
-				expect(compressedDb.compression).toBe(realCompressor);
+				expect(compressedDb.compression.algorithm).toBe(realCompressor);
 				compressedDb.close();
 
 				const noneSize = dirSize(nonePath);
@@ -190,8 +198,8 @@ describe('Compression', () => {
 				populate(dbNone, 10_000);
 				populate(dbCompressed, 10_000);
 
-				expect(dbNone.compression).toBe('none');
-				expect(dbCompressed.compression).toBe(realCompressor);
+				expect(dbNone.compression.algorithm).toBe('none');
+				expect(dbCompressed.compression.algorithm).toBe(realCompressor);
 
 				dbNone.close();
 				dbCompressed.close();
@@ -223,7 +231,7 @@ describe('Compression', () => {
 			let dbB: RocksDatabase | undefined;
 			try {
 				dbB = RocksDatabase.open(path, { compression: realCompressor });
-				expect(dbB.compression).toBe(realCompressor);
+				expect(dbB.compression.algorithm).toBe(realCompressor);
 			} finally {
 				dbA.close();
 				dbB?.close();
@@ -240,10 +248,72 @@ describe('Compression', () => {
 				let dbB: RocksDatabase | undefined;
 				try {
 					dbB = RocksDatabase.open(path);
-					expect(dbB.compression).toBe(realCompressor);
+					expect(dbB.compression.algorithm).toBe(realCompressor);
 				} finally {
 					dbA.close();
 					dbB?.close();
+				}
+			}
+		);
+
+		it.skipIf(!levelCompressor)(
+			'throws when a second open requests a different level for the same algorithm',
+			() => {
+				const path = tempPath();
+				const dbA = RocksDatabase.open(path, {
+					compression: { algorithm: levelCompressor!, level: 4 },
+				});
+				let dbSame: RocksDatabase | undefined;
+				try {
+					// Same algorithm + level: allowed.
+					dbSame = RocksDatabase.open(path, {
+						compression: { algorithm: levelCompressor!, level: 4 },
+					});
+					expect(dbSame.compression).toEqual({ algorithm: levelCompressor, level: 4 });
+					// Different level: rejected.
+					expect(() =>
+						RocksDatabase.open(path, { compression: { algorithm: levelCompressor!, level: 6 } })
+					).toThrow(/already open with compression/);
+				} finally {
+					dbA.close();
+					dbSame?.close();
+				}
+			}
+		);
+	});
+
+	describe('per-column-family', () => {
+		it.skipIf(!realCompressor)(
+			'a cold reopen of one column family preserves another CF’s compression',
+			() => {
+				// Regression: the old shared-cfOptions open stamped the opener's
+				// algorithm onto every column family, so first-open order dictated all
+				// CFs. Each CF must keep its own algorithm across a close/reopen.
+				const path = tempPath();
+				const dbPlain = RocksDatabase.open(path, { name: 'plain', compression: 'none' });
+				const dbComp = RocksDatabase.open(path, {
+					name: 'compressed',
+					compression: realCompressor,
+				});
+				dbPlain.putSync(1, 'x');
+				dbComp.putSync(1, 'y');
+				dbPlain.flushSync();
+				dbComp.flushSync();
+				dbPlain.close();
+				dbComp.close();
+
+				// Cold-reopen the 'plain' CF FIRST (explicitly 'none'). The old code
+				// would have opened every CF with 'none'; per-CF must leave
+				// 'compressed' at its own algorithm.
+				const dbPlain2 = RocksDatabase.open(path, { name: 'plain', compression: 'none' });
+				let dbComp2: RocksDatabase | undefined;
+				try {
+					expect(dbPlain2.compression.algorithm).toBe('none');
+					dbComp2 = RocksDatabase.open(path, { name: 'compressed' }); // plain reopen inherits persisted
+					expect(dbComp2.compression.algorithm).toBe(realCompressor);
+				} finally {
+					dbPlain2.close();
+					dbComp2?.close();
 				}
 			}
 		);
@@ -276,6 +346,68 @@ describe('Compression', () => {
 				compression: algorithm,
 				compressionLevel: 6,
 			});
+		});
+
+		it('coerces a numeric-string level and treats null/undefined as omitted', () => {
+			expect(normalizeCompression({ algorithm: 'none', level: '5' as never })).toEqual({
+				compression: 'none',
+				compressionLevel: 5,
+			});
+			expect(normalizeCompression({ algorithm: 'none', level: null as never })).toEqual({
+				compression: 'none',
+				compressionLevel: undefined,
+			});
+		});
+
+		it('throws for a non-integer, out-of-range, or non-numeric level', () => {
+			expect(() => normalizeCompression({ algorithm: 'none', level: '9.5' as never })).toThrow(
+				TypeError
+			);
+			expect(() => normalizeCompression({ algorithm: 'none', level: 'abc' as never })).toThrow(
+				TypeError
+			);
+			expect(() => normalizeCompression({ algorithm: 'none', level: 1e10 })).toThrow(TypeError);
+		});
+	});
+
+	describe('configure-rocksdb.mjs (build script)', () => {
+		it('emits only whitespace-free link tokens (safe for gyp <!@() under spaced paths)', () => {
+			// binding.gyp splices the script's stdout via <!@(), which splits on
+			// whitespace. Every emitted token must therefore be whitespace-free — no
+			// absolute path that could carry a space from a spaced checkout dir.
+			const out = execFileSync(
+				process.execPath,
+				[join(repoRoot, 'scripts', 'configure-rocksdb.mjs')],
+				{ cwd: repoRoot, encoding: 'utf8' }
+			).trim();
+			const tokens = out ? out.split('\n') : [];
+			for (const token of tokens) {
+				expect(token).not.toMatch(/\s/);
+				// POSIX: `-l:libX.a` / `-lX`; Windows: `X.lib`.
+				expect(token.startsWith('-l') || token.endsWith('.lib')).toBe(true);
+			}
+		});
+	});
+
+	describe('compression getter shape', () => {
+		it('omits level when none is configured', () => {
+			const db = RocksDatabase.open(tempPath(), { compression: 'none' });
+			try {
+				expect(db.compression).toEqual({ algorithm: 'none' });
+			} finally {
+				db.close();
+			}
+		});
+
+		it.skipIf(!levelCompressor)('returns the configured level', () => {
+			const db = RocksDatabase.open(tempPath(), {
+				compression: { algorithm: levelCompressor!, level: 5 },
+			});
+			try {
+				expect(db.compression).toEqual({ algorithm: levelCompressor, level: 5 });
+			} finally {
+				db.close();
+			}
 		});
 	});
 });

--- a/test/init-rocksdb-version-check.test.ts
+++ b/test/init-rocksdb-version-check.test.ts
@@ -32,6 +32,17 @@ describe('init-rocksdb version-check', () => {
 			expect(installedSatisfiesPin({ version: '11.1.2-1' }, '11.1.2-2', undefined)).toBe(false);
 		});
 
+		it('is false when only the build metadata differs (compareBuild, not eq)', () => {
+			// semver.eq ignores everything after `+`, so an exact pin like
+			// 11.1.2+rev2 must not be considered already-satisfied by 11.1.2+rev1.
+			expect(installedSatisfiesPin({ version: '11.1.2+rev1' }, '11.1.2+rev2', undefined)).toBe(
+				false
+			);
+			expect(installedSatisfiesPin({ version: '11.1.2+rev1' }, '11.1.2+rev1', undefined)).toBe(
+				true
+			);
+		});
+
 		it('is false for "latest" or an unset desired version', () => {
 			expect(installedSatisfiesPin({ version: '11.1.2' }, 'latest', undefined)).toBe(false);
 			expect(installedSatisfiesPin({ version: '11.1.2' }, undefined, undefined)).toBe(false);

--- a/test/native-test-build-identity.test.ts
+++ b/test/native-test-build-identity.test.ts
@@ -1,0 +1,45 @@
+import { resolveBuildSelection } from '../scripts/native-test/build-identity.mjs';
+import { describe, expect, it } from 'vitest';
+
+describe('native-test runner build selection', () => {
+	const pkg = { rocksdb: { version: '11.1.2-2' } };
+
+	it('uses the package pin when no env override is set', () => {
+		const { expectedVersion, identity } = resolveBuildSelection({}, pkg, 'darwin');
+		expect(expectedVersion).toBe('11.1.2-2');
+		expect(identity).toBe('11.1.2-2');
+	});
+
+	it('lets ROCKSDB_VERSION override the pin, changing the marker (the reported bug)', () => {
+		// Built under an override: the marker must record what was linked (-1), NOT
+		// the pin (-2). Otherwise dropping the override later leaves the marker
+		// matching the pin and the stale -1 binary is silently reused.
+		const under = resolveBuildSelection({ ROCKSDB_VERSION: '11.1.2-1' }, pkg, 'darwin');
+		expect(under.expectedVersion).toBe('11.1.2-1');
+		expect(under.identity).toBe('11.1.2-1');
+
+		// Dropping the override changes the identity, so the runner rebuilds.
+		const without = resolveBuildSelection({}, pkg, 'darwin');
+		expect(without.identity).toBe('11.1.2-2');
+		expect(under.identity).not.toBe(without.identity);
+	});
+
+	it('includes the Linux runtime so a libc change forces a rebuild', () => {
+		expect(resolveBuildSelection({}, pkg, 'linux').identity).toBe('11.1.2-2-glibc');
+		expect(resolveBuildSelection({ ROCKSDB_LIBC: 'musl' }, pkg, 'linux').identity).toBe(
+			'11.1.2-2-musl'
+		);
+		// Non-Linux has no runtime suffix.
+		expect(resolveBuildSelection({}, pkg, 'darwin').identity).toBe('11.1.2-2');
+	});
+
+	it('distinguishes a source build from a prebuild', () => {
+		const src = resolveBuildSelection({ ROCKSDB_PATH: '/src/rocksdb' }, pkg, 'linux');
+		expect(src.identity).toBe('source:/src/rocksdb');
+		// Source identity is independent of the runtime/pin so a path change is the
+		// only thing that flips it.
+		expect(resolveBuildSelection({ ROCKSDB_PATH: '/other' }, pkg, 'linux').identity).toBe(
+			'source:/other'
+		);
+	});
+});

--- a/test/native/compression_test.cc
+++ b/test/native/compression_test.cc
@@ -1,0 +1,58 @@
+#include <gtest/gtest.h>
+#include <algorithm>
+#include <string>
+#include <vector>
+#include "core/compression.h"
+#include "rocksdb/compression_type.h"
+
+using rocksdb_js::compressionNameFromType;
+using rocksdb_js::compressionTypeFromName;
+using rocksdb_js::isCompressionSupported;
+using rocksdb_js::supportedCompressionNames;
+
+TEST(Compression, NameToTypeKnownAlgorithms) {
+	EXPECT_EQ(compressionTypeFromName("none"), rocksdb::kNoCompression);
+	EXPECT_EQ(compressionTypeFromName("snappy"), rocksdb::kSnappyCompression);
+	EXPECT_EQ(compressionTypeFromName("zlib"), rocksdb::kZlibCompression);
+	EXPECT_EQ(compressionTypeFromName("bzip2"), rocksdb::kBZip2Compression);
+	EXPECT_EQ(compressionTypeFromName("lz4"), rocksdb::kLZ4Compression);
+	EXPECT_EQ(compressionTypeFromName("lz4hc"), rocksdb::kLZ4HCCompression);
+	EXPECT_EQ(compressionTypeFromName("xpress"), rocksdb::kXpressCompression);
+	EXPECT_EQ(compressionTypeFromName("zstd"), rocksdb::kZSTD);
+}
+
+TEST(Compression, NameToTypeIsCaseInsensitive) {
+	EXPECT_EQ(compressionTypeFromName("LZ4"), rocksdb::kLZ4Compression);
+	EXPECT_EQ(compressionTypeFromName("ZStd"), rocksdb::kZSTD);
+}
+
+TEST(Compression, NameToTypeUnknownReturnsNullopt) {
+	EXPECT_FALSE(compressionTypeFromName("gzip").has_value());
+	EXPECT_FALSE(compressionTypeFromName("").has_value());
+}
+
+TEST(Compression, TypeToNameRoundTrips) {
+	EXPECT_EQ(compressionNameFromType(rocksdb::kNoCompression), "none");
+	EXPECT_EQ(compressionNameFromType(rocksdb::kLZ4Compression), "lz4");
+	EXPECT_EQ(compressionNameFromType(rocksdb::kZSTD), "zstd");
+}
+
+TEST(Compression, TypeToNameUnknownReturnsUnknown) {
+	EXPECT_EQ(compressionNameFromType(rocksdb::kCustomCompression80), "unknown");
+}
+
+TEST(Compression, NoCompressionAlwaysSupported) {
+	EXPECT_TRUE(isCompressionSupported(rocksdb::kNoCompression));
+}
+
+TEST(Compression, SupportedListMatchesRuntimeSupport) {
+	const std::vector<std::string>& names = supportedCompressionNames();
+	// Every reported name must map back to a supported type, and "none" is
+	// always present (GetSupportedCompressions always includes kNoCompression).
+	EXPECT_NE(std::find(names.begin(), names.end(), "none"), names.end());
+	for (const std::string& name : names) {
+		auto type = compressionTypeFromName(name);
+		ASSERT_TRUE(type.has_value()) << "unmapped name: " << name;
+		EXPECT_TRUE(isCompressionSupported(*type)) << "unsupported name reported: " << name;
+	}
+}


### PR DESCRIPTION
## Summary

Exposes RocksDB block/blob compression as a per-column-family option ([issue #201](https://github.com/HarperFast/rocksdb-js/issues/201)).

- **`compression` open option** — an algorithm name (`'lz4'`, `'zstd'`, `'zlib'`, `'none'`, …) or `{ algorithm, level }`. Applies to **both** SST block compression **and** blob-file compression (large values ≥ 2 KB become blobs, whose compression otherwise defaults to none).
- **Default: LZ4** (applied natively in `Database::Open`) when the build supports it, else RocksDB's own default. Confirmed & documented that RocksDB's stock default is Snappy; we override to LZ4.
- **`supportedCompression`** — module constant listing algorithms compiled into the build (from `GetSupportedCompressions()`). Opening with an unavailable algorithm throws.
- **`db.compression`** getter — reads the live value via `DB::GetOptions`.
- Native name↔enum mapping + supported list in the Node-free `core/compression.{h,cpp}` (GoogleTest-covered).

## Build robustness (dynamic lib linking)

`librocksdb.a` references, but doesn't bundle, the compression libraries it was built with. `binding.gyp` now links **exactly** the compression static libs the resolved prebuild ships, enumerated at configure time by `scripts/configure-rocksdb.mjs` (which also provisions the pinned prebuild). This means the build works against both an older `none+zlib` prebuild and a compression-enabled one — no version-bump coupling. To actually activate LZ4, a compression-enabled prebuild must be pinned in `package.json` (currently `11.1.2`); the feature is forward-compatible until then.

## Where to look / open items for the reviewer

- **Cold open applies the requested `compression` to every existing column family**, not just the one being opened (`DBDescriptor::open`). This is intended per the author, but worth a look — it means opening a multi-CF DB with a compression option changes all CFs' algorithm for subsequently-written files. A second *in-process* open that explicitly requests a **different** algorithm for an already-open CF now **throws** (`DBRegistry::OpenDB`); a plain reopen inherits the live setting (`DBOptions::compressionExplicit` gates this).
- **Block vs blob compression are unified** (same algorithm for both). Splitting them (e.g. lz4 blocks + zstd blobs) was deliberately deferred (YAGNI); the object form extends cleanly later.
- `scripts/configure-rocksdb.mjs` runs `init-rocksdb` at gyp **configure** time (before the `prepare-rocksdb` build action) so the enumerated lib set matches what will link. The **Windows** path (spawn + `AdditionalDependencies` splice) is unverified locally — worth watching on CI.

## Testing

- `test/compression.test.ts` — supported list, getter/defaults, validation, on-disk size comparison across multiple databases, already-open conflict cases, and a `normalizeCompression` guard suite.
- `test/native/compression_test.cc` — name↔type mapping + supported-list GoogleTests.
- `benchmark/compression.bench.ts` — RocksDB-only write/read throughput per available algorithm.

## Notes

- **Stacked on [#734 (init-rocksdb prerelease/revision version)](https://github.com/HarperFast/rocksdb-js/pull/734)** — based on that branch; retarget to `main` once #734 merges. The bottom three commits belong to #734.
- User-facing surface is documented in the repo `README.md` (this library's docs); no separate documentation-repo change needed.
- Generated by an LLM (Claude Opus 4.8). The code-review findings surfaced during development were addressed in the latest commit; the remaining open items are called out above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)