### PR TITLE
fix: sync Dependabot cooldown with pnpm minimumReleaseAge policy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,9 +8,19 @@ updates:
       day: 'monday'
       time: '05:15' # UTC
     open-pull-requests-limit: 10
-    # Wait 24h after a release before proposing an update, to match pnpm's minimumReleaseAge policy.
+    # Must stay ahead of pnpm's rolling 24h minimumReleaseAge (pnpm-workspace.yaml):
+    # with `default-days: 1`, Dependabot has proposed versions <24h old (see #736)
+    # that pnpm then rejects in CI. 2 days gives a full day of margin so proposed
+    # versions are always past pnpm's cutoff at install time.
+    # Excludes mirror pnpm's minimumReleaseAgeExclude — pnpm doesn't gate these,
+    # so Dependabot needn't wait on them either.
     cooldown:
-      default-days: 1
+      default-days: 2
+      exclude:
+        - '@harperfast/*'
+        - 'lmdb'
+        - 'msgpackr'
+        - 'ordered-binary'
     # Group updates to reduce PR noise. Major version updates will fall through to individual PRs.
     groups:
       # Group all other patch updates

--- a/.github/workflows/retry-dependabot.yml
+++ b/.github/workflows/retry-dependabot.yml
@@ -1,15 +1,15 @@
 name: Retry Dependabot Checks
 
-# Dependabot's `cooldown` only delays the *direct* dependency it bumps. When it
-# regenerates pnpm-lock.yaml, pnpm re-resolves transitive deps to their latest
-# versions, and any transitive dep published within pnpm's `minimumReleaseAge`
-# window (see pnpm-workspace.yaml) fails the supply-chain check at install time
-# — turning the whole PR red for reasons unrelated to the bump.
-#
-# Those deps always age past the cutoff within a day, so this workflow simply
-# re-runs the failed checks on open Dependabot PRs. It re-uses the exact same
-# committed lockfile (no `recreate`, which could pull in another fresh dep and
-# restart the clock); only time has passed, so the age check now passes.
+# Backstop for Dependabot PRs that fail pnpm's `minimumReleaseAge` check.
+# Primary prevention lives elsewhere: pnpm-workspace.yaml sets an explicit
+# `minimumReleaseAge` (strict mode) so lockfile resolution — including
+# Dependabot's regeneration — refuses versions younger than the cutoff, and
+# dependabot.yml's `cooldown: default-days: 2` keeps direct bumps a day past
+# pnpm's rolling 24h window. If a too-young version still slips into a PR,
+# it always ages past the cutoff within a day, so this workflow re-runs the
+# failed checks on open Dependabot PRs. It re-uses the exact same committed
+# lockfile (no `recreate`, which could pull in another fresh dep and restart
+# the clock); only time has passed, so the age check now passes.
 
 on:
   schedule:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,6 +3,8 @@ allowBuilds:
   lefthook: true
   lmdb: true
   msgpackr-extract: true
+minimumReleaseAge: 1440
+minimumReleaseAgeStrict: true
 minimumReleaseAgeExclude:
   - '@harperfast/*'
   - 'lmdb'


### PR DESCRIPTION
## Problem

Dependabot PRs consistently fail CI with `ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION` — most recently [#736 "chore(deps): bump the patch group with 2 updates"](https://github.com/HarperFast/rocksdb-js/pull/736). Two distinct causes:

1. **Fresh transitive deps.** The repo never set `minimumReleaseAge` explicitly and relied on pnpm 11's built-in default (1440 minutes). The default runs in **loose** mode (`minimumReleaseAgeStrict: false`): resolution admits versions younger than 24h, and only CI's strict lockfile verification rejects them. When Dependabot regenerates `pnpm-lock.yaml`, its pnpm re-resolves transitive deps to whatever was just published (on #736, `@napi-rs/wasm-runtime@1.2.1` was 2 hours old), producing a lockfile that CI is guaranteed to fail.

2. **Direct bumps inside the 24h window.** Dependabot's `cooldown: default-days: 1` let through `postcss@8.5.25`, published only ~16h before the run, which pnpm's rolling 24h window then rejected at install time.

## Fix

- **`pnpm-workspace.yaml`**: set `minimumReleaseAge: 1440` and `minimumReleaseAgeStrict: true` explicitly. Strict mode makes resolution itself refuse immature versions — and dependabot-core runs real pnpm against the repo config when regenerating lockfiles ([it only overrides the age gate for security updates](https://github.com/dependabot/dependabot-core/blob/main/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/pnpm_lockfile_updater.rb)), so regenerated lockfiles now only contain aged transitive deps.
- **`.github/dependabot.yml`**: `cooldown.default-days: 1 → 2`, giving a full day of margin over pnpm's rolling window, and add a cooldown `exclude` mirroring pnpm's `minimumReleaseAgeExclude` (`@harperfast/*`, `lmdb`, `msgpackr`, `ordered-binary`) so trusted packages aren't needlessly delayed.
- **`.github/workflows/retry-dependabot.yml`**: comment updated — it's now a backstop rather than the primary mitigation. It still matters for security-update PRs, where Dependabot deliberately bypasses the age gate (`--config.minimumReleaseAge=0`), so those can still briefly fail CI until the version ages past the cutoff.

## Verification

- All three YAML files parse cleanly; `pnpm config get minimumReleaseAge` / `minimumReleaseAgeStrict` return `1440` / `true` with the new workspace config.
- `pnpm install --ignore-scripts --lockfile-only` passes the supply-chain policy check against the current lockfile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)