### PR TITLE
Add compressionForAllColumnFamilies so a database can adopt one codec

### DIFF
--- a/README.md
+++ b/README.md
@@ -977,6 +977,27 @@ was compiled against, so it varies by build. Always check
 [`supportedCompression`](#supportedcompression) at runtime — opening with an unavailable algorithm
 throws. `'none'` is always available.
 
+**Adopting a codec across a whole database.** Compression is chosen per column family, and RocksDB
+opens every family of a database in one call — so by default the families you did not name keep
+their persisted algorithm. If your first open targets some other family (a catalog, say), the rest
+are already open at their old algorithm before you can ask for a new one, and a family's compression
+cannot be changed while it is open. Pass `compressionForAllColumnFamilies: true` to apply the
+requested algorithm to all of them instead:
+
+```typescript
+// Every column family in this database adopts lz4, not just 'catalog'
+const db = RocksDatabase.open('/path/to/db', {
+	name: 'catalog',
+	compression: 'lz4',
+	compressionForAllColumnFamilies: true,
+});
+```
+
+It requires an explicit `compression`, and only takes effect on the open that creates the database
+handle — later opens of the same path reuse that handle. As always the algorithm governs newly
+written files; use [`compact({ bottommost: true })`](#dbcompactoptions-promisevoid) to rewrite what
+is already there.
+
 **Scope and mutability.** Compression is genuinely **per-column-family**. Each `RocksDatabase`
 targets one column family (`name`), and its `compression` applies only to that CF — opening one CF
 never changes another's algorithm, regardless of open order. A column family keeps its own

--- a/src/binding/database/database.cpp
+++ b/src/binding/database/database.cpp
@@ -1474,6 +1474,21 @@ napi_value Database::Open(napi_env env, napi_callback_info info) {
 		dbHandleOptions.compression = rocksdb::kLZ4Compression;
 	}
 
+	NAPI_STATUS_THROWS(rocksdb_js::getProperty(
+		env,
+		options,
+		"compressionForAllColumnFamilies",
+		dbHandleOptions.compressionForAllColumnFamilies
+	));
+	if (dbHandleOptions.compressionForAllColumnFamilies && !dbHandleOptions.compressionExplicit) {
+		::napi_throw_error(
+			env,
+			nullptr,
+			"compressionForAllColumnFamilies requires an explicit compression option"
+		);
+		return nullptr;
+	}
+
 	// statistics
 	NAPI_STATUS_THROWS(rocksdb_js::getProperty(env, options, "enableStats", dbHandleOptions.enableStats));
 	if (dbHandleOptions.enableStats) {

--- a/src/binding/database/db_descriptor.cpp
+++ b/src/binding/database/db_descriptor.cpp
@@ -926,6 +926,11 @@ std::shared_ptr<DBDescriptor> DBDescriptor::open(const std::string& path, const 
 		// and apply the caller's request ONLY to the target CF (options.name), and
 		// only when it was explicitly requested — the LZ4 default must never
 		// override an existing CF's stored algorithm (a plain reopen inherits it).
+		//
+		// `compressionForAllColumnFamilies` opts out of that per-CF preservation:
+		// the explicit request is applied to every family instead, which is how a
+		// caller expresses "this database uses one codec" for families it never
+		// names (see db_options.h).
 		std::unordered_map<std::string, PersistedCompression> persisted;
 		rocksdb::Status persistedStatus = loadPersistedCompression(path, persisted);
 		if (!persistedStatus.ok()) {
@@ -947,7 +952,9 @@ std::shared_ptr<DBDescriptor> DBDescriptor::open(const std::string& path, const 
 				cfo.blob_compression_type = it->second.blobCompression;
 				cfo.compression_opts = it->second.compressionOpts;
 			}
-			if (cfName == name && options.compression && options.compressionExplicit) {
+			const bool isTarget = cfName == name;
+			if ((isTarget || options.compressionForAllColumnFamilies) && options.compression &&
+				options.compressionExplicit) {
 				applyCompression(cfo, *options.compression, options.compressionLevel);
 			}
 			cfDescriptors.emplace_back(cfName, cfo);

--- a/src/binding/options/db_options.h
+++ b/src/binding/options/db_options.h
@@ -80,6 +80,16 @@ struct DBOptions final {
 	// RocksDB's per-algorithm default level. Meaning is algorithm-specific (see
 	// CompressionOptions::level).
 	std::optional<int> compressionLevel;
+	// When true, apply `compression` to EVERY column family the underlying
+	// `DB::Open` opens, not just the one named by `name`. RocksDB opens all of a
+	// database's column families in that one call, and the default behavior gives
+	// each of the others its persisted algorithm — correct when codecs are chosen
+	// per table, but it leaves a caller that wants one codec for the whole
+	// database unable to express it: the families it did not name are already open
+	// at their old algorithm before it can ask. Only meaningful together with an
+	// explicit `compression`, and only on the open that actually creates the
+	// database handle (later opens reuse it).
+	bool compressionForAllColumnFamilies = false;
 };
 
 } // namespace rocksdb_js

--- a/src/load-binding.ts
+++ b/src/load-binding.ts
@@ -206,6 +206,11 @@ export type NativeDatabaseOptions = {
 	 * is algorithm-specific; omit to use the algorithm's default.
 	 */
 	compressionLevel?: number;
+	/**
+	 * Apply `compression` to every column family the underlying `DB::Open` opens, rather than
+	 * only the one named by `name`. Requires an explicit `compression`.
+	 */
+	compressionForAllColumnFamilies?: boolean;
 	dbWriteBufferSize?: number;
 	disableWAL?: boolean;
 	enableStats?: boolean;

--- a/src/store.ts
+++ b/src/store.ts
@@ -196,6 +196,28 @@ export interface StoreOptions extends Omit<
 	 */
 	compression?: CompressionOption;
 
+	/**
+	 * Apply `compression` to every column family in the database, not only the one being opened.
+	 *
+	 * RocksDB opens all of a database's column families in a single native call, and by default
+	 * each of the ones you did not name keeps its persisted algorithm. That is right when codecs
+	 * are chosen per table, but it leaves a caller that wants one codec for the whole database
+	 * unable to say so: those families are already open at their old algorithm before it gets a
+	 * chance to ask, and a column family's compression cannot be changed while it is open.
+	 *
+	 * Setting this applies the requested algorithm to all of them instead — including families
+	 * that were persisted with a different one, which is the point when adopting a codec on a
+	 * database that predates it.
+	 *
+	 * Only meaningful with an explicit `compression` (it throws otherwise), and only on the open
+	 * that actually creates the database handle; later opens of the same path reuse that handle
+	 * and cannot revisit the decision. As always, the algorithm governs newly written files —
+	 * existing SST/blob files keep theirs until rewritten (see `compact({ bottommost: true })`).
+	 *
+	 * @default false
+	 */
+	compressionForAllColumnFamilies?: boolean;
+
 	decoder?: Encoder | null;
 	encoder?: Encoder | null;
 	encoding?: Encoding;
@@ -288,6 +310,12 @@ export class Store {
 	 * store's column family. Normalized and applied when the database opens.
 	 */
 	compression?: CompressionOption;
+
+	/**
+	 * Whether `compression` applies to every column family in the database rather than just this
+	 * store's. See `RocksDatabaseOptions.compressionForAllColumnFamilies`.
+	 */
+	compressionForAllColumnFamilies: boolean = false;
 
 	/**
 	 * Whether to disable the write ahead log.
@@ -488,6 +516,7 @@ export class Store {
 
 		this.db = new NativeDatabase();
 		this.compression = options?.compression;
+		this.compressionForAllColumnFamilies = options?.compressionForAllColumnFamilies === true;
 		this.dbWriteBufferSize = options?.dbWriteBufferSize;
 		this.decoder = options?.decoder ?? null;
 		this.disableWAL = options?.disableWAL ?? false;
@@ -1005,6 +1034,7 @@ export class Store {
 		this.db.open(this.path, {
 			compression,
 			compressionLevel,
+			compressionForAllColumnFamilies: this.compressionForAllColumnFamilies,
 			dbWriteBufferSize: this.dbWriteBufferSize,
 			disableWAL: this.disableWAL,
 			enableStats: this.enableStats,

--- a/test/compression.test.ts
+++ b/test/compression.test.ts
@@ -568,6 +568,71 @@ describe('Compression', () => {
 		);
 	});
 
+	describe('compressionForAllColumnFamilies', () => {
+		// RocksDB opens every column family of a database in one native call, and by default each
+		// family the caller did not name keeps its persisted algorithm. A caller whose first open
+		// targets some other family — a catalog, say — therefore cannot adopt a codec for the
+		// families it did not name: they are already open at the old one, and a family's
+		// compression cannot change while it is open.
+		const seed = (algorithm: CompressionAlgorithm, names: string[]) => {
+			const dbPath = generateDBPath();
+			for (const name of names) {
+				const db = RocksDatabase.open(dbPath, { name, compression: algorithm });
+				db.putSync('k', 'v');
+				db.close();
+			}
+			return dbPath;
+		};
+
+		it('leaves families the caller did not name at their persisted algorithm by default', () => {
+			if (!supportedCompression.includes('lz4')) return;
+			const dbPath = seed('none', ['__catalog__', 'records']);
+
+			const catalog = RocksDatabase.open(dbPath, { name: '__catalog__', compression: 'lz4' });
+			try {
+				expect(catalog.compression.algorithm).toBe('lz4');
+				// `records` was opened transitively alongside it, still at 'none'.
+				expect(() => RocksDatabase.open(dbPath, { name: 'records', compression: 'lz4' })).toThrow(
+					/already open with compression/
+				);
+			} finally {
+				catalog.close();
+			}
+		});
+
+		it('applies the requested algorithm to every family when set', () => {
+			if (!supportedCompression.includes('lz4')) return;
+			const dbPath = seed('none', ['__catalog__', 'records', 'orders']);
+
+			const catalog = RocksDatabase.open(dbPath, {
+				name: '__catalog__',
+				compression: 'lz4',
+				compressionForAllColumnFamilies: true,
+			});
+			try {
+				expect(catalog.compression.algorithm).toBe('lz4');
+				// Both siblings now reconcile to the same codec instead of conflicting.
+				for (const name of ['records', 'orders']) {
+					const sibling = RocksDatabase.open(dbPath, { name, compression: 'lz4' });
+					try {
+						expect(sibling.compression.algorithm).toBe('lz4');
+					} finally {
+						sibling.close();
+					}
+				}
+			} finally {
+				catalog.close();
+			}
+		});
+
+		it('requires an explicit algorithm', () => {
+			const dbPath = seed('none', ['__catalog__']);
+			expect(() =>
+				RocksDatabase.open(dbPath, { name: '__catalog__', compressionForAllColumnFamilies: true })
+			).toThrow(/requires an explicit compression option/);
+		});
+	});
+
 	describe('compression getter shape', () => {
 		it('omits level when none is configured', () => {
 			const db = RocksDatabase.open(tempPath(), { compression: 'none' });

--- a/test/compression.test.ts
+++ b/test/compression.test.ts
@@ -575,7 +575,7 @@ describe('Compression', () => {
 		// families it did not name: they are already open at the old one, and a family's
 		// compression cannot change while it is open.
 		const seed = (algorithm: CompressionAlgorithm, names: string[]) => {
-			const dbPath = generateDBPath();
+			const dbPath = tempPath();
 			for (const name of names) {
 				const db = RocksDatabase.open(dbPath, { name, compression: algorithm });
 				db.putSync('k', 'v');
@@ -584,46 +584,50 @@ describe('Compression', () => {
 			return dbPath;
 		};
 
-		it('leaves families the caller did not name at their persisted algorithm by default', () => {
-			if (!supportedCompression.includes('lz4')) return;
-			const dbPath = seed('none', ['__catalog__', 'records']);
+		it.skipIf(!supportedCompression.includes('lz4'))(
+			'leaves families the caller did not name at their persisted algorithm by default',
+			() => {
+				const dbPath = seed('none', ['__catalog__', 'records']);
 
-			const catalog = RocksDatabase.open(dbPath, { name: '__catalog__', compression: 'lz4' });
-			try {
-				expect(catalog.compression.algorithm).toBe('lz4');
-				// `records` was opened transitively alongside it, still at 'none'.
-				expect(() => RocksDatabase.open(dbPath, { name: 'records', compression: 'lz4' })).toThrow(
-					/already open with compression/
-				);
-			} finally {
-				catalog.close();
-			}
-		});
-
-		it('applies the requested algorithm to every family when set', () => {
-			if (!supportedCompression.includes('lz4')) return;
-			const dbPath = seed('none', ['__catalog__', 'records', 'orders']);
-
-			const catalog = RocksDatabase.open(dbPath, {
-				name: '__catalog__',
-				compression: 'lz4',
-				compressionForAllColumnFamilies: true,
-			});
-			try {
-				expect(catalog.compression.algorithm).toBe('lz4');
-				// Both siblings now reconcile to the same codec instead of conflicting.
-				for (const name of ['records', 'orders']) {
-					const sibling = RocksDatabase.open(dbPath, { name, compression: 'lz4' });
-					try {
-						expect(sibling.compression.algorithm).toBe('lz4');
-					} finally {
-						sibling.close();
-					}
+				const catalog = RocksDatabase.open(dbPath, { name: '__catalog__', compression: 'lz4' });
+				try {
+					expect(catalog.compression.algorithm).toBe('lz4');
+					// `records` was opened transitively alongside it, still at 'none'.
+					expect(() => RocksDatabase.open(dbPath, { name: 'records', compression: 'lz4' })).toThrow(
+						/already open with compression/
+					);
+				} finally {
+					catalog.close();
 				}
-			} finally {
-				catalog.close();
 			}
-		});
+		);
+
+		it.skipIf(!supportedCompression.includes('lz4'))(
+			'applies the requested algorithm to every family when set',
+			() => {
+				const dbPath = seed('none', ['__catalog__', 'records', 'orders']);
+
+				const catalog = RocksDatabase.open(dbPath, {
+					name: '__catalog__',
+					compression: 'lz4',
+					compressionForAllColumnFamilies: true,
+				});
+				try {
+					expect(catalog.compression.algorithm).toBe('lz4');
+					// Both siblings now reconcile to the same codec instead of conflicting.
+					for (const name of ['records', 'orders']) {
+						const sibling = RocksDatabase.open(dbPath, { name, compression: 'lz4' });
+						try {
+							expect(sibling.compression.algorithm).toBe('lz4');
+						} finally {
+							sibling.close();
+						}
+					}
+				} finally {
+					catalog.close();
+				}
+			}
+		);
 
 		it('requires an explicit algorithm', () => {
 			const dbPath = seed('none', ['__catalog__']);


### PR DESCRIPTION
Alternative to #742 for the case Harper actually has: **one codec for the whole database**, rather than a codec per table.

## The problem

RocksDB opens every column family of a database in a single `DB::Open`, and `db_descriptor.cpp` gives each family the caller did not name its **persisted** algorithm, applying the request only to the target:

```cpp
if (cfName == name && options.compression && options.compressionExplicit) {
    applyCompression(cfo, *options.compression, options.compressionLevel);
}
```

That is deliberate and right when codecs are chosen per table — opening one family must not restamp another's. But it makes a database-wide codec inexpressible. A caller whose first open targets some other family (a catalog it has to read before it knows anything else) finds every sibling already open at its old algorithm, and a family's compression cannot change while it is open.

Reproduced against families persisted at `none`, opening a non-target family first:

```
default:    __catalog__ -> lz4,  records -> throws "already open with compression none"
with flag:  __catalog__ -> lz4,  records -> lz4,  orders -> lz4
```

This is exactly what blocks Harper on a database upgraded from 5.1: every column family was created before the prebuild carried any codecs, so they are all persisted at `none`, and the per-table reconcile open cannot move them.

## The change

`compressionForAllColumnFamilies: true` applies the requested algorithm to every family in the descriptor list instead of only the target.

```typescript
const db = RocksDatabase.open('/path/to/db', {
	name: 'catalog',
	compression: 'lz4',
	compressionForAllColumnFamilies: true,
});
```

- Requires an explicit `compression` — throws otherwise, so the lz4 default can still never restamp a persisted codec by accident.
- Only affects the open that creates the database handle; later opens of the same path reuse it.
- Governs newly written files, like any compression change. Use `compact({ bottommost: true })` (#740) to rewrite what is already on disk.

## Relationship to #742

#742 adds `setCompression()` via `SetOptions()` to change an already-open family's codec at any time. That is strictly more capable — it is what you need if a caller must discover a *per-table* codec from a catalog it can only read after opening everything.

This PR takes the narrower route that fits the deployment-global model: the codec is known from config before any open, so it can simply be supplied at open time. No live mutation of an open family, no new mutable native state, no `SetOptions()` cost. The trade-off is that it cannot express per-table codecs — a family deliberately persisted at `none` is restamped along with the rest, which is the intended behavior here but would be wrong under a per-table model.

Worth deciding which model we want before merging either; they are not mutually exclusive, but only one is needed for Harper today.

## Testing

Three cases in `test/compression.test.ts`: the default leaves un-named families at their persisted algorithm (asserting the sibling open throws), the flag makes both siblings reconcile to the requested codec, and omitting an explicit algorithm throws. Skipped when the native build lacks lz4. 54 tests pass across the compression, compaction, column-families and db-options suites.

Verified against a RocksDB prebuild carrying the codecs (11.1.2); the repo's vendored prebuild has only none/zlib, so the new tests self-skip there.

Generated by Claude Opus 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)