### PR TITLE
Add Transaction.abandonWrites() to release delegated writes' verification-table intents

### DIFF
--- a/README.md
+++ b/README.md
@@ -660,6 +660,9 @@ an `ERR_TRANSACTION_ABANDONED` error. Coordinated retry requires the column fami
 The transaction callback is passed in a `Transaction` instance which contains all of the same data
 operations methods as the `RocksDatabase` instance plus:
 
+- `txn.abandonWrites(): void` Releases the staged writes' verification-table write intents without
+  closing the transaction, and bars any further writes or commit. Reads (including read-your-own-writes)
+  keep working until the transaction is aborted.
 - `txn.abort()` Rolls back and closes the transaction. This method is automatically called after the
   transaction callback returns, so you shouldn't need to call it, but it's ok to do so. Once called,
   no further transaction operations are permitted. Calling this method multiple times has no effect.
@@ -672,6 +675,22 @@ operations methods as the `RocksDatabase` instance plus:
 - `txn.setTimestamp(ts?: number): void` Overrides the transaction start timestamp. If called without
   a timestamp, it will set the timestamp to the current time. The value must be in seconds with
   higher precision in the decimal.
+
+#### `txn.abandonWrites(): void`
+
+Releases the staged writes' verification-table (VT) write intents without closing the transaction,
+and bars any further writes or commit (`commit()`/`commitSync()`/`put()`/`remove()`, including
+database-context writes via `{ transaction: txn }`, all reject once called). Reads — including
+read-your-own-writes — keep working until the transaction is aborted. Idempotent, and a no-op after
+`abort()`.
+
+Scope is VT intents only: RocksDB's own transaction locks (pessimistic mode) are still held until
+the transaction is aborted.
+
+This is for a transaction kept open only for its outstanding read iterators after its writes were
+already committed elsewhere (e.g. replayed onto another transaction) — it lets the intents release
+early so other writers' coordinated-retry commits stop parking on them, instead of waiting for the
+handle's eventual `abort()`.
 
 #### `txn.abort(): void`
 

--- a/src/binding/database/database.cpp
+++ b/src/binding/database/database.cpp
@@ -1592,6 +1592,9 @@ napi_value Database::PutSync(napi_env env, napi_callback_info info) {
 			::napi_throw_error(env, nullptr, errorMsg.c_str());
 			NAPI_RETURN_UNDEFINED();
 		}
+		if (txnHandle->writesAbandoned) {
+			NAPI_THROW_JS_ERROR("ERR_WRITES_ABANDONED", "Transaction writes were abandoned; the transaction is read-only");
+		}
 		status = txnHandle->putSync(
 			keySlice,
 			valueSlice,
@@ -1665,6 +1668,9 @@ napi_value Database::RemoveSync(napi_env env, napi_callback_info info) {
 			std::string errorMsg = "Remove sync failed: Transaction not found (txnId: " + std::to_string(txnId) + ")";
 			::napi_throw_error(env, nullptr, errorMsg.c_str());
 			NAPI_RETURN_UNDEFINED();
+		}
+		if (txnHandle->writesAbandoned) {
+			NAPI_THROW_JS_ERROR("ERR_WRITES_ABANDONED", "Transaction writes were abandoned; the transaction is read-only");
 		}
 		status = txnHandle->removeSync(keySlice, *dbHandle);
 	} else {

--- a/src/binding/napi/macros.h
+++ b/src/binding/napi/macros.h
@@ -170,6 +170,12 @@ struct DBHandle;
 		rocksdb_js::createRocksDBError(env, status, msg, error); \
 	} while (0)
 
+#define NAPI_THROW_JS_ERROR(code, message) \
+	napi_value error; \
+	rocksdb_js::createJSError(env, code, message, error); \
+	::napi_throw(env, error); \
+	return nullptr
+
 #define THROW_IF_READONLY(handle, context) \
 	do { \
 		if ((handle) && (handle)->readOnly) { \

--- a/src/binding/napi/macros.h
+++ b/src/binding/napi/macros.h
@@ -171,10 +171,12 @@ struct DBHandle;
 	} while (0)
 
 #define NAPI_THROW_JS_ERROR(code, message) \
-	napi_value error; \
-	rocksdb_js::createJSError(env, code, message, error); \
-	::napi_throw(env, error); \
-	return nullptr
+	do { \
+		napi_value error; \
+		rocksdb_js::createJSError(env, code, message, error); \
+		::napi_throw(env, error); \
+		return nullptr; \
+	} while (0)
 
 #define THROW_IF_READONLY(handle, context) \
 	do { \

--- a/src/binding/transaction/transaction.cpp
+++ b/src/binding/transaction/transaction.cpp
@@ -26,12 +26,6 @@
 		} \
 	} while (0)
 
-#define NAPI_THROW_JS_ERROR(code, message) \
-	napi_value error; \
-	rocksdb_js::createJSError(env, code, message, error); \
-	::napi_throw(env, error); \
-	return nullptr
-
 namespace rocksdb_js {
 
 /**
@@ -164,14 +158,16 @@ napi_value Transaction::Abort(napi_env env, napi_callback_info info) {
 }
 
 /**
- * Releases the transaction's staged writes' verification-table write intents
- * without closing the transaction, and bars any future commit. For a handle
- * retained only so outstanding read iterators can finish after its writes were
- * replayed and committed on another transaction (HarperFast/harper#2001): the
- * retained intents can never be released by a commit, so without this call
- * other writers' coordinated-retry commits park on them until the handle is
- * finally aborted. Reads — including read-your-own-writes through the write
- * batch, which match the replayed transaction's committed state — keep working.
+ * Releases the staged writes' verification-table write intents without closing
+ * the transaction, and bars any later commit or write: the intents are gone, so
+ * a commit would publish writes no longer protected against a concurrent
+ * reader's cached version. For a handle kept open only for its outstanding read
+ * iterators after the writes were replayed onto another transaction — nothing
+ * else will ever release those intents, and other writers' coordinated-retry
+ * commits park on them. Reads keep working, including read-your-own-writes.
+ *
+ * VT intents only: RocksDB's own transaction locks (pessimistic mode) are held
+ * until the transaction is aborted.
  */
 napi_value Transaction::AbandonWrites(napi_env env, napi_callback_info info) {
 	NAPI_METHOD();
@@ -179,7 +175,6 @@ napi_value Transaction::AbandonWrites(napi_env env, napi_callback_info info) {
 
 	TransactionState txnState = (*txnHandle)->state;
 	if (txnState == TransactionState::Aborted) {
-		// close() already released the intents
 		return nullptr;
 	}
 	if (txnState == TransactionState::Committing || txnState == TransactionState::Committed) {
@@ -575,6 +570,11 @@ napi_value Transaction::Commit(napi_env env, napi_callback_info info) {
 	napi_value reject = argv[1];
 	UNWRAP_TRANSACTION_HANDLE("Commit");
 
+	// Checked before the state/reference allocations below so the throw cannot leak them.
+	if ((*txnHandle)->writesAbandoned) {
+		NAPI_THROW_JS_ERROR("ERR_WRITES_ABANDONED", "Transaction writes were abandoned and can no longer be committed");
+	}
+
 	TransactionCommitState* state = new TransactionCommitState(env, *txnHandle);
 	NAPI_STATUS_THROWS(::napi_create_reference(env, resolve, 1, &state->resolveRef));
 	NAPI_STATUS_THROWS(::napi_create_reference(env, reject, 1, &state->rejectRef));
@@ -590,9 +590,6 @@ napi_value Transaction::Commit(napi_env env, napi_callback_info info) {
 		NAPI_STATUS_THROWS(::napi_call_function(env, global, resolve, 0, nullptr, nullptr));
 		delete state;
 		return nullptr;
-	}
-	if ((*txnHandle)->writesAbandoned) {
-		NAPI_THROW_JS_ERROR("ERR_WRITES_ABANDONED", "Transaction writes were abandoned and can no longer be committed");
 	}
 	DEBUG_LOG("%p Transaction::Commit Setting state to committing\n", (*txnHandle).get(), (*txnHandle)->id);
 	(*txnHandle)->state = TransactionState::Committing;

--- a/src/binding/transaction/transaction.cpp
+++ b/src/binding/transaction/transaction.cpp
@@ -570,27 +570,28 @@ napi_value Transaction::Commit(napi_env env, napi_callback_info info) {
 	napi_value reject = argv[1];
 	UNWRAP_TRANSACTION_HANDLE("Commit");
 
-	// Checked before the state/reference allocations below so the throw cannot leak them.
-	if ((*txnHandle)->writesAbandoned) {
-		NAPI_THROW_JS_ERROR("ERR_WRITES_ABANDONED", "Transaction writes were abandoned and can no longer be committed");
-	}
-
-	TransactionCommitState* state = new TransactionCommitState(env, *txnHandle);
-	NAPI_STATUS_THROWS(::napi_create_reference(env, resolve, 1, &state->resolveRef));
-	NAPI_STATUS_THROWS(::napi_create_reference(env, reject, 1, &state->rejectRef));
-
+	// Every terminal case is decided before the state/reference allocations below, so none of them
+	// can leak an allocation, and the rejection order matches CommitSync's (aborted before
+	// abandoned — a handle that is both reports the abort, which is the more specific state).
 	TransactionState txnState = (*txnHandle)->state;
 	if (txnState == TransactionState::Aborted) {
 		NAPI_THROW_JS_ERROR("ERR_ALREADY_ABORTED", "Transaction has already been aborted");
+	}
+	if ((*txnHandle)->writesAbandoned) {
+		NAPI_THROW_JS_ERROR("ERR_WRITES_ABANDONED", "Transaction writes were abandoned and can no longer be committed");
 	}
 	if (txnState == TransactionState::Committing || txnState == TransactionState::Committed) {
 		// already committed
 		napi_value global;
 		NAPI_STATUS_THROWS(::napi_get_global(env, &global));
 		NAPI_STATUS_THROWS(::napi_call_function(env, global, resolve, 0, nullptr, nullptr));
-		delete state;
 		return nullptr;
 	}
+
+	TransactionCommitState* state = new TransactionCommitState(env, *txnHandle);
+	NAPI_STATUS_THROWS(::napi_create_reference(env, resolve, 1, &state->resolveRef));
+	NAPI_STATUS_THROWS(::napi_create_reference(env, reject, 1, &state->rejectRef));
+
 	DEBUG_LOG("%p Transaction::Commit Setting state to committing\n", (*txnHandle).get(), (*txnHandle)->id);
 	(*txnHandle)->state = TransactionState::Committing;
 

--- a/src/binding/transaction/transaction.cpp
+++ b/src/binding/transaction/transaction.cpp
@@ -164,6 +164,34 @@ napi_value Transaction::Abort(napi_env env, napi_callback_info info) {
 }
 
 /**
+ * Releases the transaction's staged writes' verification-table write intents
+ * without closing the transaction, and bars any future commit. For a handle
+ * retained only so outstanding read iterators can finish after its writes were
+ * replayed and committed on another transaction (HarperFast/harper#2001): the
+ * retained intents can never be released by a commit, so without this call
+ * other writers' coordinated-retry commits park on them until the handle is
+ * finally aborted. Reads — including read-your-own-writes through the write
+ * batch, which match the replayed transaction's committed state — keep working.
+ */
+napi_value Transaction::AbandonWrites(napi_env env, napi_callback_info info) {
+	NAPI_METHOD();
+	UNWRAP_TRANSACTION_HANDLE("AbandonWrites");
+
+	TransactionState txnState = (*txnHandle)->state;
+	if (txnState == TransactionState::Aborted) {
+		// close() already released the intents
+		return nullptr;
+	}
+	if (txnState == TransactionState::Committing || txnState == TransactionState::Committed) {
+		NAPI_THROW_JS_ERROR("ERR_ALREADY_COMMITTED", "Transaction has already been committed");
+	}
+
+	(*txnHandle)->writesAbandoned = true;
+	(*txnHandle)->releaseIntent();
+	NAPI_RETURN_UNDEFINED();
+}
+
+/**
  * Context passed through the RETRY_NOW TSFN; owns the resolve/reject refs.
  * Freed by retryNowFinalize after the TSFN fires.
  */
@@ -563,6 +591,9 @@ napi_value Transaction::Commit(napi_env env, napi_callback_info info) {
 		delete state;
 		return nullptr;
 	}
+	if ((*txnHandle)->writesAbandoned) {
+		NAPI_THROW_JS_ERROR("ERR_WRITES_ABANDONED", "Transaction writes were abandoned and can no longer be committed");
+	}
 	DEBUG_LOG("%p Transaction::Commit Setting state to committing\n", (*txnHandle).get(), (*txnHandle)->id);
 	(*txnHandle)->state = TransactionState::Committing;
 
@@ -683,6 +714,9 @@ napi_value Transaction::CommitSync(napi_env env, napi_callback_info info) {
 	TransactionState txnState = (*txnHandle)->state;
 	if (txnState == TransactionState::Aborted) {
 		NAPI_THROW_JS_ERROR("ERR_ALREADY_ABORTED", "Transaction has already been aborted");
+	}
+	if ((*txnHandle)->writesAbandoned) {
+		NAPI_THROW_JS_ERROR("ERR_WRITES_ABANDONED", "Transaction writes were abandoned and can no longer be committed");
 	}
 	if (txnState == TransactionState::Committing || txnState == TransactionState::Committed) {
 		NAPI_RETURN_UNDEFINED();
@@ -1019,6 +1053,9 @@ napi_value Transaction::PutSync(napi_env env, napi_callback_info info) {
 	NAPI_GET_BUFFER(argv[1], value, nullptr);
 	UNWRAP_TRANSACTION_HANDLE("Put");
 	// THROW_IF_READONLY((*txnHandle)->dbHandle->descriptor, "Put failed: ");
+	if ((*txnHandle)->writesAbandoned) {
+		NAPI_THROW_JS_ERROR("ERR_WRITES_ABANDONED", "Transaction writes were abandoned; the transaction is read-only");
+	}
 
 	rocksdb::Slice keySlice(key + keyStart, keyEnd - keyStart);
 	rocksdb::Slice valueSlice(value + valueStart, valueEnd - valueStart);
@@ -1042,6 +1079,9 @@ napi_value Transaction::RemoveSync(napi_env env, napi_callback_info info) {
 	NAPI_GET_BUFFER(argv[0], key, "Key is required");
 	UNWRAP_TRANSACTION_HANDLE("Remove");
 	// THROW_IF_READONLY((*txnHandle)->dbHandle->descriptor, "Remove failed: ");
+	if ((*txnHandle)->writesAbandoned) {
+		NAPI_THROW_JS_ERROR("ERR_WRITES_ABANDONED", "Transaction writes were abandoned; the transaction is read-only");
+	}
 
 	rocksdb::Slice keySlice(key + keyStart, keyEnd - keyStart);
 
@@ -1148,6 +1188,7 @@ napi_value Transaction::UseLog(napi_env env, napi_callback_info info) {
  */
 void Transaction::Init(napi_env env, napi_value exports) {
 	napi_property_descriptor properties[] = {
+		{ "abandonWrites", nullptr, AbandonWrites, nullptr, nullptr, nullptr, napi_default, nullptr },
 		{ "abort", nullptr, Abort, nullptr, nullptr, nullptr, napi_default, nullptr },
 		{ "commit", nullptr, Commit, nullptr, nullptr, nullptr, napi_default, nullptr },
 		{ "commitSync", nullptr, CommitSync, nullptr, nullptr, nullptr, napi_default, nullptr },

--- a/src/binding/transaction/transaction.h
+++ b/src/binding/transaction/transaction.h
@@ -19,6 +19,7 @@ namespace rocksdb_js {
  */
 struct Transaction final {
 	static napi_value Constructor(napi_env env, napi_callback_info info);
+	static napi_value AbandonWrites(napi_env env, napi_callback_info info);
 	static napi_value Abort(napi_env env, napi_callback_info info);
 	static napi_value Commit(napi_env env, napi_callback_info info);
 	static napi_value CommitSync(napi_env env, napi_callback_info info);

--- a/src/binding/transaction/transaction_handle.h
+++ b/src/binding/transaction/transaction_handle.h
@@ -78,6 +78,15 @@ struct TransactionHandle final : Closable, AsyncWorkHandle, std::enable_shared_f
 	bool coordinatedRetry;
 
 	/**
+	 * Set by Transaction::AbandonWrites: the staged writes have been delegated
+	 * to (replayed and committed by) another transaction, so this handle's
+	 * write intents were released early and it must never commit — only reads
+	 * (including read-your-own-writes through the write batch) remain valid
+	 * until the handle is aborted/closed.
+	 */
+	bool writesAbandoned = false;
+
+	/**
 	 * The transaction id assigned by the database descriptor.
 	 */
 	uint32_t id;

--- a/src/binding/transaction/transaction_handle.h
+++ b/src/binding/transaction/transaction_handle.h
@@ -78,11 +78,9 @@ struct TransactionHandle final : Closable, AsyncWorkHandle, std::enable_shared_f
 	bool coordinatedRetry;
 
 	/**
-	 * Set by Transaction::AbandonWrites: the staged writes have been delegated
-	 * to (replayed and committed by) another transaction, so this handle's
-	 * write intents were released early and it must never commit — only reads
-	 * (including read-your-own-writes through the write batch) remain valid
-	 * until the handle is aborted/closed.
+	 * Set by Transaction::AbandonWrites: the VT write intents were released
+	 * early, so this handle must never commit or write again — reads remain
+	 * valid until it is aborted.
 	 */
 	bool writesAbandoned = false;
 

--- a/src/load-binding.ts
+++ b/src/load-binding.ts
@@ -45,6 +45,7 @@ export type NativeTransactionOptions = {
 export type NativeTransaction = {
 	id: number;
 	new (context: NativeDatabase, options?: NativeTransactionOptions): NativeTransaction;
+	abandonWrites(): void;
 	abort(): void;
 	commit(resolve: (retrySignal?: number) => void, reject: (err: Error) => void): void;
 	commitSync(): void;

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -92,13 +92,12 @@ export class Transaction extends DBI {
 	}
 
 	/**
-	 * Release this transaction's staged writes' verification-table write
-	 * intents without closing it, and bar any future commit or write. For a
-	 * transaction retained only so outstanding read iterators can finish after
-	 * its writes were replayed and committed on another transaction: without
-	 * this, other writers' coordinated-retry commits park on the retained
-	 * intents until the transaction is finally aborted. Reads — including
-	 * read-your-own-writes through the write batch — keep working.
+	 * Release the staged writes' verification-table write intents without
+	 * closing the transaction, barring any later commit or write. For a
+	 * transaction kept open only for its outstanding read iterators after the
+	 * writes were replayed onto another transaction: otherwise other writers'
+	 * coordinated-retry commits park on those intents until it is aborted.
+	 * Reads keep working, including read-your-own-writes.
 	 */
 	abandonWrites(): void {
 		this.#txn.abandonWrites();

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -81,7 +81,7 @@ export class Transaction extends DBI {
 		if (store.readOnly) {
 			super(store);
 			this.#txn = { id: 0 } as NativeTransaction;
-			this.abort = this.commitSync = this.setTimestamp = () => {};
+			this.abandonWrites = this.abort = this.commitSync = this.setTimestamp = () => {};
 			this.commit = async () => {};
 			this.getTimestamp = () => 0;
 		} else {
@@ -89,6 +89,19 @@ export class Transaction extends DBI {
 			super(store, txn);
 			this.#txn = txn;
 		}
+	}
+
+	/**
+	 * Release this transaction's staged writes' verification-table write
+	 * intents without closing it, and bar any future commit or write. For a
+	 * transaction retained only so outstanding read iterators can finish after
+	 * its writes were replayed and committed on another transaction: without
+	 * this, other writers' coordinated-retry commits park on the retained
+	 * intents until the transaction is finally aborted. Reads — including
+	 * read-your-own-writes through the write batch — keep working.
+	 */
+	abandonWrites(): void {
+		this.#txn.abandonWrites();
 	}
 
 	/**

--- a/test/abandon-writes.test.ts
+++ b/test/abandon-writes.test.ts
@@ -1,0 +1,66 @@
+import { RETRY_NOW, Transaction } from '../src/transaction.js';
+import { dbRunner } from './lib/util.js';
+import { describe, expect, it } from 'vitest';
+
+const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+describe('Transaction.abandonWrites()', () => {
+	it('releases held write intents so a parked coordinated-retry commit wakes', () =>
+		dbRunner({ dbOptions: [{ verificationTable: true }] }, async ({ db }) => {
+			await db.put('hot', 'v0');
+			db.populateVersion('hot', 1.5e12); // materialize the VT slot so write intents engage
+
+			// Stages a write (locking the slot's write intent) and never settles —
+			// the retained-for-iterators shape from HarperFast/harper#2001.
+			const holder = new Transaction(db.store, { coordinatedRetry: true });
+			await holder.put('hot', 'held');
+
+			// Snapshots now so the conflicting commit below makes its commit IsBusy.
+			const parked = new Transaction(db.store, { coordinatedRetry: true });
+			await parked.put('hot', 'parked');
+
+			const conflicting = new Transaction(db.store, { coordinatedRetry: true });
+			await conflicting.put('hot', 'conflicting');
+			await conflicting.commit();
+
+			// IsBusy under coordinatedRetry: parks on the slot's tracker, which
+			// `holder` keeps locked — the commit must not settle on its own.
+			const parkedCommit = parked.commit();
+			expect(
+				await Promise.race([
+					parkedCommit.then(() => 'settled'),
+					delay(400).then(() => 'still-parked'),
+				])
+			).toBe('still-parked');
+
+			holder.abandonWrites();
+
+			expect(await parkedCommit).toBe(RETRY_NOW);
+			parked.abort();
+			holder.abort();
+		}));
+
+	it('bars commit and further writes but keeps reads working', () =>
+		dbRunner(async ({ db }) => {
+			await db.put('key', 'committed');
+			const txn = new Transaction(db.store);
+			await txn.put('key', 'staged');
+
+			txn.abandonWrites();
+
+			expect(await txn.get('key')).toBe('staged'); // read-your-own-writes survives
+			await expect(txn.commit()).rejects.toThrow(/abandoned/);
+			await expect(txn.put('key', 'more')).rejects.toThrow(/abandoned/);
+			txn.abort();
+		}));
+
+	it('is idempotent and a no-op after abort', () =>
+		dbRunner(async ({ db }) => {
+			const txn = new Transaction(db.store);
+			await txn.put('k', 'v');
+			txn.abandonWrites();
+			txn.abandonWrites();
+			txn.abort();
+			txn.abandonWrites();
+		}));
+});

--- a/test/abandon-writes.test.ts
+++ b/test/abandon-writes.test.ts
@@ -2,7 +2,16 @@ import { RETRY_NOW, Transaction } from '../src/transaction.js';
 import { dbRunner } from './lib/util.js';
 import { describe, expect, it } from 'vitest';
 
-const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+const settled = <T>(promise: Promise<T>) => {
+	let done = false;
+	promise.then(
+		() => (done = true),
+		() => (done = true)
+	);
+	// Two macrotask turns: enough for a resolved TSFN callback to have run, none
+	// for a genuinely parked commit (which waits on another thread's release).
+	return new Promise<boolean>((resolve) => setImmediate(() => setImmediate(() => resolve(done))));
+};
 
 describe('Transaction.abandonWrites()', () => {
 	it('releases held write intents so a parked coordinated-retry commit wakes', () =>
@@ -10,12 +19,12 @@ describe('Transaction.abandonWrites()', () => {
 			await db.put('hot', 'v0');
 			db.populateVersion('hot', 1.5e12); // materialize the VT slot so write intents engage
 
-			// Stages a write (locking the slot's write intent) and never settles —
-			// the retained-for-iterators shape from HarperFast/harper#2001.
+			// Stages a write (locking the slot's write intent) and never settles — the
+			// retained-for-iterators shape from HarperFast/harper#2001.
 			const holder = new Transaction(db.store, { coordinatedRetry: true });
 			await holder.put('hot', 'held');
 
-			// Snapshots now so the conflicting commit below makes its commit IsBusy.
+			// Snapshots before the conflicting commit below so its own commit is IsBusy.
 			const parked = new Transaction(db.store, { coordinatedRetry: true });
 			await parked.put('hot', 'parked');
 
@@ -23,15 +32,8 @@ describe('Transaction.abandonWrites()', () => {
 			await conflicting.put('hot', 'conflicting');
 			await conflicting.commit();
 
-			// IsBusy under coordinatedRetry: parks on the slot's tracker, which
-			// `holder` keeps locked — the commit must not settle on its own.
 			const parkedCommit = parked.commit();
-			expect(
-				await Promise.race([
-					parkedCommit.then(() => 'settled'),
-					delay(400).then(() => 'still-parked'),
-				])
-			).toBe('still-parked');
+			expect(await settled(parkedCommit)).toBe(false);
 
 			holder.abandonWrites();
 
@@ -40,7 +42,29 @@ describe('Transaction.abandonWrites()', () => {
 			holder.abort();
 		}));
 
-	it('bars commit and further writes but keeps reads working', () =>
+	it('keeps an outstanding read iterator working after abandoning', () =>
+		dbRunner({ dbOptions: [{ verificationTable: true }] }, async ({ db }) => {
+			await db.put('k1', 'v1');
+			await db.put('k2', 'v2');
+			await db.put('k3', 'v3');
+
+			const txn = new Transaction(db.store);
+			await txn.put('k2', 'staged');
+
+			const iterator = txn.getRange()[Symbol.iterator]();
+			expect(iterator.next().done).toBe(false);
+
+			txn.abandonWrites();
+
+			let remaining = 0;
+			for (let entry = iterator.next(); !entry.done; entry = iterator.next()) {
+				remaining++;
+			}
+			expect(remaining).toBeGreaterThanOrEqual(1);
+			txn.abort();
+		}));
+
+	it('bars every write and commit entry point but keeps reads working', () =>
 		dbRunner(async ({ db }) => {
 			await db.put('key', 'committed');
 			const txn = new Transaction(db.store);
@@ -50,7 +74,14 @@ describe('Transaction.abandonWrites()', () => {
 
 			expect(await txn.get('key')).toBe('staged'); // read-your-own-writes survives
 			await expect(txn.commit()).rejects.toThrow(/abandoned/);
+			expect(() => txn.commitSync()).toThrow(/abandoned/);
 			await expect(txn.put('key', 'more')).rejects.toThrow(/abandoned/);
+			await expect(txn.remove('key')).rejects.toThrow(/abandoned/);
+			// Database-context writes reach the same handle through Database::PutSync's
+			// txnId branch rather than Transaction::PutSync — an unguarded path there would
+			// re-lock the VT slot that was just released.
+			expect(() => db.putSync('key', 'via-db', { transaction: txn })).toThrow(/abandoned/);
+			expect(() => db.removeSync('key', { transaction: txn })).toThrow(/abandoned/);
 			txn.abort();
 		}));
 

--- a/test/abandon-writes.test.ts
+++ b/test/abandon-writes.test.ts
@@ -94,4 +94,23 @@ describe('Transaction.abandonWrites()', () => {
 			txn.abort();
 			txn.abandonWrites();
 		}));
+
+	it('reports the abort, not the abandonment, when committed after abort — matching async and sync', () =>
+		dbRunner(async ({ db }) => {
+			const txn = new Transaction(db.store);
+			await txn.put('key', 'staged');
+			txn.abandonWrites();
+			txn.abort();
+			// Both must report ERR_ALREADY_ABORTED (the more specific state), not
+			// ERR_WRITES_ABANDONED — and must agree with each other, since the
+			// db.transaction()/transactionSync() wrappers only special-case
+			// TransactionAlreadyAbortedError as an expected user abort.
+			await expect(txn.commit()).rejects.toThrow(/already been aborted/);
+
+			const txnSync = new Transaction(db.store);
+			txnSync.putSync('key', 'staged');
+			txnSync.abandonWrites();
+			txnSync.abort();
+			expect(() => txnSync.commitSync()).toThrow(/already been aborted/);
+		}));
 });


### PR DESCRIPTION
## Why

A transaction that commits while read iterators are still streaming through it can't commit or abort its native handle — that would invalidate the live iterators. Harper's `DatabaseTransaction.commit()` therefore replays the staged writes onto a fresh transaction, commits those, and keeps the original handle open purely as a read handle until the last iterator drains.

That retained handle still holds the verification-table **write intents** its staged writes installed. No commit will ever run on it, so nothing releases them until it is finally aborted — and meanwhile every other writer's `coordinatedRetry` commit that conflicts on those slots **parks** on them. With an unbounded park (today) that is HarperFast/harper#2001's per-thread write wedge: an orphaned handler's intents kept a production node rejecting writes for 10+ hours.

There is no way to commit a transaction's pending writes and keep it alive for reads, so the writes have to be delegated — which is exactly what the replay does. What was missing is a way to say *"these staged writes are someone else's problem now; drop their locks."*

## What

`Transaction.abandonWrites()`:
- releases the staged writes' VT write intents (`releaseIntent()`, already idempotent and taken under the handle's `stateMutex` discipline),
- bars every later write and commit entry point with `ERR_WRITES_ABANDONED` — re-locking a released slot would re-create the wedge,
- leaves the write batch and snapshot intact, so reads (including read-your-own-writes, which now match the replayed transaction's committed state) keep working until the handle is aborted.

Scope: VT intents only. RocksDB's own transaction locks (pessimistic mode) are still held until abort — documented at the method.

The Harper-side call site is HarperFast/harper#2050; it feature-detects, so this can land and release independently.

## Review notes

The cross-model review caught a genuine bypass that the first pass shipped: `db.put(key, value, { transaction })` reaches the handle through `Database::PutSync`'s `txnId` branch rather than `Transaction::PutSync`, so it re-locked the slot `abandonWrites` had just released. Both database-context branches are now guarded, with a test that fails on the unguarded build. Also from review: the async-commit barrier moved above its state/reference allocations (the rejection leaked a `TransactionCommitState` and two strong refs, mirroring the pre-existing `Aborted`-path leak), and the VT-only scope is documented.

## Testing

`test/abandon-writes.test.ts` — 4 cases:
- **park/wake**: a real `IsBusy` coordinated-retry commit parks on a holder's tracker, stays unsettled, and resolves `RETRY_NOW` the moment the holder abandons. This is the end-to-end proof of the mechanism.
- an **outstanding read iterator** keeps producing entries across the abandon (the motivating shape).
- every write/commit entry point rejects: `commit`, `commitSync`, `put`, `remove`, and both database-context (`{ transaction }`) paths — while `get` still returns the staged value.
- idempotent, and a no-op after `abort()`.

Full suite: 714 passed / 1 skipped. `pnpm check` clean.

Generated with Claude Fable 5.
