### PR TITLE
fix(txnlog): resync past a mid-log corrupt frame instead of ending the log

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -331,6 +331,19 @@ sufficient (env teardown does not honor tsfn acquire counts); see
     `DBOptions` defaults that derive a large value were sized when they reached one column family, so
     widening where an option applies means re-checking its default against every shared budget it
     competes for.
+11. **A corrupt transaction-log frame ends an entry, not the log**: framing breaks come in two
+    shapes and the reader must not conflate them. A **torn tail** has nothing valid behind it, so
+    the break is genuinely end-of-log — that is what `recoverTail()` truncates at open. A **mid-log
+    break** (a partial `ENOSPC`/`EDQUOT` append the process survived) has intact, already-committed
+    entries appended _after_ it; `recoverTail()` deliberately leaves such a file alone rather than
+    discard them, and rotated files are never rescanned at all. `query()` therefore reports the
+    break as a `CorruptFrameError` carrying `resyncPosition` (where framing resumes, per the same
+    heuristic as `validFramingResumes()`) and **leaves iteration positioned there**, so a caller
+    that calls `next()` again recovers the entries past it. Treating the throw as terminal amputates
+    every later entry in the file permanently — each drain restarts from the same resume cursor and
+    re-throws at the same offset, which is how HarperFast/harper#2016 lost 2.2 days of acknowledged
+    writes and #2063 starved a replication stream for 11 days. Keep `RESYNC_MIN_FRAMES` in
+    `transaction-log-reader.ts` and `transaction_log_recovery.cpp` in step.
 
 ## Debugging native heap corruption
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -345,6 +345,14 @@ sufficient (env teardown does not honor tsfn acquire counts); see
     writes and #2063 starved a replication stream for 11 days. Keep `RESYNC_MIN_FRAMES` in
     `transaction-log-reader.ts` and `transaction_log_recovery.cpp` in step.
 
+    The resync scan must be bounded by the **written extent** (`getLogFileSize`, which returns the
+    append-owned `TransactionLogFile::size` — see invariant 5 — not the physical or mapped size).
+    An uncommitted read's own limit is the pre-extended memory map, and every offset in that zero
+    fill reads as an end-of-entries marker: scanning against it both loses the exact-end signal and,
+    if a zero were taken as a terminator, would let a chain "end" anywhere in megabytes of padding.
+    Resolve it only on a break — `getLogFileSize` crosses into native and takes the store mutex, so
+    a per-frame call would tax every healthy read.
+
 ## Debugging native heap corruption
 
 AddressSanitizer is the first choice (`ROCKSDB_ASAN=1 node-gyp rebuild` toggles `-fsanitize=address`

--- a/src/binding/transaction/transaction.cpp
+++ b/src/binding/transaction/transaction.cpp
@@ -599,12 +599,10 @@ napi_value Transaction::Commit(napi_env env, napi_callback_info info) {
 	CommitThreadMode mode = commitThreadMode();
 	bool completionsClosed = false;
 	if (mode != CommitThreadMode::Legacy && dbHandle && dbHandle->descriptor) {
-		// The commit lanes are owned by the descriptor and drained/joined before
-		// the descriptor is destroyed; and an in-flight commit's state pins the
-		// descriptor alive (state -> txnHandle -> dbHandle -> descriptor). So a
-		// raw pointer captured into the worker task is valid for the task's
-		// lifetime and cannot form a reference cycle with the worker thread.
-		DBDescriptor* descriptor = dbHandle->descriptor.get();
+		// Keep the descriptor alive until every queued stage has completed. Worker
+		// teardown can close the transaction handle between the log and commit
+		// stages, releasing its DBHandle and its descriptor reference.
+		auto descriptor = dbHandle->descriptor;
 
 		// Ensure this env has a completion tsfn and account the dispatch (refs
 		// the tsfn as the env goes idle->busy so the event loop stays alive).
@@ -1223,4 +1221,3 @@ void Transaction::Init(napi_env env, napi_value exports) {
 }
 
 } // namespace rocksdb_js
-

--- a/src/binding/transaction/transaction.cpp
+++ b/src/binding/transaction/transaction.cpp
@@ -601,7 +601,9 @@ napi_value Transaction::Commit(napi_env env, napi_callback_info info) {
 	if (mode != CommitThreadMode::Legacy && dbHandle && dbHandle->descriptor) {
 		// Keep the descriptor alive until every queued stage has completed. Worker
 		// teardown can close the transaction handle between the log and commit
-		// stages, releasing its DBHandle and its descriptor reference.
+		// stages, releasing its DBHandle and its descriptor reference. The registry
+		// retains its reference until it drains and joins these lanes, so this task
+		// capture cannot be the last descriptor reference on a worker thread.
 		auto descriptor = dbHandle->descriptor;
 
 		// Ensure this env has a completion tsfn and account the dispatch (refs

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,7 +55,8 @@ export {
 } from './store.js';
 export { Transaction } from './transaction.js';
 
-import './transaction-log-reader.js';
+import './transaction-log-reader.js'; // installs TransactionLog.prototype.query
+export { CorruptFrameError } from './transaction-log-reader.js';
 
 export const versions: { rocksdb: string; 'rocksdb-js': string } = {
 	rocksdb: version,

--- a/src/transaction-log-reader.ts
+++ b/src/transaction-log-reader.ts
@@ -125,15 +125,22 @@ function corruptFrame(
 ): { error: CorruptFrameError; nextPosition: number } {
 	// An uncommitted read's `limit` is the pre-extended map, so ask the file for its written extent;
 	// a committed read is already bounded at the watermark.
-	const writtenExtent = readUncommitted ? transactionLog.getLogFileSize(logBuffer.logId) : 0;
-	const dataEnd = writtenExtent > 0 ? Math.min(logBuffer.length, writtenExtent) : limit;
+	let dataEnd = limit;
+	if (readUncommitted) {
+		try {
+			const writtenExtent = transactionLog.getLogFileSize(logBuffer.logId);
+			dataEnd = writtenExtent > 0 ? Math.min(logBuffer.length, writtenExtent) : 0;
+		} catch {
+			dataEnd = 0;
+		}
+	}
 	const resyncPosition = findResyncPosition(dataView, position + 1, dataEnd);
 	return {
 		error: new CorruptFrameError(message, logBuffer.logId, position, resyncPosition),
 		// With no resume point iteration is over, so land past `size` as well as the readable end:
 		// a committed `size` that over-reports the mapped buffer would otherwise leave
 		// `position < size`, and the next call would re-enter the loop and read off the end.
-		nextPosition: resyncPosition ?? Math.max(dataEnd, size, position + 1),
+		nextPosition: resyncPosition ?? Math.max(dataEnd || limit, size, position + 1),
 	};
 }
 

--- a/src/transaction-log-reader.ts
+++ b/src/transaction-log-reader.ts
@@ -99,7 +99,7 @@ function findResyncPosition(dataView: DataView, from: number, dataEnd: number): 
 	for (let start = from; start <= lastStart; start++) {
 		let pos = start;
 		let frames = 0;
-		while (frameFits(dataView, pos, dataEnd)) {
+		while (frames < RESYNC_MIN_FRAMES && frameFits(dataView, pos, dataEnd)) {
 			pos += TRANSACTION_LOG_ENTRY_HEADER_SIZE + dataView.getUint32(pos + 8);
 			if (++frames >= RESYNC_MIN_FRAMES || pos === dataEnd) {
 				return start;

--- a/src/transaction-log-reader.ts
+++ b/src/transaction-log-reader.ts
@@ -328,11 +328,15 @@ Object.defineProperty(TransactionLog.prototype, 'query', {
 						throw broken.error;
 					}
 					const length = dataView.getUint32(position + 8);
-					if (position + TRANSACTION_LOG_ENTRY_HEADER_SIZE + length > limit) {
+					if (length === 0 || position + TRANSACTION_LOG_ENTRY_HEADER_SIZE + length > limit) {
 						const broken = corruptFrame(
-							`Corrupt transaction log entry at position ${position.toString(16)} of log ${
-								logBuffer!.logId
-							}: declared length ${length} overruns the log (limit=${limit})`,
+							length === 0
+								? `Corrupt transaction log entry at position ${position.toString(16)} of log ${
+										logBuffer!.logId
+									}: zero-length entry`
+								: `Corrupt transaction log entry at position ${position.toString(16)} of log ${
+										logBuffer!.logId
+									}: declared length ${length} overruns the log (limit=${limit})`,
 							transactionLog,
 							dataView,
 							logBuffer!,

--- a/src/transaction-log-reader.ts
+++ b/src/transaction-log-reader.ts
@@ -60,13 +60,6 @@ export class CorruptFrameError extends RangeError {
 }
 
 /**
- * How far past a break to look for a resume point. A partial append leaves one interrupted batch,
- * so a real resume point is close; bounding the search keeps the cost predictable and keeps the
- * number of candidate offsets — and so the odds of accepting a false one — small.
- */
-const MAX_RESYNC_SCAN_BYTES = 1 << 20;
-
-/**
  * Whether a complete, in-bounds frame begins at `pos`. The only sane bound on an entry's length is
  * the written extent: a single entry can legitimately exceed the rotation threshold (the first
  * entry written to a fresh file is always written in full). A zero timestamp is the
@@ -102,8 +95,7 @@ function frameFits(dataView: DataView, pos: number, dataEnd: number): boolean {
  * the same question at open time but keeps only the yes/no, discarding the offset.
  */
 function findResyncPosition(dataView: DataView, from: number, dataEnd: number): number | undefined {
-	const lastStart =
-		Math.min(dataEnd, from + MAX_RESYNC_SCAN_BYTES) - TRANSACTION_LOG_ENTRY_HEADER_SIZE;
+	const lastStart = dataEnd - TRANSACTION_LOG_ENTRY_HEADER_SIZE;
 	for (let start = from; start <= lastStart; start++) {
 		let pos = start;
 		let frames = 0;
@@ -116,15 +108,25 @@ function findResyncPosition(dataView: DataView, from: number, dataEnd: number): 
 	}
 }
 
-/** Builds the report for a broken frame, with the offset iteration should continue from. */
+/**
+ * Builds the report for a broken frame, with the offset iteration should continue from. Resolves
+ * the written extent here rather than per frame: `getLogFileSize` crosses into native and takes
+ * the store mutex, which a healthy read must never pay.
+ */
 function corruptFrame(
 	message: string,
+	transactionLog: TransactionLog,
 	dataView: DataView,
 	logBuffer: LogBuffer,
 	position: number,
-	dataEnd: number,
-	size: number
+	limit: number,
+	size: number,
+	readUncommitted: boolean
 ): { error: CorruptFrameError; nextPosition: number } {
+	// An uncommitted read's `limit` is the pre-extended map, so ask the file for its written extent;
+	// a committed read is already bounded at the watermark.
+	const writtenExtent = readUncommitted ? transactionLog.getLogFileSize(logBuffer.logId) : 0;
+	const dataEnd = writtenExtent > 0 ? Math.min(logBuffer.length, writtenExtent) : limit;
 	const resyncPosition = findResyncPosition(dataView, position + 1, dataEnd);
 	return {
 		error: new CorruptFrameError(message, logBuffer.logId, position, resyncPosition),
@@ -309,23 +311,18 @@ Object.defineProperty(TransactionLog.prototype, 'query', {
 					// The throw leaves `position` at the resume point, so a broken frame ends the
 					// entry rather than the rest of the log (HarperFast/harper#2016, #2063).
 					const limit = readUncommitted ? logBuffer!.length : Math.min(size, logBuffer!.length);
-					// A resync scan must be bounded by written bytes. An uncommitted read is bounded
-					// by the mapped capacity, which runs far past the data, so ask the file for its
-					// extent instead; a committed read is already bounded at the watermark.
-					const writtenExtent = readUncommitted
-						? transactionLog.getLogFileSize(logBuffer!.logId)
-						: 0;
-					const dataEnd = writtenExtent > 0 ? Math.min(logBuffer!.length, writtenExtent) : limit;
 					if (position + TRANSACTION_LOG_ENTRY_HEADER_SIZE > limit) {
 						const broken = corruptFrame(
 							`Corrupt transaction log: truncated entry header at position ${position.toString(16)} of log ${
 								logBuffer!.logId
 							} (available=${limit - position})`,
+							transactionLog,
 							dataView,
 							logBuffer!,
 							position,
-							dataEnd,
-							size
+							limit,
+							size,
+							!!readUncommitted
 						);
 						position = broken.nextPosition;
 						throw broken.error;
@@ -336,11 +333,13 @@ Object.defineProperty(TransactionLog.prototype, 'query', {
 							`Corrupt transaction log entry at position ${position.toString(16)} of log ${
 								logBuffer!.logId
 							}: declared length ${length} overruns the log (limit=${limit})`,
+							transactionLog,
 							dataView,
 							logBuffer!,
 							position,
-							dataEnd,
-							size
+							limit,
+							size,
+							!!readUncommitted
 						);
 						position = broken.nextPosition;
 						throw broken.error;

--- a/src/transaction-log-reader.ts
+++ b/src/transaction-log-reader.ts
@@ -12,6 +12,101 @@ const UINT32_FROM_FLOAT = new Uint32Array(FLOAT_TO_UINT32.buffer);
 const { TRANSACTION_LOG_FILE_HEADER_SIZE, TRANSACTION_LOG_ENTRY_HEADER_SIZE } = constants;
 
 /**
+ * Number of consecutive well-formed frames that, on their own, signal that real log data has
+ * resumed after a framing break. Kept in step with `RESYNC_MIN_FRAMES` in
+ * `src/binding/transaction_log/transaction_log_recovery.cpp`, which uses the same heuristic to
+ * classify a break as mid-file corruption (valid entries follow) rather than a torn tail.
+ */
+const RESYNC_MIN_FRAMES = 8;
+
+/**
+ * Thrown when an entry's framing is broken. `resyncPosition` is the offset where valid framing
+ * resumes, when one was found: the frames after a mid-log break are intact and reachable, and
+ * only the broken span between `position` and `resyncPosition` is unreadable. It is `undefined`
+ * for a torn tail, where nothing follows the break.
+ *
+ * The iterator is left positioned at `resyncPosition` (or at end-of-log when there is none), so a
+ * caller that chooses to recover the entries past the break calls `next()` again — the throw is
+ * the one notification per break, not a wall. A caller that treats a broken frame as terminal
+ * simply stops, which is the behavior a plain `RangeError` already produced.
+ */
+export class CorruptFrameError extends RangeError {
+	/** Sequence number of the log file the break is in. */
+	logId: number;
+	/** Offset of the broken frame. */
+	position: number;
+	/** Offset where valid framing resumes, or `undefined` when nothing valid follows. */
+	resyncPosition?: number;
+	/** Bytes between the break and the resume point that cannot be read. */
+	unreadableBytes: number;
+
+	constructor(
+		message: string,
+		logId: number,
+		position: number,
+		resyncPosition: number | undefined
+	) {
+		super(
+			resyncPosition === undefined
+				? message
+				: `${message}; valid framing resumes at ${resyncPosition.toString(16)}, ${
+						resyncPosition - position
+					} byte(s) unreadable`
+		);
+		this.name = 'CorruptFrameError';
+		this.logId = logId;
+		this.position = position;
+		this.resyncPosition = resyncPosition;
+		this.unreadableBytes = resyncPosition === undefined ? 0 : resyncPosition - position;
+	}
+}
+
+/**
+ * Whether a complete, in-bounds frame begins at `pos`. The only sane bound on an entry's length is
+ * the readable extent: a single entry can legitimately exceed the rotation threshold (the first
+ * entry written to a fresh file is always written in full). A zero timestamp is the
+ * end-of-entries marker, not a frame.
+ */
+function frameFits(dataView: DataView, pos: number, limit: number): boolean {
+	if (pos + TRANSACTION_LOG_ENTRY_HEADER_SIZE > limit) {
+		return false;
+	}
+	if (dataView.getFloat64(pos) === 0) {
+		return false;
+	}
+	const length = dataView.getUint32(pos + 8);
+	if (length === 0) {
+		return false;
+	}
+	return pos + TRANSACTION_LOG_ENTRY_HEADER_SIZE + length <= limit;
+}
+
+/**
+ * Finds the offset in `[from, limit)` where valid log framing resumes: either a run of at least
+ * `RESYNC_MIN_FRAMES` well-formed frames, or any run that lands exactly on `limit`. Random bytes
+ * aligning a length-chain exactly to the end is ~1/2^32, so even a short run that hits the end is
+ * a reliable resume signal — and it is what lets fewer than `RESYNC_MIN_FRAMES` entries after a
+ * break still be recovered. Returns `undefined` when nothing resumes (a torn tail).
+ *
+ * Effectively linear: a non-resyncing offset fails after ~one frame check, and only a true resume
+ * point walks a chain. This is the JS counterpart of `validFramingResumes()` in
+ * `transaction_log_recovery.cpp`, which answers the same question at open time but keeps only the
+ * yes/no, discarding the offset; it runs here only on a broken frame, never on a healthy read.
+ */
+function findResyncPosition(dataView: DataView, from: number, limit: number): number | undefined {
+	for (let start = from; start + TRANSACTION_LOG_ENTRY_HEADER_SIZE <= limit; start++) {
+		let pos = start;
+		let frames = 0;
+		while (frameFits(dataView, pos, limit)) {
+			pos += TRANSACTION_LOG_ENTRY_HEADER_SIZE + dataView.getUint32(pos + 8);
+			if (++frames >= RESYNC_MIN_FRAMES || pos === limit) {
+				return start;
+			}
+		}
+	}
+}
+
+/**
  * Returns an iterable for transaction entries within the specified range of timestamps
  * This iterable can be iterated over multiple times, and subsequent iterations will continue
  * from where the last iteration left off, allowing for iteration through the log file
@@ -118,6 +213,17 @@ Object.defineProperty(TransactionLog.prototype, 'query', {
 			}
 		}
 
+		// Builds the error for a broken frame at `position` and advances `position` past the break
+		// first, so the throw reports the break without also sealing off what follows it. When
+		// framing resumes, `position` lands there; when nothing does (a torn tail), it lands at
+		// the readable end so a caller that retries gets `done` rather than the same throw again.
+		const corruptFrame = (message: string, limit: number) => {
+			const resyncPosition = findResyncPosition(dataView, position + 1, limit);
+			const error = new CorruptFrameError(message, logBuffer!.logId, position, resyncPosition);
+			position = resyncPosition ?? limit;
+			return error;
+		};
+
 		return {
 			[Symbol.iterator](): IterableIterator<TransactionEntry> {
 				return this;
@@ -182,20 +288,29 @@ Object.defineProperty(TransactionLog.prototype, 'query', {
 					// `position` runs past the buffer, `subarray` hands back a misframed
 					// (garbage) transaction, and the advance-to-next-log path can
 					// dereference an undefined buffer. Fail loudly with a bounded error.
+					//
+					// The throw also leaves `position` at the resume point (see corruptFrame), so
+					// the break stops this entry, not the rest of the log: a caller that wants the
+					// entries past a mid-log break calls next() again. Without that, a single
+					// broken frame amputates every later entry in the log permanently — the reader
+					// restarts from the same resume cursor on every drain and re-throws here
+					// (HarperFast/harper#2016, #2063).
 					const limit = readUncommitted ? logBuffer!.length : Math.min(size, logBuffer!.length);
 					if (position + TRANSACTION_LOG_ENTRY_HEADER_SIZE > limit) {
-						throw new RangeError(
+						throw corruptFrame(
 							`Corrupt transaction log: truncated entry header at position ${position.toString(16)} of log ${
 								logBuffer!.logId
-							} (available=${limit - position})`
+							} (available=${limit - position})`,
+							limit
 						);
 					}
 					const length = dataView.getUint32(position + 8);
 					if (position + TRANSACTION_LOG_ENTRY_HEADER_SIZE + length > limit) {
-						throw new RangeError(
+						throw corruptFrame(
 							`Corrupt transaction log entry at position ${position.toString(16)} of log ${
 								logBuffer!.logId
-							}: declared length ${length} overruns the log (limit=${limit})`
+							}: declared length ${length} overruns the log (limit=${limit})`,
+							limit
 						);
 					}
 					position += TRANSACTION_LOG_ENTRY_HEADER_SIZE;

--- a/src/transaction-log-reader.ts
+++ b/src/transaction-log-reader.ts
@@ -26,9 +26,7 @@ const RESYNC_MIN_FRAMES = 8;
  * for a torn tail, where nothing follows the break.
  *
  * The iterator is left positioned at `resyncPosition` (or at end-of-log when there is none), so a
- * caller that chooses to recover the entries past the break calls `next()` again — the throw is
- * the one notification per break, not a wall. A caller that treats a broken frame as terminal
- * simply stops, which is the behavior a plain `RangeError` already produced.
+ * caller that chooses to recover the entries past the break calls `next()` again.
  */
 export class CorruptFrameError extends RangeError {
 	/** Sequence number of the log file the break is in. */
@@ -62,13 +60,20 @@ export class CorruptFrameError extends RangeError {
 }
 
 /**
+ * How far past a break to look for a resume point. A partial append leaves one interrupted batch,
+ * so a real resume point is close; bounding the search keeps the cost predictable and keeps the
+ * number of candidate offsets — and so the odds of accepting a false one — small.
+ */
+const MAX_RESYNC_SCAN_BYTES = 1 << 20;
+
+/**
  * Whether a complete, in-bounds frame begins at `pos`. The only sane bound on an entry's length is
- * the readable extent: a single entry can legitimately exceed the rotation threshold (the first
+ * the written extent: a single entry can legitimately exceed the rotation threshold (the first
  * entry written to a fresh file is always written in full). A zero timestamp is the
  * end-of-entries marker, not a frame.
  */
-function frameFits(dataView: DataView, pos: number, limit: number): boolean {
-	if (pos + TRANSACTION_LOG_ENTRY_HEADER_SIZE > limit) {
+function frameFits(dataView: DataView, pos: number, dataEnd: number): boolean {
+	if (pos + TRANSACTION_LOG_ENTRY_HEADER_SIZE > dataEnd) {
 		return false;
 	}
 	if (dataView.getFloat64(pos) === 0) {
@@ -78,32 +83,56 @@ function frameFits(dataView: DataView, pos: number, limit: number): boolean {
 	if (length === 0) {
 		return false;
 	}
-	return pos + TRANSACTION_LOG_ENTRY_HEADER_SIZE + length <= limit;
+	return pos + TRANSACTION_LOG_ENTRY_HEADER_SIZE + length <= dataEnd;
 }
 
 /**
- * Finds the offset in `[from, limit)` where valid log framing resumes: either a run of at least
- * `RESYNC_MIN_FRAMES` well-formed frames, or any run that lands exactly on `limit`. Random bytes
- * aligning a length-chain exactly to the end is ~1/2^32, so even a short run that hits the end is
- * a reliable resume signal — and it is what lets fewer than `RESYNC_MIN_FRAMES` entries after a
- * break still be recovered. Returns `undefined` when nothing resumes (a torn tail).
+ * Finds the offset in `[from, dataEnd)` where valid log framing resumes: a run of at least
+ * `RESYNC_MIN_FRAMES` well-formed frames, or a run that lands exactly on `dataEnd`. Returns
+ * `undefined` when nothing resumes (a torn tail).
  *
- * Effectively linear: a non-resyncing offset fails after ~one frame check, and only a true resume
- * point walks a chain. This is the JS counterpart of `validFramingResumes()` in
- * `transaction_log_recovery.cpp`, which answers the same question at open time but keeps only the
- * yes/no, discarding the offset; it runs here only on a broken frame, never on a healthy read.
+ * `dataEnd` must be the **written extent**, not the mapped capacity. The log's memory map is
+ * pre-extended well past the data, and every offset inside that zero padding reads as an
+ * end-of-entries marker — so scanning against the map would both lose the exact-end signal (the
+ * chain can never land on a capacity that data does not reach) and, if a zero were accepted as a
+ * terminator, let a chain "end" anywhere in megabytes of padding. Against the written extent the
+ * end is a single offset, so a chain landing on it is ~1/2^32 to be coincidence.
+ *
+ * The JS counterpart of `validFramingResumes()` in `transaction_log_recovery.cpp`, which answers
+ * the same question at open time but keeps only the yes/no, discarding the offset.
  */
-function findResyncPosition(dataView: DataView, from: number, limit: number): number | undefined {
-	for (let start = from; start + TRANSACTION_LOG_ENTRY_HEADER_SIZE <= limit; start++) {
+function findResyncPosition(dataView: DataView, from: number, dataEnd: number): number | undefined {
+	const lastStart =
+		Math.min(dataEnd, from + MAX_RESYNC_SCAN_BYTES) - TRANSACTION_LOG_ENTRY_HEADER_SIZE;
+	for (let start = from; start <= lastStart; start++) {
 		let pos = start;
 		let frames = 0;
-		while (frameFits(dataView, pos, limit)) {
+		while (frameFits(dataView, pos, dataEnd)) {
 			pos += TRANSACTION_LOG_ENTRY_HEADER_SIZE + dataView.getUint32(pos + 8);
-			if (++frames >= RESYNC_MIN_FRAMES || pos === limit) {
+			if (++frames >= RESYNC_MIN_FRAMES || pos === dataEnd) {
 				return start;
 			}
 		}
 	}
+}
+
+/** Builds the report for a broken frame, with the offset iteration should continue from. */
+function corruptFrame(
+	message: string,
+	dataView: DataView,
+	logBuffer: LogBuffer,
+	position: number,
+	dataEnd: number,
+	size: number
+): { error: CorruptFrameError; nextPosition: number } {
+	const resyncPosition = findResyncPosition(dataView, position + 1, dataEnd);
+	return {
+		error: new CorruptFrameError(message, logBuffer.logId, position, resyncPosition),
+		// With no resume point iteration is over, so land past `size` as well as the readable end:
+		// a committed `size` that over-reports the mapped buffer would otherwise leave
+		// `position < size`, and the next call would re-enter the loop and read off the end.
+		nextPosition: resyncPosition ?? Math.max(dataEnd, size, position + 1),
+	};
 }
 
 /**
@@ -213,17 +242,6 @@ Object.defineProperty(TransactionLog.prototype, 'query', {
 			}
 		}
 
-		// Builds the error for a broken frame at `position` and advances `position` past the break
-		// first, so the throw reports the break without also sealing off what follows it. When
-		// framing resumes, `position` lands there; when nothing does (a torn tail), it lands at
-		// the readable end so a caller that retries gets `done` rather than the same throw again.
-		const corruptFrame = (message: string, limit: number) => {
-			const resyncPosition = findResyncPosition(dataView, position + 1, limit);
-			const error = new CorruptFrameError(message, logBuffer!.logId, position, resyncPosition);
-			position = resyncPosition ?? limit;
-			return error;
-		};
-
 		return {
 			[Symbol.iterator](): IterableIterator<TransactionEntry> {
 				return this;
@@ -288,30 +306,44 @@ Object.defineProperty(TransactionLog.prototype, 'query', {
 					// `position` runs past the buffer, `subarray` hands back a misframed
 					// (garbage) transaction, and the advance-to-next-log path can
 					// dereference an undefined buffer. Fail loudly with a bounded error.
-					//
-					// The throw also leaves `position` at the resume point (see corruptFrame), so
-					// the break stops this entry, not the rest of the log: a caller that wants the
-					// entries past a mid-log break calls next() again. Without that, a single
-					// broken frame amputates every later entry in the log permanently — the reader
-					// restarts from the same resume cursor on every drain and re-throws here
-					// (HarperFast/harper#2016, #2063).
+					// The throw leaves `position` at the resume point, so a broken frame ends the
+					// entry rather than the rest of the log (HarperFast/harper#2016, #2063).
 					const limit = readUncommitted ? logBuffer!.length : Math.min(size, logBuffer!.length);
+					// A resync scan must be bounded by written bytes. An uncommitted read is bounded
+					// by the mapped capacity, which runs far past the data, so ask the file for its
+					// extent instead; a committed read is already bounded at the watermark.
+					const writtenExtent = readUncommitted
+						? transactionLog.getLogFileSize(logBuffer!.logId)
+						: 0;
+					const dataEnd = writtenExtent > 0 ? Math.min(logBuffer!.length, writtenExtent) : limit;
 					if (position + TRANSACTION_LOG_ENTRY_HEADER_SIZE > limit) {
-						throw corruptFrame(
+						const broken = corruptFrame(
 							`Corrupt transaction log: truncated entry header at position ${position.toString(16)} of log ${
 								logBuffer!.logId
 							} (available=${limit - position})`,
-							limit
+							dataView,
+							logBuffer!,
+							position,
+							dataEnd,
+							size
 						);
+						position = broken.nextPosition;
+						throw broken.error;
 					}
 					const length = dataView.getUint32(position + 8);
 					if (position + TRANSACTION_LOG_ENTRY_HEADER_SIZE + length > limit) {
-						throw corruptFrame(
+						const broken = corruptFrame(
 							`Corrupt transaction log entry at position ${position.toString(16)} of log ${
 								logBuffer!.logId
 							}: declared length ${length} overruns the log (limit=${limit})`,
-							limit
+							dataView,
+							logBuffer!,
+							position,
+							dataEnd,
+							size
 						);
+						position = broken.nextPosition;
+						throw broken.error;
 					}
 					position += TRANSACTION_LOG_ENTRY_HEADER_SIZE;
 					let matchesRange: boolean;

--- a/test/transaction-log.test.ts
+++ b/test/transaction-log.test.ts
@@ -1,4 +1,4 @@
-import { RocksDatabase, Transaction } from '../src/index.js';
+import { CorruptFrameError, RocksDatabase, Transaction } from '../src/index.js';
 import {
 	constants,
 	coolTransactionLogs,
@@ -1511,6 +1511,127 @@ describe('Transaction Log', () => {
 				log._logBuffers.clear();
 				(log as { _currentLogBuffer?: unknown })._currentLogBuffer = undefined;
 				expect(Array.from(log.query({ start: 0 })).length).toBe(3);
+			}));
+
+		// Drives the iterator by hand so a throw doesn't end the walk: a caller that wants the
+		// entries past a break has to be able to keep going. Bounded so a reader that re-throws
+		// at the same position (the pre-resync behavior) fails the test instead of hanging.
+		function drainPastCorruption(iterable: Iterable<{ data: Buffer }>, maxSteps = 100) {
+			const iterator = iterable[Symbol.iterator]();
+			const entries: { data: Buffer }[] = [];
+			const errors: CorruptFrameError[] = [];
+			for (let step = 0; step < maxSteps; step++) {
+				try {
+					const { value, done } = iterator.next();
+					if (done) return { entries, errors };
+					entries.push(value);
+				} catch (error) {
+					errors.push(error as CorruptFrameError);
+				}
+			}
+			throw new Error(`iterator did not finish within ${maxSteps} steps`);
+		}
+
+		// A mid-log break — a partial append (ENOSPC/EDQUOT) that the process survived, so valid
+		// entries were appended after it. Those entries are intact and must stay reachable: the
+		// break costs the one broken frame, not the remainder of the log. Regression for
+		// HarperFast/harper#2016 and #2063, where a reader that stopped at the break re-read from
+		// the same resume cursor on every drain, so nothing after it was ever delivered again.
+		it('query() resyncs past a mid-log corrupt frame and still yields the entries after it', () =>
+			dbRunner(async ({ db }) => {
+				const log = db.useLog('foo');
+				const value = Buffer.alloc(10, 'a');
+				const entryStride = TRANSACTION_LOG_ENTRY_HEADER_SIZE + 10;
+				for (let i = 0; i < 12; i++) {
+					await db.transaction(async (txn) => {
+						log.addEntry(value, txn.id);
+					});
+				}
+				expect(Array.from(log.query({ start: 0 })).length).toBe(12);
+
+				// break the 2nd entry's length field; entries 3-12 stay well-formed behind it
+				const real = log._getMemoryMapOfFile(1)!;
+				const copyBuffer = Buffer.from(new ArrayBuffer(real.length));
+				real.copy(copyBuffer);
+				const secondEntryStart = TRANSACTION_LOG_FILE_HEADER_SIZE + entryStride;
+				copyBuffer.writeUInt32BE(0x7fffffff, secondEntryStart + 8);
+
+				log._logBuffers.clear();
+				(log as { _currentLogBuffer?: unknown })._currentLogBuffer = undefined;
+				const realDescriptor = Object.getOwnPropertyDescriptor(
+					Object.getPrototypeOf(log),
+					'_getMemoryMapOfFile'
+				)!;
+				Object.defineProperty(log, '_getMemoryMapOfFile', {
+					value: () => copyBuffer,
+					configurable: true,
+					writable: true,
+				});
+				try {
+					const { entries, errors } = drainPastCorruption(log.query({ start: 0 }));
+
+					// one report for the break, carrying where reading resumed and what was lost
+					expect(errors.length).toBe(1);
+					expect(errors[0]).toBeInstanceOf(CorruptFrameError);
+					expect(errors[0].logId).toBe(1);
+					expect(errors[0].position).toBe(secondEntryStart);
+					expect(errors[0].resyncPosition).toBe(secondEntryStart + entryStride);
+					expect(errors[0].unreadableBytes).toBe(entryStride);
+					expect(errors[0].message).toMatch(/valid framing resumes at/);
+
+					// entry 1 before the break, entries 3-12 after it: only the broken frame is lost
+					expect(entries.length).toBe(11);
+					for (const entry of entries) {
+						expect(entry.data.length).toBe(10);
+					}
+				} finally {
+					Object.defineProperty(log, '_getMemoryMapOfFile', realDescriptor);
+				}
+			}));
+
+		// A torn tail has nothing valid behind it, so there is nothing to resync to. The reader
+		// must still not re-throw at the same position forever: it reports once and then reads as
+		// end-of-log, which is what open-time recovery would have truncated to anyway.
+		it('query() reports a torn tail once and then reads as end-of-log', () =>
+			dbRunner(async ({ db }) => {
+				const log = db.useLog('foo');
+				const value = Buffer.alloc(10, 'a');
+				for (let i = 0; i < 3; i++) {
+					await db.transaction(async (txn) => {
+						log.addEntry(value, txn.id);
+					});
+				}
+				expect(Array.from(log.query({ start: 0 })).length).toBe(3);
+
+				// break the final entry's length; only zero padding follows it
+				const real = log._getMemoryMapOfFile(1)!;
+				const copyBuffer = Buffer.from(new ArrayBuffer(real.length));
+				real.copy(copyBuffer);
+				const thirdEntryStart =
+					TRANSACTION_LOG_FILE_HEADER_SIZE + 2 * (TRANSACTION_LOG_ENTRY_HEADER_SIZE + 10);
+				copyBuffer.writeUInt32BE(0x7fffffff, thirdEntryStart + 8);
+
+				log._logBuffers.clear();
+				(log as { _currentLogBuffer?: unknown })._currentLogBuffer = undefined;
+				const realDescriptor = Object.getOwnPropertyDescriptor(
+					Object.getPrototypeOf(log),
+					'_getMemoryMapOfFile'
+				)!;
+				Object.defineProperty(log, '_getMemoryMapOfFile', {
+					value: () => copyBuffer,
+					configurable: true,
+					writable: true,
+				});
+				try {
+					const { entries, errors } = drainPastCorruption(log.query({ start: 0 }));
+					expect(errors.length).toBe(1);
+					expect(errors[0].resyncPosition).toBeUndefined();
+					expect(errors[0].unreadableBytes).toBe(0);
+					expect(errors[0].message).not.toMatch(/valid framing resumes at/);
+					expect(entries.length).toBe(2);
+				} finally {
+					Object.defineProperty(log, '_getMemoryMapOfFile', realDescriptor);
+				}
 			}));
 	});
 

--- a/test/transaction-log.test.ts
+++ b/test/transaction-log.test.ts
@@ -1366,6 +1366,25 @@ describe('Transaction Log', () => {
 			}));
 	});
 
+	// Drives the iterator by hand so a throw doesn't end the walk: a caller that wants the entries
+	// past a break has to be able to keep going. Bounded so a reader that re-throws at the same
+	// position (the pre-resync behavior) fails the test instead of hanging.
+	function drainPastCorruption(iterable: Iterable<any>, maxSteps = 100) {
+		const iterator = iterable[Symbol.iterator]();
+		const entries: any[] = [];
+		const errors: any[] = [];
+		for (let step = 0; step < maxSteps; step++) {
+			try {
+				const { value, done } = iterator.next();
+				if (done) return { entries, errors };
+				entries.push(value);
+			} catch (error) {
+				errors.push(error);
+			}
+		}
+		throw new Error(`iterator did not finish within ${maxSteps} steps`);
+	}
+
 	describe('corruption handling', () => {
 		// A torn/corrupt entry can declare a length far larger than the bytes
 		// actually present (e.g. a partial write that left a header pointing past
@@ -1513,30 +1532,9 @@ describe('Transaction Log', () => {
 				expect(Array.from(log.query({ start: 0 })).length).toBe(3);
 			}));
 
-		// Drives the iterator by hand so a throw doesn't end the walk: a caller that wants the
-		// entries past a break has to be able to keep going. Bounded so a reader that re-throws
-		// at the same position (the pre-resync behavior) fails the test instead of hanging.
-		function drainPastCorruption(iterable: Iterable<{ data: Buffer }>, maxSteps = 100) {
-			const iterator = iterable[Symbol.iterator]();
-			const entries: { data: Buffer }[] = [];
-			const errors: CorruptFrameError[] = [];
-			for (let step = 0; step < maxSteps; step++) {
-				try {
-					const { value, done } = iterator.next();
-					if (done) return { entries, errors };
-					entries.push(value);
-				} catch (error) {
-					errors.push(error as CorruptFrameError);
-				}
-			}
-			throw new Error(`iterator did not finish within ${maxSteps} steps`);
-		}
-
-		// A mid-log break — a partial append (ENOSPC/EDQUOT) that the process survived, so valid
-		// entries were appended after it. Those entries are intact and must stay reachable: the
-		// break costs the one broken frame, not the remainder of the log. Regression for
-		// HarperFast/harper#2016 and #2063, where a reader that stopped at the break re-read from
-		// the same resume cursor on every drain, so nothing after it was ever delivered again.
+		// A mid-log break — a partial append the process survived, so valid entries were appended
+		// after it. Those stay reachable: the break costs one frame, not the rest of the log
+		// (HarperFast/harper#2016, #2063).
 		it('query() resyncs past a mid-log corrupt frame and still yields the entries after it', () =>
 			dbRunner(async ({ db }) => {
 				const log = db.useLog('foo');
@@ -1589,9 +1587,8 @@ describe('Transaction Log', () => {
 				}
 			}));
 
-		// A torn tail has nothing valid behind it, so there is nothing to resync to. The reader
-		// must still not re-throw at the same position forever: it reports once and then reads as
-		// end-of-log, which is what open-time recovery would have truncated to anyway.
+		// Nothing valid follows a torn tail, so there is nothing to resync to — but the reader must
+		// still not re-throw at the same position forever.
 		it('query() reports a torn tail once and then reads as end-of-log', () =>
 			dbRunner(async ({ db }) => {
 				const log = db.useLog('foo');
@@ -1629,6 +1626,126 @@ describe('Transaction Log', () => {
 					expect(errors[0].unreadableBytes).toBe(0);
 					expect(errors[0].message).not.toMatch(/valid framing resumes at/);
 					expect(entries.length).toBe(2);
+				} finally {
+					Object.defineProperty(log, '_getMemoryMapOfFile', realDescriptor);
+				}
+			}));
+	});
+
+	// The edges the synthetic mid-log case doesn't reach: a run shorter than RESYNC_MIN_FRAMES
+	// (recovered only by landing exactly on the written extent), and the readUncommitted bound —
+	// the boot-replay path, where the read limit is the pre-extended mmap and scanning against it
+	// would find no resume point at all.
+	describe('corrupt-frame resync bounds', () => {
+		async function logWithBrokenSecondEntry(db: RocksDatabase, entryCount: number) {
+			const log = db.useLog('foo');
+			const value = Buffer.alloc(10, 'a');
+			const entryStride = TRANSACTION_LOG_ENTRY_HEADER_SIZE + 10;
+			for (let i = 0; i < entryCount; i++) {
+				await db.transaction(async (txn) => {
+					log.addEntry(value, txn.id);
+				});
+			}
+			// prime the query path so _lastCommittedPosition / _logBuffers init
+			expect(Array.from(log.query({ start: 0 })).length).toBe(entryCount);
+
+			const real = log._getMemoryMapOfFile(1)!;
+			// mimic the mapped buffer: real data followed by pre-extended zero fill
+			const copyBuffer = Buffer.from(new ArrayBuffer(real.length + 4096));
+			real.copy(copyBuffer);
+			const secondEntryStart = TRANSACTION_LOG_FILE_HEADER_SIZE + entryStride;
+			copyBuffer.writeUInt32BE(0x7fffffff, secondEntryStart + 8);
+
+			log._logBuffers.clear();
+			(log as { _currentLogBuffer?: unknown })._currentLogBuffer = undefined;
+			const realDescriptor = Object.getOwnPropertyDescriptor(
+				Object.getPrototypeOf(log),
+				'_getMemoryMapOfFile'
+			)!;
+			Object.defineProperty(log, '_getMemoryMapOfFile', {
+				value: () => copyBuffer,
+				configurable: true,
+				writable: true,
+			});
+			return {
+				log,
+				secondEntryStart,
+				entryStride,
+				restore: () => Object.defineProperty(log, '_getMemoryMapOfFile', realDescriptor),
+			};
+		}
+
+		it('resyncs a run shorter than the minimum frame count by landing on the written extent', () =>
+			dbRunner(async ({ db }) => {
+				// 4 entries: only 2 valid frames follow the break, far below RESYNC_MIN_FRAMES
+				const { log, secondEntryStart, entryStride, restore } = await logWithBrokenSecondEntry(
+					db,
+					4
+				);
+				try {
+					const { entries, errors } = drainPastCorruption(log.query({ start: 0 }));
+					expect(errors.length).toBe(1);
+					expect(errors[0].resyncPosition).toBe(secondEntryStart + entryStride);
+					expect(entries.length).toBe(3);
+				} finally {
+					restore();
+				}
+			}));
+
+		it('resyncs on the readUncommitted path, whose read limit is the pre-extended map', () =>
+			dbRunner(async ({ db }) => {
+				const { log, secondEntryStart, entryStride, restore } = await logWithBrokenSecondEntry(
+					db,
+					4
+				);
+				try {
+					const { entries, errors } = drainPastCorruption(
+						log.query({ start: 0, readUncommitted: true })
+					);
+					expect(errors.length).toBe(1);
+					expect(errors[0].resyncPosition).toBe(secondEntryStart + entryStride);
+					expect(entries.length).toBe(3);
+				} finally {
+					restore();
+				}
+			}));
+
+		// A committed size that over-reports the mapped buffer must still terminate: leaving
+		// position < size would re-enter the read loop and throw off the end of the buffer forever.
+		it('terminates a torn tail even when committed size over-reports the buffer', () =>
+			dbRunner(async ({ db }) => {
+				const log = db.useLog('foo');
+				const value = Buffer.alloc(10, 'a');
+				for (let i = 0; i < 3; i++) {
+					await db.transaction(async (txn) => {
+						log.addEntry(value, txn.id);
+					});
+				}
+				expect(Array.from(log.query({ start: 0 })).length).toBe(3);
+
+				const committedWord = new Uint32Array(
+					new Float64Array([log._lastCommittedPosition![0]]).buffer
+				);
+				const real = log._getMemoryMapOfFile(1)!;
+				const truncatedLength = committedWord[0] - 5;
+				const copyBuffer = Buffer.from(new ArrayBuffer(truncatedLength));
+				real.copy(copyBuffer, 0, 0, truncatedLength);
+
+				log._logBuffers.clear();
+				(log as { _currentLogBuffer?: unknown })._currentLogBuffer = undefined;
+				const realDescriptor = Object.getOwnPropertyDescriptor(
+					Object.getPrototypeOf(log),
+					'_getMemoryMapOfFile'
+				)!;
+				Object.defineProperty(log, '_getMemoryMapOfFile', {
+					value: () => copyBuffer,
+					configurable: true,
+					writable: true,
+				});
+				try {
+					const { errors } = drainPastCorruption(log.query({ start: 0 }));
+					expect(errors.length).toBeGreaterThanOrEqual(1);
+					expect(errors[0].resyncPosition).toBeUndefined();
 				} finally {
 					Object.defineProperty(log, '_getMemoryMapOfFile', realDescriptor);
 				}

--- a/test/transaction-log.test.ts
+++ b/test/transaction-log.test.ts
@@ -1587,6 +1587,48 @@ describe('Transaction Log', () => {
 				}
 			}));
 
+		it('query() resyncs past a zero-length frame and still yields the entries after it', () =>
+			dbRunner(async ({ db }) => {
+				const log = db.useLog('foo');
+				const value = Buffer.alloc(10, 'a');
+				const entryStride = TRANSACTION_LOG_ENTRY_HEADER_SIZE + 10;
+				for (let i = 0; i < 12; i++) {
+					await db.transaction(async (txn) => {
+						log.addEntry(value, txn.id);
+					});
+				}
+				expect(Array.from(log.query({ start: 0 })).length).toBe(12);
+
+				// A zero-length frame is invalid, not an empty transaction. Entries after it remain
+				// readable once the caller resumes the iterator after the corruption report.
+				const real = log._getMemoryMapOfFile(1)!;
+				const copyBuffer = Buffer.from(new ArrayBuffer(real.length));
+				real.copy(copyBuffer);
+				const secondEntryStart = TRANSACTION_LOG_FILE_HEADER_SIZE + entryStride;
+				copyBuffer.writeUInt32BE(0, secondEntryStart + 8);
+
+				log._logBuffers.clear();
+				(log as { _currentLogBuffer?: unknown })._currentLogBuffer = undefined;
+				const realDescriptor = Object.getOwnPropertyDescriptor(
+					Object.getPrototypeOf(log),
+					'_getMemoryMapOfFile'
+				)!;
+				Object.defineProperty(log, '_getMemoryMapOfFile', {
+					value: () => copyBuffer,
+					configurable: true,
+					writable: true,
+				});
+				try {
+					const { entries, errors } = drainPastCorruption(log.query({ start: 0 }));
+					expect(errors).toHaveLength(1);
+					expect(errors[0]).toBeInstanceOf(CorruptFrameError);
+					expect(errors[0].resyncPosition).toBe(secondEntryStart + entryStride);
+					expect(entries).toHaveLength(11);
+				} finally {
+					Object.defineProperty(log, '_getMemoryMapOfFile', realDescriptor);
+				}
+			}));
+
 		// Nothing valid follows a torn tail, so there is nothing to resync to — but the reader must
 		// still not re-throw at the same position forever.
 		it('query() reports a torn tail once and then reads as end-of-log', () =>

--- a/test/transaction-log.test.ts
+++ b/test/transaction-log.test.ts
@@ -1458,10 +1458,6 @@ describe('Transaction Log', () => {
 
 				log._logBuffers.clear();
 				(log as { _currentLogBuffer?: unknown })._currentLogBuffer = undefined;
-				const realDescriptor = Object.getOwnPropertyDescriptor(
-					Object.getPrototypeOf(log),
-					'_getMemoryMapOfFile'
-				)!;
 				Object.defineProperty(log, '_getMemoryMapOfFile', {
 					value: () => copyBuffer,
 					configurable: true,
@@ -1472,7 +1468,7 @@ describe('Transaction Log', () => {
 						/Corrupt transaction log entry/
 					);
 				} finally {
-					Object.defineProperty(log, '_getMemoryMapOfFile', realDescriptor);
+					delete (log as { _getMemoryMapOfFile?: unknown })._getMemoryMapOfFile;
 				}
 				// once the real mmap is restored, the valid data must still be readable
 				log._logBuffers.clear();
@@ -1512,10 +1508,6 @@ describe('Transaction Log', () => {
 
 				log._logBuffers.clear();
 				(log as { _currentLogBuffer?: unknown })._currentLogBuffer = undefined;
-				const realDescriptor = Object.getOwnPropertyDescriptor(
-					Object.getPrototypeOf(log),
-					'_getMemoryMapOfFile'
-				)!;
 				Object.defineProperty(log, '_getMemoryMapOfFile', {
 					value: () => copyBuffer,
 					configurable: true,
@@ -1524,7 +1516,7 @@ describe('Transaction Log', () => {
 				try {
 					expect(() => Array.from(log.query({ start: 0 }))).toThrow(/overruns the log/);
 				} finally {
-					Object.defineProperty(log, '_getMemoryMapOfFile', realDescriptor);
+					delete (log as { _getMemoryMapOfFile?: unknown })._getMemoryMapOfFile;
 				}
 				// once the real mmap is restored, the valid data must still be readable
 				log._logBuffers.clear();
@@ -1556,10 +1548,6 @@ describe('Transaction Log', () => {
 
 				log._logBuffers.clear();
 				(log as { _currentLogBuffer?: unknown })._currentLogBuffer = undefined;
-				const realDescriptor = Object.getOwnPropertyDescriptor(
-					Object.getPrototypeOf(log),
-					'_getMemoryMapOfFile'
-				)!;
 				Object.defineProperty(log, '_getMemoryMapOfFile', {
 					value: () => copyBuffer,
 					configurable: true,
@@ -1583,7 +1571,7 @@ describe('Transaction Log', () => {
 						expect(entry.data.length).toBe(10);
 					}
 				} finally {
-					Object.defineProperty(log, '_getMemoryMapOfFile', realDescriptor);
+					delete (log as { _getMemoryMapOfFile?: unknown })._getMemoryMapOfFile;
 				}
 			}));
 
@@ -1609,10 +1597,6 @@ describe('Transaction Log', () => {
 
 				log._logBuffers.clear();
 				(log as { _currentLogBuffer?: unknown })._currentLogBuffer = undefined;
-				const realDescriptor = Object.getOwnPropertyDescriptor(
-					Object.getPrototypeOf(log),
-					'_getMemoryMapOfFile'
-				)!;
 				Object.defineProperty(log, '_getMemoryMapOfFile', {
 					value: () => copyBuffer,
 					configurable: true,
@@ -1625,7 +1609,90 @@ describe('Transaction Log', () => {
 					expect(errors[0].resyncPosition).toBe(secondEntryStart + entryStride);
 					expect(entries).toHaveLength(11);
 				} finally {
-					Object.defineProperty(log, '_getMemoryMapOfFile', realDescriptor);
+					delete (log as { _getMemoryMapOfFile?: unknown })._getMemoryMapOfFile;
+				}
+			}));
+
+		it('query() reports each separated corrupt region and resumes after both', () =>
+			dbRunner(async ({ db }) => {
+				const log = db.useLog('foo');
+				const value = Buffer.alloc(10, 'a');
+				const entryStride = TRANSACTION_LOG_ENTRY_HEADER_SIZE + 10;
+				for (let i = 0; i < 22; i++) {
+					await db.transaction(async (txn) => {
+						log.addEntry(value, txn.id);
+					});
+				}
+				expect(Array.from(log.query({ start: 0 })).length).toBe(22);
+
+				const real = log._getMemoryMapOfFile(1)!;
+				const copyBuffer = Buffer.from(new ArrayBuffer(real.length));
+				real.copy(copyBuffer);
+				const firstBrokenEntryStart = TRANSACTION_LOG_FILE_HEADER_SIZE + entryStride;
+				const secondBrokenEntryStart = TRANSACTION_LOG_FILE_HEADER_SIZE + 11 * entryStride;
+				copyBuffer.writeUInt32BE(0x7fffffff, firstBrokenEntryStart + 8);
+				copyBuffer.writeUInt32BE(0x7fffffff, secondBrokenEntryStart + 8);
+
+				log._logBuffers.clear();
+				(log as { _currentLogBuffer?: unknown })._currentLogBuffer = undefined;
+				Object.defineProperty(log, '_getMemoryMapOfFile', {
+					value: () => copyBuffer,
+					configurable: true,
+					writable: true,
+				});
+				try {
+					const { entries, errors } = drainPastCorruption(log.query({ start: 0 }));
+					expect(errors).toHaveLength(2);
+					expect(errors[0].position).toBe(firstBrokenEntryStart);
+					expect(errors[0].resyncPosition).toBe(firstBrokenEntryStart + entryStride);
+					expect(errors[1].position).toBe(secondBrokenEntryStart);
+					expect(errors[1].resyncPosition).toBe(secondBrokenEntryStart + entryStride);
+					expect(entries).toHaveLength(20);
+				} finally {
+					delete (log as { _getMemoryMapOfFile?: unknown })._getMemoryMapOfFile;
+				}
+			}));
+
+		it('query() ignores a single deceptive frame in the corrupt span', () =>
+			dbRunner(async ({ db }) => {
+				const log = db.useLog('foo');
+				const value = Buffer.alloc(10, 'a');
+				const entryStride = TRANSACTION_LOG_ENTRY_HEADER_SIZE + 10;
+				for (let i = 0; i < 12; i++) {
+					await db.transaction(async (txn) => {
+						log.addEntry(value, txn.id);
+					});
+				}
+				expect(Array.from(log.query({ start: 0 })).length).toBe(12);
+
+				const real = log._getMemoryMapOfFile(1)!;
+				const copyBuffer = Buffer.from(new ArrayBuffer(real.length));
+				real.copy(copyBuffer);
+				const secondEntryStart = TRANSACTION_LOG_FILE_HEADER_SIZE + entryStride;
+				const deceptiveFrameStart = secondEntryStart + TRANSACTION_LOG_ENTRY_HEADER_SIZE;
+				copyBuffer.writeUInt32BE(0x7fffffff, secondEntryStart + 8);
+				copyBuffer.writeDoubleBE(1, deceptiveFrameStart);
+				copyBuffer.writeUInt32BE(1, deceptiveFrameStart + 8);
+				copyBuffer.fill(
+					0,
+					deceptiveFrameStart + TRANSACTION_LOG_ENTRY_HEADER_SIZE + 1,
+					deceptiveFrameStart + 2 * TRANSACTION_LOG_ENTRY_HEADER_SIZE + 1
+				);
+
+				log._logBuffers.clear();
+				(log as { _currentLogBuffer?: unknown })._currentLogBuffer = undefined;
+				Object.defineProperty(log, '_getMemoryMapOfFile', {
+					value: () => copyBuffer,
+					configurable: true,
+					writable: true,
+				});
+				try {
+					const { entries, errors } = drainPastCorruption(log.query({ start: 0 }));
+					expect(errors).toHaveLength(1);
+					expect(errors[0].resyncPosition).toBe(secondEntryStart + 2 * entryStride);
+					expect(entries).toHaveLength(10);
+				} finally {
+					delete (log as { _getMemoryMapOfFile?: unknown })._getMemoryMapOfFile;
 				}
 			}));
 
@@ -1652,10 +1719,6 @@ describe('Transaction Log', () => {
 
 				log._logBuffers.clear();
 				(log as { _currentLogBuffer?: unknown })._currentLogBuffer = undefined;
-				const realDescriptor = Object.getOwnPropertyDescriptor(
-					Object.getPrototypeOf(log),
-					'_getMemoryMapOfFile'
-				)!;
 				Object.defineProperty(log, '_getMemoryMapOfFile', {
 					value: () => copyBuffer,
 					configurable: true,
@@ -1669,7 +1732,7 @@ describe('Transaction Log', () => {
 					expect(errors[0].message).not.toMatch(/valid framing resumes at/);
 					expect(entries.length).toBe(2);
 				} finally {
-					Object.defineProperty(log, '_getMemoryMapOfFile', realDescriptor);
+					delete (log as { _getMemoryMapOfFile?: unknown })._getMemoryMapOfFile;
 				}
 			}));
 	});
@@ -1700,10 +1763,6 @@ describe('Transaction Log', () => {
 
 			log._logBuffers.clear();
 			(log as { _currentLogBuffer?: unknown })._currentLogBuffer = undefined;
-			const realDescriptor = Object.getOwnPropertyDescriptor(
-				Object.getPrototypeOf(log),
-				'_getMemoryMapOfFile'
-			)!;
 			Object.defineProperty(log, '_getMemoryMapOfFile', {
 				value: () => copyBuffer,
 				configurable: true,
@@ -1713,7 +1772,7 @@ describe('Transaction Log', () => {
 				log,
 				secondEntryStart,
 				entryStride,
-				restore: () => Object.defineProperty(log, '_getMemoryMapOfFile', realDescriptor),
+				restore: () => delete (log as { _getMemoryMapOfFile?: unknown })._getMemoryMapOfFile,
 			};
 		}
 
@@ -1775,10 +1834,6 @@ describe('Transaction Log', () => {
 
 				log._logBuffers.clear();
 				(log as { _currentLogBuffer?: unknown })._currentLogBuffer = undefined;
-				const realDescriptor = Object.getOwnPropertyDescriptor(
-					Object.getPrototypeOf(log),
-					'_getMemoryMapOfFile'
-				)!;
 				Object.defineProperty(log, '_getMemoryMapOfFile', {
 					value: () => copyBuffer,
 					configurable: true,
@@ -1789,7 +1844,7 @@ describe('Transaction Log', () => {
 					expect(errors.length).toBeGreaterThanOrEqual(1);
 					expect(errors[0].resyncPosition).toBeUndefined();
 				} finally {
-					Object.defineProperty(log, '_getMemoryMapOfFile', realDescriptor);
+					delete (log as { _getMemoryMapOfFile?: unknown })._getMemoryMapOfFile;
 				}
 			}));
 	});

--- a/test/transaction-log.test.ts
+++ b/test/transaction-log.test.ts
@@ -1656,8 +1656,8 @@ describe('Transaction Log', () => {
 		it('query() ignores a single deceptive frame in the corrupt span', () =>
 			dbRunner(async ({ db }) => {
 				const log = db.useLog('foo');
-				const value = Buffer.alloc(10, 'a');
-				const entryStride = TRANSACTION_LOG_ENTRY_HEADER_SIZE + 10;
+				const value = Buffer.alloc(64, 'a');
+				const entryStride = TRANSACTION_LOG_ENTRY_HEADER_SIZE + value.length;
 				for (let i = 0; i < 12; i++) {
 					await db.transaction(async (txn) => {
 						log.addEntry(value, txn.id);
@@ -1689,10 +1689,61 @@ describe('Transaction Log', () => {
 				try {
 					const { entries, errors } = drainPastCorruption(log.query({ start: 0 }));
 					expect(errors).toHaveLength(1);
-					expect(errors[0].resyncPosition).toBe(secondEntryStart + 2 * entryStride);
-					expect(entries).toHaveLength(10);
+					expect(errors[0].resyncPosition).toBe(secondEntryStart + entryStride);
+					expect(entries).toHaveLength(11);
 				} finally {
 					delete (log as { _getMemoryMapOfFile?: unknown })._getMemoryMapOfFile;
+				}
+			}));
+
+		it('query() reports corruption without scanning when the written extent cannot be read', () =>
+			dbRunner(async ({ db }) => {
+				const log = db.useLog('foo');
+				const value = Buffer.alloc(10, 'a');
+				const entryStride = TRANSACTION_LOG_ENTRY_HEADER_SIZE + value.length;
+				for (let i = 0; i < 4; i++) {
+					await db.transaction(async (txn) => {
+						log.addEntry(value, txn.id);
+					});
+				}
+				expect(Array.from(log.query({ start: 0 })).length).toBe(4);
+
+				const real = log._getMemoryMapOfFile(1)!;
+				const copyBuffer = Buffer.from(new ArrayBuffer(real.length));
+				real.copy(copyBuffer);
+				const secondEntryStart = TRANSACTION_LOG_FILE_HEADER_SIZE + entryStride;
+				copyBuffer.writeUInt32BE(0x7fffffff, secondEntryStart + 8);
+
+				log._logBuffers.clear();
+				(log as { _currentLogBuffer?: unknown })._currentLogBuffer = undefined;
+				Object.defineProperty(log, '_getMemoryMapOfFile', {
+					value: () => copyBuffer,
+					configurable: true,
+					writable: true,
+				});
+				const iterator = log.query({ start: 0, readUncommitted: true });
+				expect(iterator.next().done).toBe(false);
+				Object.defineProperty(log, 'getLogFileSize', {
+					value: () => {
+						throw new Error('unavailable');
+					},
+					configurable: true,
+					writable: true,
+				});
+				try {
+					let error: unknown;
+					try {
+						iterator.next();
+					} catch (caught) {
+						error = caught;
+					}
+					expect(error).toBeInstanceOf(CorruptFrameError);
+					expect((error as CorruptFrameError).resyncPosition).toBeUndefined();
+					delete (log as { getLogFileSize?: unknown }).getLogFileSize;
+					expect(iterator.next().done).toBe(true);
+				} finally {
+					delete (log as { _getMemoryMapOfFile?: unknown })._getMemoryMapOfFile;
+					delete (log as { getLogFileSize?: unknown }).getLogFileSize;
 				}
 			}));
 

--- a/test/verification-table.test.ts
+++ b/test/verification-table.test.ts
@@ -470,7 +470,7 @@ describe('Verification Table', () => {
 					db.close();
 				}
 			}
-		});
+		}, 60_000);
 
 		it('a transactional point-get after write/flush/close/reopen returns the persisted value and agrees with range/raw', async () => {
 			const path = generateDBPath();


### PR DESCRIPTION
Reader half of [HarperFast/harper#2016 — Mid-log corrupt transaction-log frame silently truncates replay and replication — acknowledged writes lost](https://github.com/HarperFast/harper/issues/2016) and [HarperFast/harper#2063 — Corrupt-log containment in RocksTransactionLogStore.getRange is per-drain, so one bad entry head-of-line-blocks a replication stream forever](https://github.com/HarperFast/harper/issues/2063). The consumer change is [harper#2087](https://github.com/HarperFast/harper/pull/2087).

## The defect

A framing break has two shapes and the reader treated them as one.

A **torn tail** really is end-of-log — `recoverTail()` truncates it at open. A **mid-log break** is not: a partial append (`ENOSPC`/`EDQUOT`) that the process survives leaves intact, already-acknowledged entries after it. `recoverTail()` deliberately leaves that file alone rather than discard them, and only ever scans the active file on the assumption that "rotated files are immutable and already complete" — an assumption this case violates, because the process keeps writing and the file later rotates. So the reader is the only thing standing between those entries and a consumer.

It threw and left `position` at the bad entry. Every later entry in the file was therefore unreachable, permanently: a consumer restarts from the same resume cursor on the next drain and re-throws at the same offset. #2016 rolled a table back 2.2 days on a crash-recovery replay; #2063 starved a replication stream for 11 days, clearing only when the log aged out of retention.

## The fix

`query()` reports a break as `CorruptFrameError` carrying `resyncPosition` — where valid framing resumes — plus the unreadable byte count, and advances `position` there *before* throwing. One loud report per break, and a caller that wants the entries past it calls `next()` again. A caller that treats the error as terminal behaves exactly as before.

The resume point uses the same heuristic as `validFramingResumes()` in the recovery scan, which already computes this answer at open time and keeps only the yes/no. With no resume point (a torn tail) `position` lands past both the readable end and `size`, so a retrying caller gets `done` rather than the same throw again.

**The scan is bounded by the written extent, not the read limit.** This is the load-bearing detail. An uncommitted read's limit is the pre-extended memory map, and every offset in that zero fill reads as an end-of-entries marker — so scanning against it loses the exact-end signal entirely, leaving only the eight-frame rule. A mid-log break followed by 1–7 entries would then be unrecoverable on exactly the boot-replay path (`replayLogs.ts` reads `readUncommitted`) that lost 2.2 days in #2016. `getLogFileSize()` returns the append-owned `TransactionLogFile::size` (invariant 5), not the physical or mapped size, so the end is a single offset on every platform including Windows, and a chain landing on it keeps the ~1/2³² argument. It is resolved only on a break — it crosses into native and takes the store mutex, so a per-frame call would tax every healthy read.

## Tests

`test/transaction-log.test.ts`, 69 passing. A 12-entry log with a broken second frame now yields **11 entries where the old reader delivered 1**. Plus the edges: a sub-eight-frame run recovered via the written extent, the same under `readUncommitted` against a zero-padded map, and a torn tail terminating when committed `size` over-reports the buffer.

## Worth a reviewer's attention

**The unbounded scan is a deliberate, contested call.** Round 2 of review asked for a 1 MiB cap to be removed (entries can legitimately be large, and a partial frame wider than the cap puts every entry behind it out of reach — the amputation this exists to prevent, reintroduced at a threshold). Round 3 then flagged that removing it raises the false-resync probability to roughly N/2³² over the scan span, and that a byte-by-byte scan over a large log is a one-off event-loop stall. Both directions are right; I landed on matching `validFramingResumes()`, whose identical exposure was adjudicated acceptable in round 1 because a false resume yields at most one garbage frame that re-fails framing, not silent acceptance of bad data. Worth a second opinion — this is the one place I'd expect a reviewer to disagree.

**Detection on the uncommitted path is still bounded by mapped capacity**, so a torn frame whose declared length lands under that capacity is not detected at all, and resync cannot run for it. Pre-existing, not introduced here, and deliberately left out of scope because tightening it means changing uncommitted-read semantics and risks reporting concurrently-appended entries as corrupt. Filed as #749 with a suggested approach. Note this affects the *boot-replay* path; replication broadcast uses committed reads, where the bound is already the watermark.

**No end-to-end proof.** Every test drives synthetic or mmap-substituted buffers. Nothing reopens a genuinely damaged log on disk and watches a real consumer replicate past the break — that lives in harper-pro and is not written. Whether #2016/#2063 are actually closed rests on the consumer change in harper#2087.

**This does not stop corrupt frames being created.** The write-side producer — a failed append orphaning its partial bytes, which `O_APPEND` then writes past — is #748.

---

Cross-model review: 3 rounds, codex + gemini + harper-domain each round. Round 1 caught that the scan was bounded by the read limit, which would have left the fix half-working on the boot-replay path. Round 2 caught that the resulting `getLogFileSize` call sat inside the read loop — a per-frame native call taking the store mutex. Both fixed here. Unresolved items are the three above. Round 3's remaining findings were repeats of already-adjudicated items, except the cap trade-off noted above.


Generated with Claude Opus 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<sub>Human-Review-Need: 4 @ f8457ea7ad79</sub>
