### PR TITLE
Fix permanent write stall when the derived memtable-history target exceeds the WriteBufferManager budget

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -320,6 +320,17 @@ sufficient (env teardown does not honor tsfn acquire counts); see
    inspect a concurrently closing `DBHandle` from the worker. Transactional count iterators must also
    pass the transaction snapshot through `ReadOptions`; `disableSnapshot` intentionally leaves it null
    so counts observe the latest committed state.
+10. **Retained memtable history must fit the WriteBufferManager budget**: `max_write_buffer_size_to_maintain`
+   is a floor, not a cap — RocksDB trims history back down to it and never below — and that memory is
+   charged to the process-wide WriteBufferManager. A target above the manager's budget therefore fills
+   the budget with memory that is never released, and a manager built with `allowStall` stalls every
+   write to that database permanently rather than until a flush catches up. `buildColumnFamilyOptions`
+   resolves the derived (`-1`) default to 0 whenever a stalling manager is configured for exactly this
+   reason (`resolveMaxWriteBufferSizeToMaintain`); an explicit caller value is honored as given, and
+   sizing it against the budget and the column-family count is then the caller's job. The general trap:
+   `DBOptions` defaults that derive a large value were sized when they reached one column family, so
+   widening where an option applies means re-checking its default against every shared budget it
+   competes for.
 
 ## Debugging native heap corruption
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -321,16 +321,16 @@ sufficient (env teardown does not honor tsfn acquire counts); see
    pass the transaction snapshot through `ReadOptions`; `disableSnapshot` intentionally leaves it null
    so counts observe the latest committed state.
 10. **Retained memtable history must fit the WriteBufferManager budget**: `max_write_buffer_size_to_maintain`
-   is a floor, not a cap — RocksDB trims history back down to it and never below — and that memory is
-   charged to the process-wide WriteBufferManager. A target above the manager's budget therefore fills
-   the budget with memory that is never released, and a manager built with `allowStall` stalls every
-   write to that database permanently rather than until a flush catches up. `buildColumnFamilyOptions`
-   resolves the derived (`-1`) default to 0 whenever a stalling manager is configured for exactly this
-   reason (`resolveMaxWriteBufferSizeToMaintain`); an explicit caller value is honored as given, and
-   sizing it against the budget and the column-family count is then the caller's job. The general trap:
-   `DBOptions` defaults that derive a large value were sized when they reached one column family, so
-   widening where an option applies means re-checking its default against every shared budget it
-   competes for.
+    is a floor, not a cap — RocksDB trims history back down to it and never below — and that memory is
+    charged to the process-wide WriteBufferManager. A target above the manager's budget therefore fills
+    the budget with memory that is never released, and a manager built with `allowStall` stalls every
+    write to that database permanently rather than until a flush catches up. `buildColumnFamilyOptions`
+    resolves the derived (`-1`) default to 0 whenever a stalling manager is configured for exactly this
+    reason (`resolveMaxWriteBufferSizeToMaintain`); an explicit caller value is honored as given, and
+    sizing it against the budget and the column-family count is then the caller's job. The general trap:
+    `DBOptions` defaults that derive a large value were sized when they reached one column family, so
+    widening where an option applies means re-checking its default against every shared budget it
+    competes for.
 
 ## Debugging native heap corruption
 

--- a/src/binding/database/db_descriptor.cpp
+++ b/src/binding/database/db_descriptor.cpp
@@ -70,6 +70,13 @@ static void applyCompression(
  * history window too. The cost is that conflict checking reports "cannot determine"
  * (`kTryAgain`) more often, which callers retry; the cost of the alternative is a hang.
  *
+ * That cost was measured rather than assumed, which is why the coarse form is kept instead of a
+ * budget-aware clamp: it is ~zero whenever flushing is organic (driven by memtables filling), and
+ * only appears once flushes are frequent relative to transaction lifetime — at a forced 20ms
+ * cadence against 20ms+ transactions it roughly doubles attempts per commit, as history is what
+ * would otherwise resolve a non-conflicting transaction whose snapshot has already been flushed
+ * away. A clamp would only recover that regime.
+ *
  * An explicit caller value is honored untouched — sizing it against the budget and the
  * column-family count is then the caller's job.
  */

--- a/src/binding/database/db_descriptor.cpp
+++ b/src/binding/database/db_descriptor.cpp
@@ -55,6 +55,38 @@ static void applyCompression(
 		level ? *level : rocksdb::CompressionOptions::kDefaultCompressionLevel;
 }
 
+/**
+ * Resolves `max_write_buffer_size_to_maintain` for a column family.
+ *
+ * Retained memtable history is memory RocksDB has already flushed but deliberately keeps live for
+ * transaction conflict checking, and it is only trimmable back DOWN TO this target — never below.
+ * That memory is still charged to the process-wide WriteBufferManager, so a target the manager's
+ * budget cannot hold is not backpressure, it is a deadlock: the budget fills with history that will
+ * never be released, and a manager built with `allowStall` then stalls every write to that database
+ * forever. Observed as a receiver wedging partway through a Harper base copy — the writes neither
+ * land nor fail (HarperFast/harper-pro cluster shard 5, 2026-08-05).
+ *
+ * So the DERIVED default (`-1` → `maxWriteBufferNumber * writeBufferSize`, 256MB at our defaults)
+ * is dropped to 0 whenever a stalling manager is configured, since nothing guarantees a caller's
+ * budget is anywhere near that. This is exactly what every named column family ran with before
+ * these options reached late-created families, so it restores the long-shipping behavior rather
+ * than inventing one. Conflict checking then falls back to reporting "cannot determine" (RocksDB
+ * `kTryAgain`) more often, which callers already retry.
+ *
+ * An EXPLICIT caller value is honored untouched: a caller naming a number has taken on the job of
+ * sizing it against its own manager budget and column-family count.
+ */
+static int64_t resolveMaxWriteBufferSizeToMaintain(const DBOptions& options) {
+	if (options.maxWriteBufferSizeToMaintain >= 0) {
+		return options.maxWriteBufferSizeToMaintain;
+	}
+	DBSettings& settings = DBSettings::getInstance();
+	if (settings.getWriteBufferManagerSize() > 0 && settings.getWriteBufferManagerAllowStall()) {
+		return 0;
+	}
+	return options.maxWriteBufferSizeToMaintain;
+}
+
 rocksdb::ColumnFamilyOptions buildColumnFamilyOptions(
 	const DBOptions& options,
 	rocksdb::ColumnFamilyOptions cfOptions
@@ -71,7 +103,7 @@ rocksdb::ColumnFamilyOptions buildColumnFamilyOptions(
 	cfOptions.enable_blob_garbage_collection = true;
 	cfOptions.write_buffer_size = static_cast<size_t>(options.writeBufferSize);
 	cfOptions.max_write_buffer_number = options.maxWriteBufferNumber;
-	cfOptions.max_write_buffer_size_to_maintain = options.maxWriteBufferSizeToMaintain;
+	cfOptions.max_write_buffer_size_to_maintain = resolveMaxWriteBufferSizeToMaintain(options);
 	cfOptions.table_factory.reset(rocksdb::NewBlockBasedTableFactory(tableOptions));
 	return cfOptions;
 }

--- a/src/binding/database/db_descriptor.cpp
+++ b/src/binding/database/db_descriptor.cpp
@@ -58,23 +58,20 @@ static void applyCompression(
 /**
  * Resolves `max_write_buffer_size_to_maintain` for a column family.
  *
- * Retained memtable history is memory RocksDB has already flushed but deliberately keeps live for
- * transaction conflict checking, and it is only trimmable back DOWN TO this target — never below.
- * That memory is still charged to the process-wide WriteBufferManager, so a target the manager's
- * budget cannot hold is not backpressure, it is a deadlock: the budget fills with history that will
- * never be released, and a manager built with `allowStall` then stalls every write to that database
- * forever. Observed as a receiver wedging partway through a Harper base copy — the writes neither
- * land nor fail (HarperFast/harper-pro cluster shard 5, 2026-08-05).
+ * Retained memtable history is a floor, not a cap — RocksDB trims down to this target and never
+ * below — and that memory is charged to the process-wide WriteBufferManager. A target the budget
+ * cannot hold is therefore a deadlock rather than backpressure: the budget fills with history that
+ * is never released, and a manager built with `allowStall` stalls every write to the database
+ * permanently.
  *
- * So the DERIVED default (`-1` → `maxWriteBufferNumber * writeBufferSize`, 256MB at our defaults)
- * is dropped to 0 whenever a stalling manager is configured, since nothing guarantees a caller's
- * budget is anywhere near that. This is exactly what every named column family ran with before
- * these options reached late-created families, so it restores the long-shipping behavior rather
- * than inventing one. Conflict checking then falls back to reporting "cannot determine" (RocksDB
- * `kTryAgain`) more often, which callers already retry.
+ * The derived default (`-1` → `maxWriteBufferNumber * writeBufferSize`) is dropped to 0 under any
+ * stalling manager. Deliberately coarse: the safe per-family bound is the budget divided by the
+ * live column-family count, which is not knowable here, so a comfortably-sized budget loses its
+ * history window too. The cost is that conflict checking reports "cannot determine"
+ * (`kTryAgain`) more often, which callers retry; the cost of the alternative is a hang.
  *
- * An EXPLICIT caller value is honored untouched: a caller naming a number has taken on the job of
- * sizing it against its own manager budget and column-family count.
+ * An explicit caller value is honored untouched — sizing it against the budget and the
+ * column-family count is then the caller's job.
  */
 static int64_t resolveMaxWriteBufferSizeToMaintain(const DBOptions& options) {
 	if (options.maxWriteBufferSizeToMaintain >= 0) {

--- a/src/binding/database/db_settings.h
+++ b/src/binding/database/db_settings.h
@@ -88,6 +88,10 @@ public:
 		return writeBufferManagerCostToCache.load(std::memory_order_relaxed);
 	}
 
+	bool getWriteBufferManagerAllowStall() const {
+		return writeBufferManagerAllowStall.load(std::memory_order_relaxed);
+	}
+
 	std::shared_ptr<rocksdb::WriteBufferManager> getWriteBufferManager();
 
 	inline bool getCompactOnClose() const {

--- a/src/binding/options/db_options.h
+++ b/src/binding/options/db_options.h
@@ -37,7 +37,11 @@ struct DBOptions final {
 	// Bytes of recent memtable history to retain in memory for transaction
 	// conflict checking. -1 derives the value from
 	// `maxWriteBufferNumber * writeBufferSize` (the RocksDB-recommended default
-	// for OptimisticTransactionDB).
+	// for OptimisticTransactionDB) — EXCEPT when a stalling WriteBufferManager
+	// is configured, where the derived value becomes 0 because retained history
+	// the manager's budget cannot hold stalls writes permanently (see
+	// resolveMaxWriteBufferSizeToMaintain in db_descriptor.cpp). An explicit
+	// value is always honored as given.
 	int64_t maxWriteBufferSizeToMaintain = -1;
 	// Maximum number of table files RocksDB keeps open (`max_open_files`).
 	// 0 = auto: derive a budget from the effective per-process open-file limit

--- a/src/store.ts
+++ b/src/store.ts
@@ -403,7 +403,11 @@ export class Store {
 	/**
 	 * The bytes of recent memtable history to retain in memory for transaction
 	 * conflict checking. `-1` derives the value from
-	 * `maxWriteBufferNumber * writeBufferSize`.
+	 * `maxWriteBufferNumber * writeBufferSize`, except under a stalling
+	 * `writeBufferManager`, where it derives `0`: retained history is charged to
+	 * that manager and is only trimmable down to this target, so a target the
+	 * budget cannot hold stalls writes permanently. Set a number to size it
+	 * yourself against the budget and the column-family count.
 	 */
 	maxWriteBufferSizeToMaintain?: number;
 

--- a/test/write-buffer-manager-stall.test.ts
+++ b/test/write-buffer-manager-stall.test.ts
@@ -47,25 +47,28 @@ describe('WriteBufferManager stall', () => {
 		60_000
 	);
 
-	// Zeroing history is only safe because RocksDB's fallback is conservative: with no history to
-	// check against it reports "cannot determine" rather than passing the commit. A change that
+	// Zeroing history is only safe because RocksDB's fallback is conservative: asked to validate a
+	// sequence it no longer holds, it refuses the commit rather than passing it. A change that
 	// turned that into a silent accept would be a lost update, and the stall test above would
-	// still pass, so assert the conflict is refused here.
-	it('should still refuse a conflicting commit with no retained history', () =>
+	// still pass. The flush is what makes this the zero-history path rather than an ordinary
+	// active-memtable conflict — it discards the sequence the check would otherwise have found.
+	it('should still refuse a conflicting commit whose sequence was flushed out of history', () =>
 		dbRunner({ dbOptions: [{}, { name: 'late' }] }, async (_, { db }) => {
 			await db.put('conflict', 'initial');
-			setTimeout(() => db?.put('conflict', 'concurrent'));
 
 			let committed = false;
 			try {
 				await db.transaction(async (txn) => {
 					await txn.get('conflict');
-					await new Promise((resolve) => setTimeout(resolve, 100));
+					await db.put('conflict', 'concurrent');
+					await db.flush();
 					await txn.put('conflict', 'transactional');
 				});
 				committed = true;
 			} catch (error) {
-				expect((error as { code?: string }).code).toMatch(/ERR_BUSY|ERR_TRY_AGAIN/);
+				// ERR_TRY_AGAIN, not ERR_BUSY: the flush is what puts this on the zero-history
+				// path, so the code also confirms the scenario is the intended one.
+				expect((error as { code?: string }).code).toBe('ERR_TRY_AGAIN');
 			}
 			expect(committed).toBe(false);
 			expect(await db.get('conflict')).toBe('concurrent');

--- a/test/write-buffer-manager-stall.test.ts
+++ b/test/write-buffer-manager-stall.test.ts
@@ -1,0 +1,56 @@
+import { RocksDatabase } from '../src/index.js';
+import { dbRunner } from './lib/util.js';
+import { beforeAll, describe, expect, it } from 'vitest';
+
+/**
+ * `allowStall` is fixed when the WriteBufferManager singleton is created and cannot be changed
+ * afterwards, so this scenario needs a WBM nothing else in the process has built yet — hence its
+ * own file (Vitest isolates each test file in its own worker/process).
+ *
+ * The regression: retained memtable history is only trimmable back DOWN TO
+ * `max_write_buffer_size_to_maintain`, and it is charged to the WriteBufferManager. A derived
+ * target far above the manager's budget therefore fills the budget with memory that is never
+ * released, and a stalling manager stalls every subsequent write forever — not until a flush
+ * catches up. It surfaced as a Harper replication receiver wedging partway through a base copy on
+ * a deployment with a small block cache (the WBM is sized from it): the writes neither landed nor
+ * failed.
+ */
+describe('WriteBufferManager stall', () => {
+	beforeAll(() => {
+		// Budget deliberately far below the derived history target
+		// (`maxWriteBufferNumber` 16 * `writeBufferSize` 16MB = 256MB).
+		RocksDatabase.config({
+			blockCacheSize: 8 * 1024 * 1024,
+			writeBufferManagerSize: 4 * 1024 * 1024,
+			writeBufferManagerAllowStall: true,
+		});
+	});
+
+	it(
+		'should not stall writes forever on a late-created column family',
+		() =>
+			dbRunner({ dbOptions: [{}, { name: 'late' }] }, async (_, { db }) => {
+				const value = 'x'.repeat(8192);
+				// ~8MB written across several flushes: comfortably more than the 4MB budget, so if
+				// flushed memtables are pinned as history rather than released, the budget is exhausted
+				// and the stall never clears.
+				const writeAll = (async () => {
+					for (let cycle = 0; cycle < 4; cycle++) {
+						for (let i = 0; i < 250; i++) {
+							await db.put(`k-${cycle}-${i.toString().padStart(6, '0')}`, value);
+						}
+						await db.flush();
+					}
+				})();
+
+				const stalled = Symbol('stalled');
+				const outcome = await Promise.race([
+					writeAll.then(() => 'completed'),
+					new Promise((resolve) => setTimeout(() => resolve(stalled), 30_000).unref?.()),
+				]);
+				expect(outcome).toBe('completed');
+				expect(await db.get('k-3-000249')).toBe(value);
+			}),
+		60_000
+	);
+});

--- a/test/write-buffer-manager-stall.test.ts
+++ b/test/write-buffer-manager-stall.test.ts
@@ -1,6 +1,6 @@
 import { RocksDatabase } from '../src/index.js';
 import { dbRunner } from './lib/util.js';
-import { beforeAll, describe, expect, it } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 /**
  * `allowStall` is fixed when the WriteBufferManager singleton is created and cannot be changed
@@ -26,29 +26,34 @@ describe('WriteBufferManager stall', () => {
 		});
 	});
 
+	// Leave no manager attached to databases opened by later files (same reason
+	// write-buffer-manager.test.ts resets); `allowStall` itself is not resettable.
+	afterAll(() => {
+		RocksDatabase.config({
+			blockCacheSize: 32 * 1024 * 1024,
+			writeBufferManagerSize: 0,
+		});
+	});
+
 	it(
 		'should not stall writes forever on a late-created column family',
 		() =>
 			dbRunner({ dbOptions: [{}, { name: 'late' }] }, async (_, { db }) => {
 				const value = 'x'.repeat(8192);
 				// ~8MB written across several flushes: comfortably more than the 4MB budget, so if
-				// flushed memtables are pinned as history rather than released, the budget is exhausted
-				// and the stall never clears.
-				const writeAll = (async () => {
-					for (let cycle = 0; cycle < 4; cycle++) {
-						for (let i = 0; i < 250; i++) {
-							await db.put(`k-${cycle}-${i.toString().padStart(6, '0')}`, value);
-						}
-						await db.flush();
+				// flushed memtables are pinned as history rather than released, the budget is
+				// exhausted and the stall never clears.
+				//
+				// A regression shows up as a HANG, not as a failed assertion — the manager stalls
+				// inside RocksDB's write path, which blocks the calling thread, so no in-test timer
+				// can fire to turn it into a clean failure. The test timeout below is what surfaces
+				// it. (Measured: ~45ms when history is released, unbounded when it is not.)
+				for (let cycle = 0; cycle < 4; cycle++) {
+					for (let i = 0; i < 250; i++) {
+						await db.put(`k-${cycle}-${i.toString().padStart(6, '0')}`, value);
 					}
-				})();
-
-				const stalled = Symbol('stalled');
-				const outcome = await Promise.race([
-					writeAll.then(() => 'completed'),
-					new Promise((resolve) => setTimeout(() => resolve(stalled), 30_000).unref?.()),
-				]);
-				expect(outcome).toBe('completed');
+					await db.flush();
+				}
 				expect(await db.get('k-3-000249')).toBe(value);
 			}),
 		60_000

--- a/test/write-buffer-manager-stall.test.ts
+++ b/test/write-buffer-manager-stall.test.ts
@@ -6,14 +6,6 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest';
  * `allowStall` is fixed when the WriteBufferManager singleton is created and cannot be changed
  * afterwards, so this scenario needs a WBM nothing else in the process has built yet — hence its
  * own file (Vitest isolates each test file in its own worker/process).
- *
- * The regression: retained memtable history is only trimmable back DOWN TO
- * `max_write_buffer_size_to_maintain`, and it is charged to the WriteBufferManager. A derived
- * target far above the manager's budget therefore fills the budget with memory that is never
- * released, and a stalling manager stalls every subsequent write forever — not until a flush
- * catches up. It surfaced as a Harper replication receiver wedging partway through a base copy on
- * a deployment with a small block cache (the WBM is sized from it): the writes neither landed nor
- * failed.
  */
 describe('WriteBufferManager stall', () => {
 	beforeAll(() => {
@@ -40,14 +32,10 @@ describe('WriteBufferManager stall', () => {
 		() =>
 			dbRunner({ dbOptions: [{}, { name: 'late' }] }, async (_, { db }) => {
 				const value = 'x'.repeat(8192);
-				// ~8MB written across several flushes: comfortably more than the 4MB budget, so if
-				// flushed memtables are pinned as history rather than released, the budget is
-				// exhausted and the stall never clears.
-				//
-				// A regression shows up as a HANG, not as a failed assertion — the manager stalls
-				// inside RocksDB's write path, which blocks the calling thread, so no in-test timer
-				// can fire to turn it into a clean failure. The test timeout below is what surfaces
-				// it. (Measured: ~45ms when history is released, unbounded when it is not.)
+				// ~8MB across several flushes: more than the 4MB budget, so pinned-as-history
+				// memtables exhaust it and the stall never clears. A regression manifests as a
+				// HANG, not a failed assertion — the stall blocks the calling thread, so no
+				// in-test timer can fire; the test timeout is what surfaces it.
 				for (let cycle = 0; cycle < 4; cycle++) {
 					for (let i = 0; i < 250; i++) {
 						await db.put(`k-${cycle}-${i.toString().padStart(6, '0')}`, value);
@@ -58,4 +46,28 @@ describe('WriteBufferManager stall', () => {
 			}),
 		60_000
 	);
+
+	// Zeroing history is only safe because RocksDB's fallback is conservative: with no history to
+	// check against it reports "cannot determine" rather than passing the commit. A change that
+	// turned that into a silent accept would be a lost update, and the stall test above would
+	// still pass, so assert the conflict is refused here.
+	it('should still refuse a conflicting commit with no retained history', () =>
+		dbRunner({ dbOptions: [{}, { name: 'late' }] }, async (_, { db }) => {
+			await db.put('conflict', 'initial');
+			setTimeout(() => db?.put('conflict', 'concurrent'));
+
+			let committed = false;
+			try {
+				await db.transaction(async (txn) => {
+					await txn.get('conflict');
+					await new Promise((resolve) => setTimeout(resolve, 100));
+					await txn.put('conflict', 'transactional');
+				});
+				committed = true;
+			} catch (error) {
+				expect((error as { code?: string }).code).toMatch(/ERR_BUSY|ERR_TRY_AGAIN/);
+			}
+			expect(committed).toBe(false);
+			expect(await db.get('conflict')).toBe('concurrent');
+		}));
 });


### PR DESCRIPTION
Human-Review-Need: 4 @ f4799b79e5f2
Retained memtable history (`max_write_buffer_size_to_maintain`) is a floor, not a cap: RocksDB trims history back down to it and never below. That memory is charged to the process-wide WriteBufferManager, so a target above the manager's budget fills the budget with memory that is never released — and a manager built with `allowStall` then stalls every write to that database *permanently*, rather than until a flush catches up.

The derived (`-1`) default is `maxWriteBufferNumber * writeBufferSize` — 256MB at our defaults. That was harmless while it only reached the default column family, which holds little data. #721 started applying the database's `ColumnFamilyOptions` to late-created families, which is every named column family on a fresh database — the ones that take the write volume. `resolveMaxWriteBufferSizeToMaintain` now resolves the derived default to 0 whenever a stalling manager is configured, which is what every named CF ran with before #721. An explicit caller value is honored untouched; sizing it against the budget and the CF count is then the caller's job.

Conflict checking falls back to reporting "cannot determine" (`kTryAgain`) more often as a result. Callers already retry that.

## How it was found

A Harper replication receiver wedged partway through a base copy on a deployment configuring a 32MB block cache (Harper sizes its WriteBufferManager at 1/3 of the block cache, `allowStall` on, so ~10.7MB against a 256MB-per-CF target). Records arrived and were logged, the tail of the copy never committed, and later writes to that database hung with no error — deterministic 445 of 501 rows. It surfaced as `HarperFast/harper-pro` "Cluster Integration Tests 5/6" going red on every Node version the moment harper-pro moved to rocksdb-js 2.7.0.

## The coarse zero vs a budget-aware clamp — measured

Cross-model review flagged the blanket zero as an over-correction, and structurally it is one: the real deadlock condition is *derived target > available budget*, but this discards history for **every** stalling manager regardless of size. A node with a comfortably large stalling WBM that could hold the 256MB window gets 0 anyway. Since Harper enables a stalling manager by default on every RocksDB node (`writeBufferManagerSize` defaults to `blockCacheSize / 3`, `allowStall` defaults true), that is not a corner case — it is every deployment.

So I measured the cost instead of arguing about it. Harness: N concurrent optimistic transactions (read → window → write) over a key set, explicit `maxWriteBufferSizeToMaintain` per arm, WBM at 1GB so no arm can deadlock; counting `ERR_BUSY` vs `ERR_TRY_AGAIN` and attempts per commit.

**With a forced 20ms flush cadence, history starts to matter once transactions outlive the flush interval** — 512 keys, 16 writers, 400 commits, best-of-2:

| txn window | `0` att/commit | `0` ERR_TRY_AGAIN | `256MB` att/commit | throughput 256MB : 0 |
|---|---|---|---|---|
| 5ms | 1.01 | 0 | 1.02 | none |
| 10ms | 1.02 | 0 | 1.02 | none |
| 20ms | 1.18 | 67 | 1.02 | 1.18x |
| 40ms | 1.38 | 149 | 1.02 | 1.35x |

`ERR_BUSY` stays at 4-13 across every arm, so real conflicts are rare and essentially every one of those `ERR_TRY_AGAIN`s is a *false* retry — a transaction that never conflicted, forced to redo its work because its snapshot had been flushed away and there was no history left to check it against.

**With organic flushing the difference vanishes entirely:**

| config | `0` commits/s | `256MB` commits/s | `0` ERR_TRY_AGAIN |
|---|---|---|---|
| writeBuffer 16MB, 10ms txn | 1467 | 1413 | 0 |
| writeBuffer 16MB, 40ms txn | 374 | 375 | 0 |

Both directions within noise, with zero `ERR_TRY_AGAIN` in either arm. Producing any penalty at all required *forcing* a 20ms flush cadence against transactions that outlive it.

(An earlier revision of this description carried larger figures — up to 2.1x — measured against a tmpfs, where fsync is a no-op. Redone on durable storage; the effect is milder and starts later, because a memtable stays queryable while its flush is in flight rather than vanishing instantly.)

**Conclusion: keep the zero, don't build the clamp.** The effect scales with txn-duration ÷ flush-interval, and Harper's own forced flush is the base-copy cursor gate at 64MB / **5000ms** — about 250× more headroom than the cadence that produced it. A transaction would have to stay open for seconds to span a flush. The clamp would only recover a regime Harper isn't in, at the cost of a constant that still isn't provably deadlock-free (N families each holding a "safe" share of one budget can exhaust it together).

Happy to be overruled — but I'd want a workload that flushes far more aggressively than the copy path does before I'd build it.

## Where to look

- `resolveMaxWriteBufferSizeToMaintain` in `src/binding/database/db_descriptor.cpp` — the whole behavior change, and the tradeoff above.
- The condition is `writeBufferManagerSize > 0 && allowStall` — a non-stalling manager still gets the derived default, since there the budget produces backpressure rather than a deadlock.
- `buildColumnFamilyOptions` is called from both `DBDescriptor::open` and `DBRegistry::OpenDB`, so this changes the **default** column family too, not only late-created ones. That is intentional (the deadlock argument does not distinguish them) but it is the part of the blast radius worth a second opinion: the default CF has carried the derived value since before #721.

## Verification

Route: existing integration test in a downstream repo, plus a new unit test here.

- `test/write-buffer-manager-stall.test.ts` (new, 2 cases):
  - the stall case passes with this change (well under a second) and **hangs** without it — verified by reverting `db_descriptor.cpp`, rebuilding, and running it, which had to be killed at 300s. A regression manifests as a hang rather than an assertion failure, because the stall blocks the calling thread and no in-test timer can fire; the test timeout is what surfaces it.
  - the conflict case asserts a conflicting commit is still *refused* once its sequence is gone from history. Zeroing history is only safe because RocksDB's fallback is conservative (`kTryAgain`, never a silent accept); if that ever inverted it would be a lost update, and the stall case alone would stay green. The `flush()` between the read and the write is load-bearing — without it the conflict is an ordinary active-memtable one that would be caught regardless of history size. Cross-model review caught that in my first version; the assertion now pins `ERR_TRY_AGAIN` rather than `ERR_BUSY`, which is what confirms the intended path.
- Full suite: 721 passed / 5 skipped / 55 files (macOS, Node 24.18.0). Earlier on Linux/Node 26.2.0 at 719/6 before the second test; the one unhandled rejection seen there in `block-cache.test.ts` is pre-existing — confirmed by running the full suite on unmodified `main` and getting the identical error.
- `HarperFast/harper-pro` `integrationTests/cluster/blockCacheEviction.test.mjs`, the test that caught this: fails deterministically against stock 2.7.0, passes with this binding linked in. Full `test:integration:cluster --shard=5/6`: 13/13 green.

## Notes

Only unreleased main is exposed — `harper` and `harper-pro` main pin `^2.7.0`; both v5.1 branches pin `~2.4.1`, which cannot reach it. No shipped release is affected.

Generated by Claude Opus 5.
