### PR TITLE
fix: silence GCC 13 -Wstringop-overflow false positive in native tests

### DIFF
--- a/test/native/transaction_log_recovery_test.cc
+++ b/test/native/transaction_log_recovery_test.cc
@@ -57,20 +57,23 @@ public:
 	uint32_t size() const { return static_cast<uint32_t>(bytes.size()); }
 
 private:
+	// Grow-then-write instead of insert(end, ptr, ptr+N): GCC 12/13 emit a
+	// -Wstringop-overflow false positive on the vector range-insert under
+	// inlining (it assumes the pre-grow capacity while sizing the copy).
 	void appendU8(uint8_t v) {
-		char b[1];
-		rocksdb_js::writeUint8(b, v);
-		bytes.insert(bytes.end(), b, b + 1);
+		size_t off = bytes.size();
+		bytes.resize(off + 1);
+		rocksdb_js::writeUint8(bytes.data() + off, v);
 	}
 	void appendU32(uint32_t v) {
-		char b[4];
-		rocksdb_js::writeUint32BE(b, v);
-		bytes.insert(bytes.end(), b, b + 4);
+		size_t off = bytes.size();
+		bytes.resize(off + 4);
+		rocksdb_js::writeUint32BE(bytes.data() + off, v);
 	}
 	void appendF64(double v) {
-		char b[8];
-		rocksdb_js::writeDoubleBE(b, v);
-		bytes.insert(bytes.end(), b, b + 8);
+		size_t off = bytes.size();
+		bytes.resize(off + 8);
+		rocksdb_js::writeDoubleBE(bytes.data() + off, v);
 	}
 
 	std::vector<char> bytes;

--- a/test/native/transaction_log_validation_test.cc
+++ b/test/native/transaction_log_validation_test.cc
@@ -75,20 +75,23 @@ public:
 	}
 
 private:
+	// Grow-then-write instead of insert(end, ptr, ptr+N): GCC 12/13 emit a
+	// -Wstringop-overflow false positive on the vector range-insert under
+	// inlining (it assumes the pre-grow capacity while sizing the copy).
 	void appendU8(uint8_t v) {
-		char b[1];
-		rocksdb_js::writeUint8(b, v);
-		bytes.insert(bytes.end(), b, b + 1);
+		size_t off = bytes.size();
+		bytes.resize(off + 1);
+		rocksdb_js::writeUint8(bytes.data() + off, v);
 	}
 	void appendU32(uint32_t v) {
-		char b[4];
-		rocksdb_js::writeUint32BE(b, v);
-		bytes.insert(bytes.end(), b, b + 4);
+		size_t off = bytes.size();
+		bytes.resize(off + 4);
+		rocksdb_js::writeUint32BE(bytes.data() + off, v);
 	}
 	void appendF64(double v) {
-		char b[8];
-		rocksdb_js::writeDoubleBE(b, v);
-		bytes.insert(bytes.end(), b, b + 8);
+		size_t off = bytes.size();
+		bytes.resize(off + 8);
+		rocksdb_js::writeDoubleBE(bytes.data() + off, v);
 	}
 
 	std::vector<char> bytes;


### PR DESCRIPTION
## Summary

GCC 12/13 (e.g. 13.3.0 on Ubuntu 24.04) emit a `-Wstringop-overflow` false positive when compiling `test/native/transaction_log_recovery_test.cc`:

```
stl_algobase.h:437:30: warning: writing 8 bytes into a region of size 3 [-Wstringop-overflow=]
  inlined from 'void {anonymous}::LogImage::appendF64(double)' at ../test/native/transaction_log_recovery_test.cc:73:15,
  inlined from '{anonymous}::LogImage::LogImage()' at ../test/native/transaction_log_recovery_test.cc:25:12
```

This is the known GCC 12/13 false-positive family on `std::vector<char>::insert(end, ptr, ptr+N)` under inlining — the optimizer sizes the copy against the pre-grow capacity. The code is correct; only the diagnostic is wrong.

## Fix

Rewrite the three `LogImage` append helpers (`appendU8`/`appendU32`/`appendF64`) to grow-then-write: `resize()` the vector, then write directly into `bytes.data() + off` via the existing `rocksdb_js::writeUint8`/`writeUint32BE`/`writeDoubleBE` helpers. Same bytes produced, but no range-insert for the optimizer to mis-model — more robust than a `reserve()` workaround, which would only mask this one inline chain.

`transaction_log_validation_test.cc` has a byte-for-byte identical helper. It happens not to warn today (its constructor takes runtime arguments, which blocks the const-propagation chain), but it gets the same rewrite so the sibling helpers stay consistent and out of this diagnostic family.

## Verification

Fresh Ubuntu 24.04 container (podman), g++ 13.3.0-6ubuntu2~24.04.1, Node 24, full `node scripts/native-test/run.mjs` builds:

| Build | `stringop-overflow` | Native tests |
|---|---|---|
| Pristine `main` (repro) | **1** — exact warning above | 104 ran, 103 passed, 1 skipped* |
| With this fix | **0** | 104 ran, 103 passed, 1 skipped* |

\* `FileLock.SharedHardFailsOnPermissionDenied` skips when running as root.

Also verified on macOS (clang): both TUs compile clean, 104 ran, 101 passed + 3 platform-conditional madvise skips.

Pre-existing on `main` (confirmed at 3ea9a0fb), unrelated to #780.

🤖 Generated with [Claude Code](https://claude.com/claude-code)