### PR TITLE
Benchmark dbWriteBufferSize across concurrent column families

### DIFF
--- a/benchmark/db-write-buffer-size-multicf.bench.ts
+++ b/benchmark/db-write-buffer-size-multicf.bench.ts
@@ -216,6 +216,9 @@ async function measureArm(columnFamilies: number, dbWriteBufferSize: number): Pr
 		}
 		const elapsedMs = performance.now() - start;
 
+		console.log(
+			`Settling ${columnFamilies} CF / ${formatDbWriteBufferSize(dbWriteBufferSize)} after ingest`
+		);
 		databases[0].flushSync();
 		await waitForBackgroundWork(databases);
 

--- a/benchmark/db-write-buffer-size-multicf.bench.ts
+++ b/benchmark/db-write-buffer-size-multicf.bench.ts
@@ -131,7 +131,8 @@ function measureArm(columnFamilies: number, dbWriteBufferSize: number): ArmResul
 describe('dbWriteBufferSize multi-column-family ingest', () => {
 	bench(
 		'round-robin ingest counters',
-		() => {
+		// Tinybench probes synchronous callbacks before the timed iteration.
+		async () => {
 			const results: ArmResult[] = [];
 			for (const columnFamilies of COLUMN_FAMILY_COUNTS) {
 				for (const dbWriteBufferSize of DB_WRITE_BUFFER_SIZES) {
@@ -139,7 +140,8 @@ describe('dbWriteBufferSize multi-column-family ingest', () => {
 				}
 			}
 			console.table(results);
+			await Promise.resolve();
 		},
-		{ iterations: 1, time: 1, warmupIterations: 0, warmupTime: 0 }
+		{ iterations: 1, time: 0, warmupIterations: 0, warmupTime: 0 }
 	);
 });

--- a/benchmark/db-write-buffer-size-multicf.bench.ts
+++ b/benchmark/db-write-buffer-size-multicf.bench.ts
@@ -5,16 +5,21 @@ import {
 	type StatsDefault,
 } from '../dist/index.mjs';
 import { randomBytes } from 'node:crypto';
-import { rmSync } from 'node:fs';
+import { mkdirSync, rmSync, statfsSync } from 'node:fs';
 import { join } from 'node:path';
 import { bench, describe } from 'vitest';
 
 const MIB = 1024 * 1024;
-const RECORD_COUNT = 64 * 1024;
+const TMPFS_MAGIC = 0x01021994;
+const RECORD_COUNT = Number(process.env.BENCH_RECORDS ?? 256 * 1024);
 const VALUE_BYTES = 1024;
 const VALUE_POOL = randomBytes(64 * MIB);
-const COLUMN_FAMILY_COUNTS = [1, 4, 16] as const;
+const COLUMN_FAMILY_COUNTS = process.env.BENCH_CFS
+	? process.env.BENCH_CFS.split(',').map(Number)
+	: [1, 4, 8, 16];
 const DB_WRITE_BUFFER_SIZES = [32 * MIB, 256 * MIB, 0] as const;
+const WRITE_BUFFER_SIZE = Number(process.env.BENCH_WRITE_BUFFER ?? 16 * MIB);
+const BENCH_DATA_DIR = process.env.BENCH_DATA_DIR ?? join('benchmark', 'data');
 
 type ArmResult = {
 	columnFamilies: number;
@@ -39,7 +44,7 @@ function levelFiles(databases: RocksDatabase[]): string {
 	const levels: string[] = [];
 	for (let level = 0; level < 7; level++) {
 		const files = databases.reduce(
-			(total, db) => total + (db.getDBIntProperty(`rocksdb.num-files-at-level${level}`) ?? 0),
+			(total, db) => total + Number(db.getDBProperty(`rocksdb.num-files-at-level${level}`) ?? 0),
 			0
 		);
 		if (files > 0) {
@@ -49,17 +54,31 @@ function levelFiles(databases: RocksDatabase[]): string {
 	return levels.join(' ') || 'none';
 }
 
+function scatteredKey(record: number): string {
+	const hash = Math.imul(record, 2654435761) >>> 0;
+	return `key-${hash.toString().padStart(10, '0')}-${record.toString().padStart(8, '0')}`;
+}
+
+function ensureDurableStorage(): void {
+	mkdirSync(BENCH_DATA_DIR, { recursive: true });
+	if (Number(statfsSync(BENCH_DATA_DIR).type) === TMPFS_MAGIC) {
+		throw new Error(
+			`BENCH_DATA_DIR must use durable storage; ${BENCH_DATA_DIR} is on a tmpfs filesystem`
+		);
+	}
+}
+
 function measureArm(columnFamilies: number, dbWriteBufferSize: number): ArmResult {
+	ensureDurableStorage();
 	const dbPath = join(
-		'benchmark',
-		'data',
+		BENCH_DATA_DIR,
 		`db-write-buffer-size-multicf-${columnFamilies}-${dbWriteBufferSize}-${randomBytes(8).toString('hex')}`
 	);
 	const options: RocksDatabaseOptions = {
 		dbWriteBufferSize,
 		enableStats: true,
 		maxWriteBufferNumber: 16,
-		writeBufferSize: 64 * MIB,
+		writeBufferSize: WRITE_BUFFER_SIZE,
 	};
 	const databases: RocksDatabase[] = [];
 
@@ -74,7 +93,7 @@ function measureArm(columnFamilies: number, dbWriteBufferSize: number): ArmResul
 		for (let record = 0; record < RECORD_COUNT; record++) {
 			const offset = (record * 4099) % (VALUE_POOL.length - VALUE_BYTES);
 			databases[record % columnFamilies].putSync(
-				`key-${record.toString().padStart(8, '0')}`,
+				scatteredKey(record),
 				VALUE_POOL.subarray(offset, offset + VALUE_BYTES)
 			);
 		}

--- a/benchmark/db-write-buffer-size-multicf.bench.ts
+++ b/benchmark/db-write-buffer-size-multicf.bench.ts
@@ -1,0 +1,126 @@
+import {
+	RocksDatabase,
+	shutdown,
+	type RocksDatabaseOptions,
+	type StatsDefault,
+} from '../dist/index.mjs';
+import { randomBytes } from 'node:crypto';
+import { rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { bench, describe } from 'vitest';
+
+const MIB = 1024 * 1024;
+const RECORD_COUNT = 64 * 1024;
+const VALUE_BYTES = 1024;
+const VALUE_POOL = randomBytes(64 * MIB);
+const COLUMN_FAMILY_COUNTS = [1, 4, 16] as const;
+const DB_WRITE_BUFFER_SIZES = [32 * MIB, 256 * MIB, 0] as const;
+
+type ArmResult = {
+	columnFamilies: number;
+	dbWriteBufferSize: string;
+	flushCount: number;
+	flushMedianMs: string;
+	ingestMiBPerSecond: string;
+	levelFiles: string;
+	stallMs: string;
+	sstMiB: string;
+};
+
+function formatMiB(bytes: number): string {
+	return (bytes / MIB).toFixed(1);
+}
+
+function formatDbWriteBufferSize(size: number): string {
+	return size === 0 ? 'disabled' : `${size / MIB} MiB`;
+}
+
+function levelFiles(databases: RocksDatabase[]): string {
+	const levels: string[] = [];
+	for (let level = 0; level < 7; level++) {
+		const files = databases.reduce(
+			(total, db) => total + (db.getDBIntProperty(`rocksdb.num-files-at-level${level}`) ?? 0),
+			0
+		);
+		if (files > 0) {
+			levels.push(`L${level}:${files}`);
+		}
+	}
+	return levels.join(' ') || 'none';
+}
+
+function measureArm(columnFamilies: number, dbWriteBufferSize: number): ArmResult {
+	const dbPath = join(
+		'benchmark',
+		'data',
+		`db-write-buffer-size-multicf-${columnFamilies}-${dbWriteBufferSize}-${randomBytes(8).toString('hex')}`
+	);
+	const options: RocksDatabaseOptions = {
+		dbWriteBufferSize,
+		enableStats: true,
+		maxWriteBufferNumber: 16,
+		writeBufferSize: 64 * MIB,
+	};
+	const databases: RocksDatabase[] = [];
+
+	try {
+		for (let index = 0; index < columnFamilies; index++) {
+			databases.push(
+				RocksDatabase.open(dbPath, index === 0 ? options : { ...options, name: `cf-${index}` })
+			);
+		}
+
+		const start = performance.now();
+		for (let record = 0; record < RECORD_COUNT; record++) {
+			const offset = (record * 4099) % (VALUE_POOL.length - VALUE_BYTES);
+			databases[record % columnFamilies].putSync(
+				`key-${record.toString().padStart(8, '0')}`,
+				VALUE_POOL.subarray(offset, offset + VALUE_BYTES)
+			);
+		}
+		const elapsedMs = performance.now() - start;
+
+		for (const db of databases) {
+			db.flushSync();
+		}
+
+		const stats = databases[0].getStats() as StatsDefault;
+		const flush = stats['rocksdb.db.flush.micros'];
+		const sstBytes = databases.reduce(
+			(total, db) => total + (db.getDBIntProperty('rocksdb.total-sst-files-size') ?? 0),
+			0
+		);
+		return {
+			columnFamilies,
+			dbWriteBufferSize: formatDbWriteBufferSize(dbWriteBufferSize),
+			flushCount: flush.count,
+			flushMedianMs: (flush.median / 1000).toFixed(2),
+			ingestMiBPerSecond: formatMiB((RECORD_COUNT * VALUE_BYTES * 1000) / elapsedMs),
+			levelFiles: levelFiles(databases),
+			stallMs: ((stats['rocksdb.stall.micros'] ?? 0) / 1000).toFixed(2),
+			sstMiB: formatMiB(sstBytes),
+		};
+	} finally {
+		for (const db of databases.reverse()) {
+			db.close();
+		}
+		shutdown();
+		rmSync(dbPath, { force: true, recursive: true, maxRetries: 3 });
+	}
+}
+
+describe('dbWriteBufferSize multi-column-family ingest', () => {
+	bench(
+		'round-robin ingest counters',
+		() => {
+			const results: ArmResult[] = [];
+			for (const columnFamilies of COLUMN_FAMILY_COUNTS) {
+				for (const dbWriteBufferSize of DB_WRITE_BUFFER_SIZES) {
+					results.push(measureArm(columnFamilies, dbWriteBufferSize));
+				}
+			}
+			console.table(results);
+		},
+		{ iterations: 1, time: 1, warmupIterations: 0, warmupTime: 0 }
+	);
+});

--- a/benchmark/db-write-buffer-size-multicf.bench.ts
+++ b/benchmark/db-write-buffer-size-multicf.bench.ts
@@ -200,15 +200,15 @@ async function measureArm(columnFamilies: number, dbWriteBufferSize: number): Pr
 			const recordsWritten = record + 1;
 			if (recordsWritten % 1024 === 0 || recordsWritten === RECORD_COUNT) {
 				const now = performance.now();
-				const elapsedMs = now - start;
-				const progress =
-					`${columnFamilies} CF / ${formatDbWriteBufferSize(dbWriteBufferSize)} ingest: ` +
-					`${formatMiB(recordsWritten * VALUE_BYTES)}/${formatMiB(RECORD_COUNT * VALUE_BYTES)} MiB, ` +
-					`${formatMiB((recordsWritten * VALUE_BYTES * 1000) / elapsedMs)} MiB/s`;
-				if (now >= deadline) {
-					throw new Error(`${progress}; exceeded ${ARM_TIMEOUT_MS} ms deadline`);
-				}
-				if (now >= nextProgress) {
+				if (now >= deadline || now >= nextProgress) {
+					const elapsedMs = now - start;
+					const progress =
+						`${columnFamilies} CF / ${formatDbWriteBufferSize(dbWriteBufferSize)} ingest: ` +
+						`${formatMiB(recordsWritten * VALUE_BYTES)}/${formatMiB(RECORD_COUNT * VALUE_BYTES)} MiB, ` +
+						`${formatMiB((recordsWritten * VALUE_BYTES * 1000) / elapsedMs)} MiB/s`;
+					if (now >= deadline) {
+						throw new Error(`${progress}; exceeded ${ARM_TIMEOUT_MS} ms deadline`);
+					}
 					console.log(progress);
 					nextProgress = now + PROGRESS_INTERVAL_MS;
 				}
@@ -254,7 +254,7 @@ describe.skipIf(process.env.BENCHMARK_MODE === 'essential' || !!process.env.LMDB
 	'dbWriteBufferSize multi-column-family ingest',
 	() => {
 		bench(
-			'round-robin ingest counters (~25 min default)',
+			'round-robin ingest counters (~25 min observed default)',
 			async () => {
 				if (++sweepRuns !== 1) {
 					throw new Error('The multi-column-family counter sweep must execute exactly once');

--- a/benchmark/db-write-buffer-size-multicf.bench.ts
+++ b/benchmark/db-write-buffer-size-multicf.bench.ts
@@ -11,22 +11,41 @@ import { join } from 'node:path';
 import { setTimeout as delay } from 'node:timers/promises';
 import { bench, describe } from 'vitest';
 
+function parseInteger(name: string, raw: string, minimum: number): number {
+	const value = Number(raw);
+	if (!Number.isInteger(value) || value < minimum) {
+		throw new Error(`${name} must be an integer >= ${minimum}; received ${raw}`);
+	}
+	return value;
+}
+
+function environmentInteger(name: string, fallback: number, minimum: number = 1): number {
+	const raw = process.env[name];
+	return raw === undefined ? fallback : parseInteger(name, raw, minimum);
+}
+
+function environmentIntegerList(name: string, fallback: number[]): number[] {
+	const raw = process.env[name];
+	return raw === undefined
+		? fallback
+		: raw.split(',').map((value, index) => parseInteger(`${name}[${index}]`, value, 1));
+}
+
 const MIB = 1024 * 1024;
 const TMPFS_MAGIC = 0x01021994;
-const RECORD_COUNT = Number(process.env.BENCH_RECORDS ?? 256 * 1024);
+const RECORD_COUNT = environmentInteger('BENCH_RECORDS', 256 * 1024);
 const VALUE_BYTES = 1024;
 const VALUE_POOL_BYTES = 64 * MIB;
-const COLUMN_FAMILY_COUNTS = process.env.BENCH_CFS
-	? process.env.BENCH_CFS.split(',').map(Number)
-	: [1, 4, 8, 16];
+const COLUMN_FAMILY_COUNTS = environmentIntegerList('BENCH_CFS', [1, 4, 8, 16]);
 const DB_WRITE_BUFFER_SIZES = [32 * MIB, 256 * MIB, 0] as const;
-const WRITE_BUFFER_SIZE = Number(process.env.BENCH_WRITE_BUFFER ?? 16 * MIB);
-const MAX_WRITE_BUFFER_SIZE_TO_MAINTAIN = Number(
-	process.env.BENCH_MAX_WRITE_BUFFER_SIZE_TO_MAINTAIN ?? -1
+const WRITE_BUFFER_SIZE = environmentInteger('BENCH_WRITE_BUFFER', 16 * MIB);
+const MAX_WRITE_BUFFER_SIZE_TO_MAINTAIN = environmentInteger(
+	'BENCH_MAX_WRITE_BUFFER_SIZE_TO_MAINTAIN',
+	-1,
+	-1
 );
 const BENCH_DATA_DIR = process.env.BENCH_DATA_DIR ?? join('benchmark', 'data');
-const SETTLE_TIMEOUT_MS = Number(process.env.BENCH_SETTLE_TIMEOUT_MS ?? 5 * 60_000);
-const ARM_COUNT = COLUMN_FAMILY_COUNTS.length * DB_WRITE_BUFFER_SIZES.length;
+const SETTLE_TIMEOUT_MS = environmentInteger('BENCH_SETTLE_TIMEOUT_MS', 5 * 60_000);
 let valuePool: Buffer | undefined;
 let sweepRuns = 0;
 
@@ -90,16 +109,20 @@ function flushHistogram(database: RocksDatabase): StatsCurated['rocksdb.db.flush
 	return flush;
 }
 
-async function waitForBackgroundWork(database: RocksDatabase): Promise<void> {
+async function waitForBackgroundWork(databases: RocksDatabase[]): Promise<void> {
 	const deadline = performance.now() + SETTLE_TIMEOUT_MS;
 	let idleChecks = 0;
-	while (idleChecks < 2) {
-		const stats = database.getStats() as StatsDefault;
-		if (
-			stats['rocksdb.mem-table-flush-pending'] === 0 &&
-			stats['rocksdb.compaction-pending'] === 0 &&
-			stats['rocksdb.num-running-compactions'] === 0
-		) {
+	while (idleChecks < 3) {
+		const idle = databases.every((database) => {
+			const stats = database.getStats() as StatsDefault;
+			return (
+				stats['rocksdb.mem-table-flush-pending'] === 0 &&
+				stats['rocksdb.compaction-pending'] === 0 &&
+				stats['rocksdb.num-running-compactions'] === 0 &&
+				stats['rocksdb.num-running-flushes'] === 0
+			);
+		});
+		if (idle) {
 			idleChecks++;
 		} else {
 			idleChecks = 0;
@@ -169,12 +192,10 @@ async function measureArm(columnFamilies: number, dbWriteBufferSize: number): Pr
 		}
 		const elapsedMs = performance.now() - start;
 
-		for (const db of databases) {
-			db.flushSync();
-		}
-		await waitForBackgroundWork(databases[0]);
+		databases[0].flushSync();
+		await waitForBackgroundWork(databases);
 
-		const stats = databases[0].getStats() as StatsDefault;
+		const stats = databases[0].getStats() as StatsCurated;
 		const flush = flushHistogram(databases[0]);
 		if (flush.count === 0) {
 			throw new Error('The completed arm did not record any memtable flushes');
@@ -220,9 +241,6 @@ describe.skipIf(process.env.BENCHMARK_MODE === 'essential' || !!process.env.LMDB
 						for (const dbWriteBufferSize of DB_WRITE_BUFFER_SIZES) {
 							results.push(await measureArm(columnFamilies, dbWriteBufferSize));
 						}
-					}
-					if (results.length !== ARM_COUNT) {
-						throw new Error(`Expected ${ARM_COUNT} benchmark arms, received ${results.length}`);
 					}
 				} finally {
 					console.table(results);

--- a/benchmark/db-write-buffer-size-multicf.bench.ts
+++ b/benchmark/db-write-buffer-size-multicf.bench.ts
@@ -37,7 +37,7 @@ const RECORD_COUNT = environmentInteger('BENCH_RECORDS', 256 * 1024);
 const VALUE_BYTES = 1024;
 const VALUE_POOL_BYTES = 64 * MIB;
 const COLUMN_FAMILY_COUNTS = environmentIntegerList('BENCH_CFS', [1, 4, 8, 16]);
-const DB_WRITE_BUFFER_SIZES = [32 * MIB, 256 * MIB, 0] as const;
+const DB_WRITE_BUFFER_SIZES = [256 * MIB, 0, 32 * MIB] as const;
 const WRITE_BUFFER_SIZE = environmentInteger('BENCH_WRITE_BUFFER', 16 * MIB);
 const MAX_WRITE_BUFFER_SIZE_TO_MAINTAIN = environmentInteger(
 	'BENCH_MAX_WRITE_BUFFER_SIZE_TO_MAINTAIN',
@@ -45,6 +45,8 @@ const MAX_WRITE_BUFFER_SIZE_TO_MAINTAIN = environmentInteger(
 	-1
 );
 const BENCH_DATA_DIR = process.env.BENCH_DATA_DIR ?? join('benchmark', 'data');
+const ARM_TIMEOUT_MS = environmentInteger('BENCH_ARM_TIMEOUT_MS', 30 * 60_000);
+const PROGRESS_INTERVAL_MS = environmentInteger('BENCH_PROGRESS_INTERVAL_MS', 30_000);
 const SETTLE_TIMEOUT_MS = environmentInteger('BENCH_SETTLE_TIMEOUT_MS', 5 * 60_000);
 let valuePool: Buffer | undefined;
 let sweepRuns = 0;
@@ -183,12 +185,34 @@ async function measureArm(columnFamilies: number, dbWriteBufferSize: number): Pr
 
 		const currentValuePool = getValuePool();
 		const start = performance.now();
+		const deadline = start + ARM_TIMEOUT_MS;
+		let nextProgress = start + PROGRESS_INTERVAL_MS;
+		console.log(
+			`Starting ${columnFamilies} CF / ${formatDbWriteBufferSize(dbWriteBufferSize)} ingest ` +
+				`(${formatMiB(RECORD_COUNT * VALUE_BYTES)} MiB, ${ARM_TIMEOUT_MS / 1000}s deadline)`
+		);
 		for (let record = 0; record < RECORD_COUNT; record++) {
 			const offset = (record * 4099) % (currentValuePool.length - VALUE_BYTES);
 			databases[record % columnFamilies].putSync(
 				scatteredKey(record),
 				currentValuePool.subarray(offset, offset + VALUE_BYTES)
 			);
+			const recordsWritten = record + 1;
+			if (recordsWritten % 1024 === 0 || recordsWritten === RECORD_COUNT) {
+				const now = performance.now();
+				const elapsedMs = now - start;
+				const progress =
+					`${columnFamilies} CF / ${formatDbWriteBufferSize(dbWriteBufferSize)} ingest: ` +
+					`${formatMiB(recordsWritten * VALUE_BYTES)}/${formatMiB(RECORD_COUNT * VALUE_BYTES)} MiB, ` +
+					`${formatMiB((recordsWritten * VALUE_BYTES * 1000) / elapsedMs)} MiB/s`;
+				if (now >= deadline) {
+					throw new Error(`${progress}; exceeded ${ARM_TIMEOUT_MS} ms deadline`);
+				}
+				if (now >= nextProgress) {
+					console.log(progress);
+					nextProgress = now + PROGRESS_INTERVAL_MS;
+				}
+			}
 		}
 		const elapsedMs = performance.now() - start;
 
@@ -230,15 +254,15 @@ describe.skipIf(process.env.BENCHMARK_MODE === 'essential' || !!process.env.LMDB
 	'dbWriteBufferSize multi-column-family ingest',
 	() => {
 		bench(
-			'round-robin ingest counters',
+			'round-robin ingest counters (~25 min default)',
 			async () => {
 				if (++sweepRuns !== 1) {
 					throw new Error('The multi-column-family counter sweep must execute exactly once');
 				}
 				const results: ArmResult[] = [];
 				try {
-					for (const columnFamilies of COLUMN_FAMILY_COUNTS) {
-						for (const dbWriteBufferSize of DB_WRITE_BUFFER_SIZES) {
+					for (const dbWriteBufferSize of DB_WRITE_BUFFER_SIZES) {
+						for (const columnFamilies of COLUMN_FAMILY_COUNTS) {
 							results.push(await measureArm(columnFamilies, dbWriteBufferSize));
 						}
 					}
@@ -246,7 +270,7 @@ describe.skipIf(process.env.BENCHMARK_MODE === 'essential' || !!process.env.LMDB
 					console.table(results);
 				}
 			},
-			{ iterations: 1, throws: true, time: 0, warmupIterations: 0, warmupTime: 0 }
+			{ iterations: 1, throws: false, time: 0, warmupIterations: 0, warmupTime: 0 }
 		);
 	}
 );

--- a/benchmark/db-write-buffer-size-multicf.bench.ts
+++ b/benchmark/db-write-buffer-size-multicf.bench.ts
@@ -2,24 +2,33 @@ import {
 	RocksDatabase,
 	shutdown,
 	type RocksDatabaseOptions,
+	type StatsCurated,
 	type StatsDefault,
 } from '../dist/index.mjs';
 import { randomBytes } from 'node:crypto';
 import { mkdirSync, rmSync, statfsSync } from 'node:fs';
 import { join } from 'node:path';
+import { setTimeout as delay } from 'node:timers/promises';
 import { bench, describe } from 'vitest';
 
 const MIB = 1024 * 1024;
 const TMPFS_MAGIC = 0x01021994;
 const RECORD_COUNT = Number(process.env.BENCH_RECORDS ?? 256 * 1024);
 const VALUE_BYTES = 1024;
-const VALUE_POOL = randomBytes(64 * MIB);
+const VALUE_POOL_BYTES = 64 * MIB;
 const COLUMN_FAMILY_COUNTS = process.env.BENCH_CFS
 	? process.env.BENCH_CFS.split(',').map(Number)
 	: [1, 4, 8, 16];
 const DB_WRITE_BUFFER_SIZES = [32 * MIB, 256 * MIB, 0] as const;
 const WRITE_BUFFER_SIZE = Number(process.env.BENCH_WRITE_BUFFER ?? 16 * MIB);
+const MAX_WRITE_BUFFER_SIZE_TO_MAINTAIN = Number(
+	process.env.BENCH_MAX_WRITE_BUFFER_SIZE_TO_MAINTAIN ?? -1
+);
 const BENCH_DATA_DIR = process.env.BENCH_DATA_DIR ?? join('benchmark', 'data');
+const SETTLE_TIMEOUT_MS = Number(process.env.BENCH_SETTLE_TIMEOUT_MS ?? 5 * 60_000);
+const ARM_COUNT = COLUMN_FAMILY_COUNTS.length * DB_WRITE_BUFFER_SIZES.length;
+let valuePool: Buffer | undefined;
+let sweepRuns = 0;
 
 type ArmResult = {
 	columnFamilies: number;
@@ -28,6 +37,7 @@ type ArmResult = {
 	flushMedianMs: string;
 	ingestMiBPerSecond: string;
 	levelFiles: string;
+	memtableHistory: string;
 	stallMs: string;
 	sstMiB: string;
 };
@@ -59,6 +69,10 @@ function scatteredKey(record: number): string {
 	return `key-${hash.toString().padStart(10, '0')}-${record.toString().padStart(8, '0')}`;
 }
 
+function getValuePool(): Buffer {
+	return (valuePool ??= randomBytes(VALUE_POOL_BYTES));
+}
+
 function ensureDurableStorage(): void {
 	mkdirSync(BENCH_DATA_DIR, { recursive: true });
 	if (Number(statfsSync(BENCH_DATA_DIR).type) === TMPFS_MAGIC) {
@@ -68,7 +82,60 @@ function ensureDurableStorage(): void {
 	}
 }
 
-function measureArm(columnFamilies: number, dbWriteBufferSize: number): ArmResult {
+function flushHistogram(database: RocksDatabase): StatsCurated['rocksdb.db.flush.micros'] {
+	const flush = (database.getStats() as StatsCurated)['rocksdb.db.flush.micros'];
+	if (!flush) {
+		throw new Error('rocksdb.db.flush.micros is unavailable; enableStats did not take effect');
+	}
+	return flush;
+}
+
+async function waitForBackgroundWork(database: RocksDatabase): Promise<void> {
+	const deadline = performance.now() + SETTLE_TIMEOUT_MS;
+	let idleChecks = 0;
+	while (idleChecks < 2) {
+		const stats = database.getStats() as StatsDefault;
+		if (
+			stats['rocksdb.mem-table-flush-pending'] === 0 &&
+			stats['rocksdb.compaction-pending'] === 0 &&
+			stats['rocksdb.num-running-compactions'] === 0
+		) {
+			idleChecks++;
+		} else {
+			idleChecks = 0;
+		}
+		if (performance.now() >= deadline) {
+			throw new Error(`RocksDB background work did not settle within ${SETTLE_TIMEOUT_MS} ms`);
+		}
+		await delay(100);
+	}
+}
+
+function cleanupArm(databases: RocksDatabase[], dbPath: string, armError: unknown): void {
+	const errors: unknown[] = armError === undefined ? [] : [armError];
+	for (let index = databases.length - 1; index >= 0; index--) {
+		try {
+			databases[index].close();
+		} catch (error) {
+			errors.push(error);
+		}
+	}
+	try {
+		shutdown();
+	} catch (error) {
+		errors.push(error);
+	}
+	try {
+		rmSync(dbPath, { force: true, recursive: true, maxRetries: 3 });
+	} catch (error) {
+		errors.push(error);
+	}
+	if (errors.length > (armError === undefined ? 0 : 1)) {
+		throw new AggregateError(errors, `Failed to clean up benchmark arm at ${dbPath}`);
+	}
+}
+
+async function measureArm(columnFamilies: number, dbWriteBufferSize: number): Promise<ArmResult> {
 	ensureDurableStorage();
 	const dbPath = join(
 		BENCH_DATA_DIR,
@@ -78,9 +145,11 @@ function measureArm(columnFamilies: number, dbWriteBufferSize: number): ArmResul
 		dbWriteBufferSize,
 		enableStats: true,
 		maxWriteBufferNumber: 16,
+		maxWriteBufferSizeToMaintain: MAX_WRITE_BUFFER_SIZE_TO_MAINTAIN,
 		writeBufferSize: WRITE_BUFFER_SIZE,
 	};
 	const databases: RocksDatabase[] = [];
+	let armError: unknown;
 
 	try {
 		for (let index = 0; index < columnFamilies; index++) {
@@ -89,12 +158,13 @@ function measureArm(columnFamilies: number, dbWriteBufferSize: number): ArmResul
 			);
 		}
 
+		const currentValuePool = getValuePool();
 		const start = performance.now();
 		for (let record = 0; record < RECORD_COUNT; record++) {
-			const offset = (record * 4099) % (VALUE_POOL.length - VALUE_BYTES);
+			const offset = (record * 4099) % (currentValuePool.length - VALUE_BYTES);
 			databases[record % columnFamilies].putSync(
 				scatteredKey(record),
-				VALUE_POOL.subarray(offset, offset + VALUE_BYTES)
+				currentValuePool.subarray(offset, offset + VALUE_BYTES)
 			);
 		}
 		const elapsedMs = performance.now() - start;
@@ -102,9 +172,13 @@ function measureArm(columnFamilies: number, dbWriteBufferSize: number): ArmResul
 		for (const db of databases) {
 			db.flushSync();
 		}
+		await waitForBackgroundWork(databases[0]);
 
 		const stats = databases[0].getStats() as StatsDefault;
-		const flush = stats['rocksdb.db.flush.micros'];
+		const flush = flushHistogram(databases[0]);
+		if (flush.count === 0) {
+			throw new Error('The completed arm did not record any memtable flushes');
+		}
 		const sstBytes = databases.reduce(
 			(total, db) => total + (db.getDBIntProperty('rocksdb.total-sst-files-size') ?? 0),
 			0
@@ -116,32 +190,45 @@ function measureArm(columnFamilies: number, dbWriteBufferSize: number): ArmResul
 			flushMedianMs: (flush.median / 1000).toFixed(2),
 			ingestMiBPerSecond: formatMiB((RECORD_COUNT * VALUE_BYTES * 1000) / elapsedMs),
 			levelFiles: levelFiles(databases),
+			memtableHistory:
+				MAX_WRITE_BUFFER_SIZE_TO_MAINTAIN === -1
+					? 'derived'
+					: formatDbWriteBufferSize(MAX_WRITE_BUFFER_SIZE_TO_MAINTAIN),
 			stallMs: ((stats['rocksdb.stall.micros'] ?? 0) / 1000).toFixed(2),
 			sstMiB: formatMiB(sstBytes),
 		};
+	} catch (error) {
+		armError = error;
+		throw error;
 	} finally {
-		for (const db of databases.reverse()) {
-			db.close();
-		}
-		shutdown();
-		rmSync(dbPath, { force: true, recursive: true, maxRetries: 3 });
+		cleanupArm(databases, dbPath, armError);
 	}
 }
 
-describe('dbWriteBufferSize multi-column-family ingest', () => {
-	bench(
-		'round-robin ingest counters',
-		// Tinybench probes synchronous callbacks before the timed iteration.
-		async () => {
-			const results: ArmResult[] = [];
-			for (const columnFamilies of COLUMN_FAMILY_COUNTS) {
-				for (const dbWriteBufferSize of DB_WRITE_BUFFER_SIZES) {
-					results.push(measureArm(columnFamilies, dbWriteBufferSize));
+describe.skipIf(process.env.BENCHMARK_MODE === 'essential' || !!process.env.LMDB_ONLY)(
+	'dbWriteBufferSize multi-column-family ingest',
+	() => {
+		bench(
+			'round-robin ingest counters',
+			async () => {
+				if (++sweepRuns !== 1) {
+					throw new Error('The multi-column-family counter sweep must execute exactly once');
 				}
-			}
-			console.table(results);
-			await Promise.resolve();
-		},
-		{ iterations: 1, time: 0, warmupIterations: 0, warmupTime: 0 }
-	);
-});
+				const results: ArmResult[] = [];
+				try {
+					for (const columnFamilies of COLUMN_FAMILY_COUNTS) {
+						for (const dbWriteBufferSize of DB_WRITE_BUFFER_SIZES) {
+							results.push(await measureArm(columnFamilies, dbWriteBufferSize));
+						}
+					}
+					if (results.length !== ARM_COUNT) {
+						throw new Error(`Expected ${ARM_COUNT} benchmark arms, received ${results.length}`);
+					}
+				} finally {
+					console.table(results);
+				}
+			},
+			{ iterations: 1, throws: true, time: 0, warmupIterations: 0, warmupTime: 0 }
+		);
+	}
+);


### PR DESCRIPTION
Adds a committed counter-style benchmark for the failure mode behind [Honor dbWriteBufferSize open option (#756)](https://github.com/HarperFast/rocksdb-js/pull/756): one DB-wide memtable budget shared by several concurrently written column families.

The sweep uses 1 KiB inline values from a 64 MiB random pool, scattered keys, a 16 MiB per-CF write buffer, and 256 MiB of fixed total ingest. It compares 1/4/8/16 column families against a 32 MiB DB budget, a 256 MiB practical-unconstrained baseline, and the disabled global trigger. Each arm reports ingest throughput, the DB flush histogram's count and median, stall time, total SST size, level-file distribution, and whether retained memtable history is derived or explicit. It force-flushes once across all CFs, then requires every CF to remain idle for three samples before collecting final metrics.

The preserved durable-NVMe results from the scattered-key run are:

| column families | `dbWriteBufferSize: 32 MiB` | `256 MiB` | `disabled (0)` |
|---|---|---|---|
| 8 | 191.0 MiB/s, 256 flushes, no stall | 198.7 MiB/s | 200.4 MiB/s |
| 16 | **0.9 MiB/s**, 122,756 flushes, 242 s stall | 207.5 MiB/s | 201.9 MiB/s |

Under rocksdb-js's production geometry, 32 MiB is a real throughput ceiling once enough column families are hot. Eight CFs remain within about 5% of the unconstrained arms, but sixteen CFs make the 32 MiB arm 224–231× slower, with 122,756 flushes and 242 seconds of accumulated stall; the 256 MiB and disabled arms remain near 200 MiB/s. This is a synthetic concurrent-table/bulk-ingest result, not an end-to-end Harper workload. Because rocksdb-js enables atomic flush and this run uses derived retained-memtable history, it measures their combined production-default behavior rather than isolating `dbWriteBufferSize` in vanilla RocksDB.

The harness now [runs every healthy control before the destructive 32 MiB treatment arms](https://github.com/HarperFast/rocksdb-js/pull/788/changes?w=1#diff-f45008a4bcb6ff94547daa0561a3b37000955581ec8b9d71459d50ffe34e95a1R264), so a 16-CF/32-MiB flush storm cannot contaminate a following control. Each arm [announces its geometry, reports throughput periodically, and enforces a configurable ingest deadline](https://github.com/HarperFast/rocksdb-js/pull/788/changes?w=1#diff-f45008a4bcb6ff94547daa0561a3b37000955581ec8b9d71459d50ffe34e95a1R187). The benchmark name explicitly identifies the observed default runtime, and Tinybench captures thrown errors so Vitest reports a failed suite instead of hanging outside its task-result path.

## For the human reviewer

- **Arm ordering:** all 256 MiB and disabled controls run before any 32 MiB treatment. This follows the reviewer's accepted control-first option and prevents the demonstrated control contamination. It intentionally favors trustworthy controls over randomization; monotonic device drift remains a limitation of any single sequential sweep.
- **Production geometry vs. isolated trigger:** kept `maxWriteBufferSizeToMaintain: -1` (derived) to match the preserved production-default results, and exposed it as `memtableHistory` in every row. Setting it to `0` would better isolate active memtables but answer a different question; the env override makes that follow-up reversible.
- **Atomic flush:** this binding deliberately enables it, so one trigger can flush every CF. The table characterizes rocksdb-js as shipped, not a generic RocksDB-only effect.
- **256 MiB arm:** at this fixed 256 MiB payload, per-CF triggers keep the live total below that cap. It is a practical unconstrained control alongside `0`, not proof that a 256 MiB cap fired.
- **Fixed total volume and durable storage:** total records stay fixed while CF count changes because the task compares how one workload behaves when split across more families. The benchmark hard-fails on Linux tmpfs; allowing it would produce fast but misleading storage numbers.

## Verification

- `pnpm build` — passed (TypeScript bundle and native binding).
- `pnpm check` — passed.
- `pnpm test` — 55 files passed; 767 tests passed, 2 skipped.
- `pnpm test:native` — 105 tests passed.
- `CI=1 BENCH_RECORDS=4096 BENCH_CFS=1,2 BENCH_PROGRESS_INTERVAL_MS=1 ...vitest... benchmark/db-write-buffer-size-multicf.bench.ts` — passed; printed progress and ran controls before 32 MiB arms.
- `CI=1 BENCH_RECORDS=4096 BENCH_CFS=1 BENCH_ARM_TIMEOUT_MS=1 ...vitest... benchmark/db-write-buffer-size-multicf.bench.ts` — failed as expected in under one second with `exceeded 1 ms deadline` and exit code 1.

Per Kris's ruling, this update did not rerun the prior full measurement unchanged; the table above is the existing durable-storage result. The focused smoke validates the corrected harness without presenting its 4 MiB dataset as performance evidence.

Complexity: 2

Refs #756

Authored by GPT-5 Codex.

Generated by GPT-5 Codex.

<sub>Review-Coverage: authored=codex; ran=claude,gemini; declined=cursor-grok,cursor-composer,domain; rounds=3 @ b599a8f9ddfe</sub>

<sub>Human-Review-Need: 4 @ b599a8f9ddfe</sub>
