### PR TITLE
fix(usb): stop finalizer from dereferencing tsfn-owned callbackRef during shutdown (#790)

### DIFF
--- a/src/binding/database/database.cpp
+++ b/src/binding/database/database.cpp
@@ -1415,21 +1415,21 @@ napi_value Database::GetUserSharedBuffer(napi_env env, napi_callback_info info) 
 	std::string keyStr(key + keyStart, keyEnd - keyStart);
 
 	// if we have a callback, add it as a listener
-	napi_ref callbackRef = nullptr;
+	std::shared_ptr<ListenerCallback> listener;
 	napi_valuetype type;
 	NAPI_STATUS_THROWS(::napi_typeof(env, argv[2], &type));
 	if (type != napi_undefined) {
 		if (type == napi_function) {
 			DEBUG_LOG("Database::GetUserSharedBuffer key start=%u end=%u:", keyStart, keyEnd);
 			DEBUG_LOG_KEY_LN(keyStr);
-			callbackRef = (*dbHandle)->descriptor->addListener(env, keyStr, argv[2], *dbHandle);
+			listener = (*dbHandle)->descriptor->addListener(env, keyStr, argv[2], *dbHandle);
 		} else {
 			::napi_throw_error(env, nullptr, "Callback must be a function");
 			return nullptr;
 		}
 	}
 
-	return (*dbHandle)->descriptor->getUserSharedBuffer(env, keyStr, *dbHandle, argv[1], callbackRef);
+	return (*dbHandle)->descriptor->getUserSharedBuffer(env, keyStr, *dbHandle, argv[1], std::move(listener));
 }
 
 /**

--- a/src/binding/database/db_descriptor.cpp
+++ b/src/binding/database/db_descriptor.cpp
@@ -1569,15 +1569,10 @@ static void userSharedBufferFinalize(napi_env env, void* unusedData, void* hint)
 
 	if (auto dbHandle = finalizeData->dbHandle.lock()) {
 		DEBUG_LOG("userSharedBufferFinalize GC'd dbHandle=%p\n", dbHandle.get());
-		// Remove the listener registered for this buffer's key by identity, but
-		// only while it is still live. The listener's napi_ref is owned by its
-		// threadsafe function, which deletes it once the listener is torn down
-		// (on close / env teardown), so re-resolving the ref here would be a
-		// use-after-free during shutdown (HarperFast/rocksdb-js#790). A live
-		// weak_ptr means the listener is still in the emitter's map; if it has
-		// already been removed (e.g. by close's removeListenersByOwner, which
-		// runs before descriptor.reset()), the lock fails and there is nothing
-		// to do.
+		// Remove this buffer's listener by identity, never by its napi_ref: the
+		// ref is owned by the listener's tsfn (see UserSharedBufferFinalizeData),
+		// so re-resolving it here was the shutdown UAF in #790. removeListener is
+		// a no-op if the listener is already gone (close / env teardown).
 		if (auto listener = finalizeData->listener.lock()) {
 			if (dbHandle->descriptor) {
 				DEBUG_LOG("%p userSharedBufferFinalize removing listener for key:", dbHandle.get());

--- a/src/binding/database/db_descriptor.cpp
+++ b/src/binding/database/db_descriptor.cpp
@@ -1699,7 +1699,7 @@ napi_value DBDescriptor::removeListener(napi_env env, std::string& key, napi_val
 	return this->events.removeListener(env, key, callback);
 }
 
-void DBDescriptor::removeListener(std::string& key, const std::shared_ptr<ListenerCallback>& target) {
+void DBDescriptor::removeListener(const std::string& key, const std::shared_ptr<ListenerCallback>& target) {
 	this->events.removeListener(key, target);
 }
 

--- a/src/binding/database/db_descriptor.cpp
+++ b/src/binding/database/db_descriptor.cpp
@@ -1569,19 +1569,21 @@ static void userSharedBufferFinalize(napi_env env, void* unusedData, void* hint)
 
 	if (auto dbHandle = finalizeData->dbHandle.lock()) {
 		DEBUG_LOG("userSharedBufferFinalize GC'd dbHandle=%p\n", dbHandle.get());
-		if (finalizeData->callbackRef) {
-			napi_value callback;
-			if (::napi_get_reference_value(env, finalizeData->callbackRef, &callback) == napi_ok) {
+		// Remove the listener registered for this buffer's key by identity, but
+		// only while it is still live. The listener's napi_ref is owned by its
+		// threadsafe function, which deletes it once the listener is torn down
+		// (on close / env teardown), so re-resolving the ref here would be a
+		// use-after-free during shutdown (HarperFast/rocksdb-js#790). A live
+		// weak_ptr means the listener is still in the emitter's map; if it has
+		// already been removed (e.g. by close's removeListenersByOwner, which
+		// runs before descriptor.reset()), the lock fails and there is nothing
+		// to do.
+		if (auto listener = finalizeData->listener.lock()) {
+			if (dbHandle->descriptor) {
 				DEBUG_LOG("%p userSharedBufferFinalize removing listener for key:", dbHandle.get());
 				DEBUG_LOG_KEY_LN(finalizeData->key);
-				if (dbHandle->descriptor) {
-					DEBUG_LOG("%p userSharedBufferFinalize descriptor is still alive %p", dbHandle.get(), dbHandle->descriptor.get());
-					dbHandle->descriptor->removeListener(env, finalizeData->key, callback);
-				} else {
-					DEBUG_LOG("%p userSharedBufferFinalize descriptor is not alive %p", dbHandle.get(), dbHandle->descriptor.get());
-				}
+				dbHandle->descriptor->removeListener(finalizeData->key, listener);
 			}
-			finalizeData->callbackRef = nullptr;
 		}
 	} else {
 		DEBUG_LOG("userSharedBufferFinalize GC'd dbHandle was already destroyed for key:");
@@ -1611,7 +1613,7 @@ napi_value DBDescriptor::getUserSharedBuffer(
 	std::string& key,
 	std::shared_ptr<DBHandle> dbHandle,
 	napi_value defaultBuffer,
-	napi_ref callbackRef
+	std::shared_ptr<ListenerCallback> listener
 ) {
 	bool isArrayBuffer;
 	NAPI_STATUS_THROWS(::napi_is_arraybuffer(env, defaultBuffer, &isArrayBuffer));
@@ -1655,7 +1657,7 @@ napi_value DBDescriptor::getUserSharedBuffer(
 		std::weak_ptr<DBHandle>(dbHandle),
 		std::weak_ptr<ColumnFamilyDescriptor>(dbHandle->columnDescriptor),
 		userSharedBuffer,
-		callbackRef
+		std::weak_ptr<ListenerCallback>(listener)
 	);
 
 	napi_value result;
@@ -1673,7 +1675,7 @@ napi_value DBDescriptor::getUserSharedBuffer(
 /**
  * Adds an event listener to this descriptor's event emitter.
  */
-napi_ref DBDescriptor::addListener(
+std::shared_ptr<ListenerCallback> DBDescriptor::addListener(
 	napi_env env,
 	std::string& key,
 	napi_value callback,
@@ -1700,6 +1702,10 @@ napi_value DBDescriptor::listeners(napi_env env, std::string& key) {
 
 napi_value DBDescriptor::removeListener(napi_env env, std::string& key, napi_value callback) {
 	return this->events.removeListener(env, key, callback);
+}
+
+void DBDescriptor::removeListener(std::string& key, const std::shared_ptr<ListenerCallback>& target) {
+	this->events.removeListener(key, target);
 }
 
 void DBDescriptor::removeListenersByOwner(DBHandle* owner) {

--- a/src/binding/database/db_descriptor.h
+++ b/src/binding/database/db_descriptor.h
@@ -370,21 +370,22 @@ public:
 	 * @param key The key of the user shared buffer.
 	 * @param defaultBuffer The default buffer to use if the user shared buffer does
 	 * not exist.
-	 * @param callbackRef An optional callback reference to remove the listener when
-	 * the user shared buffer is garbage collected.
+	 * @param listener An optional listener (from addListener) to remove when the
+	 * user shared buffer is garbage collected.
 	 */
 	napi_value getUserSharedBuffer(
 		napi_env env,
 		std::string& key,
 		std::shared_ptr<DBHandle> dbHandle,
 		napi_value defaultBuffer,
-		napi_ref callbackRef = nullptr
+		std::shared_ptr<ListenerCallback> listener = nullptr
 	);
 
-	napi_ref addListener(napi_env env, std::string& key, napi_value callback, std::weak_ptr<DBHandle> owner);
+	std::shared_ptr<ListenerCallback> addListener(napi_env env, std::string& key, napi_value callback, std::weak_ptr<DBHandle> owner);
 	bool notify(std::string key, ListenerData* data);
 	napi_value listeners(napi_env env, std::string& key);
 	napi_value removeListener(napi_env env, std::string& key, napi_value callback);
+	void removeListener(std::string& key, const std::shared_ptr<ListenerCallback>& target);
 	void removeListenersByOwner(DBHandle* owner);
 	void removeListenersByEnv(napi_env env);
 
@@ -528,21 +529,27 @@ struct UserSharedBufferData final {
  * until JS releases every retained ArrayBuffer for the key. The weak pointers
  * to `DBHandle` / `ColumnFamilyDescriptor` are used for opportunistic cleanup
  * (removing listeners, erasing map entries) when those are still alive.
+ *
+ * The listener is held as a `weak_ptr` (not the raw `napi_ref`): the ref's
+ * ownership belongs to the listener's threadsafe function, which deletes it
+ * once the listener is torn down. A `weak_ptr` lets the finalizer remove the
+ * listener by identity only while it is still live, without ever dereferencing
+ * a ref it does not own (HarperFast/rocksdb-js#790).
  */
 struct UserSharedBufferFinalizeData final {
 	std::string key;
 	std::weak_ptr<DBHandle> dbHandle;
 	std::weak_ptr<ColumnFamilyDescriptor> columnDescriptor;
 	std::shared_ptr<UserSharedBufferData> sharedData;
-	napi_ref callbackRef;
+	std::weak_ptr<ListenerCallback> listener;
 
 	UserSharedBufferFinalizeData(
 		const std::string& k,
 		std::weak_ptr<DBHandle> d,
 		std::weak_ptr<ColumnFamilyDescriptor> c,
 		std::shared_ptr<UserSharedBufferData> data,
-		napi_ref callbackRef = nullptr
-	) : key(k), dbHandle(d), columnDescriptor(c), sharedData(std::move(data)), callbackRef(callbackRef) {}
+		std::weak_ptr<ListenerCallback> listener = {}
+	) : key(k), dbHandle(d), columnDescriptor(c), sharedData(std::move(data)), listener(std::move(listener)) {}
 };
 
 /**

--- a/src/binding/database/db_descriptor.h
+++ b/src/binding/database/db_descriptor.h
@@ -385,7 +385,7 @@ public:
 	bool notify(std::string key, ListenerData* data);
 	napi_value listeners(napi_env env, std::string& key);
 	napi_value removeListener(napi_env env, std::string& key, napi_value callback);
-	void removeListener(std::string& key, const std::shared_ptr<ListenerCallback>& target);
+	void removeListener(const std::string& key, const std::shared_ptr<ListenerCallback>& target);
 	void removeListenersByOwner(DBHandle* owner);
 	void removeListenersByEnv(napi_env env);
 

--- a/src/binding/napi/event_emitter.cpp
+++ b/src/binding/napi/event_emitter.cpp
@@ -455,11 +455,8 @@ void EventEmitter::removeListener(const std::string& key, const std::shared_ptr<
 	}
 
 	auto& listeners = it->second;
-	for (auto listener = listeners.begin(); listener != listeners.end(); ++listener) {
-		if (*listener != target) {
-			continue;
-		}
-
+	auto listener = std::find(listeners.begin(), listeners.end(), target);
+	if (listener != listeners.end()) {
 		// Release the tsfn first (queues napi_ref deletion on the JS thread via
 		// the tsfn finalizer), then erase. No napi_ref is dereferenced here, so
 		// this is safe from a finalizer during teardown.
@@ -468,7 +465,6 @@ void EventEmitter::removeListener(const std::string& key, const std::shared_ptr<
 		this->listenerCount.fetch_sub(1, std::memory_order_relaxed);
 		DEBUG_LOG("%p EventEmitter::removeListener (by identity) removed listener for key:", this);
 		DEBUG_LOG_KEY_LN(key);
-		break;
 	}
 
 	if (listeners.empty()) {

--- a/src/binding/napi/event_emitter.cpp
+++ b/src/binding/napi/event_emitter.cpp
@@ -163,7 +163,7 @@ ListenerData* serializeListenerArgs(napi_env env, napi_value value) {
 	return data;
 }
 
-napi_ref EventEmitter::addListener(
+std::shared_ptr<ListenerCallback> EventEmitter::addListener(
 	napi_env env,
 	const std::string& key,
 	napi_value callback,
@@ -265,7 +265,7 @@ napi_ref EventEmitter::addListener(
 	DEBUG_LOG_KEY(key);
 	DEBUG_LOG_MSG(" (listeners=%zu)\n", it->second.size());
 
-	return callbackRef;
+	return listenerCallback;
 }
 
 bool EventEmitter::notify(const std::string& key, ListenerData* data) {
@@ -441,6 +441,39 @@ napi_value EventEmitter::removeListener(napi_env env, const std::string& key, na
 	napi_value result;
 	NAPI_STATUS_THROWS(::napi_get_boolean(env, found, &result));
 	return result;
+}
+
+void EventEmitter::removeListener(const std::string& key, const std::shared_ptr<ListenerCallback>& target) {
+	if (!target) {
+		return;
+	}
+
+	std::lock_guard<std::mutex> lock(this->mutex);
+	auto it = this->callbacks.find(key);
+	if (it == this->callbacks.end()) {
+		return;
+	}
+
+	auto& listeners = it->second;
+	for (auto listener = listeners.begin(); listener != listeners.end(); ++listener) {
+		if (*listener != target) {
+			continue;
+		}
+
+		// Release the tsfn first (queues napi_ref deletion on the JS thread via
+		// the tsfn finalizer), then erase. No napi_ref is dereferenced here, so
+		// this is safe from a finalizer during teardown.
+		releaseListenerResources(**listener);
+		listeners.erase(listener);
+		this->listenerCount.fetch_sub(1, std::memory_order_relaxed);
+		DEBUG_LOG("%p EventEmitter::removeListener (by identity) removed listener for key:", this);
+		DEBUG_LOG_KEY_LN(key);
+		break;
+	}
+
+	if (listeners.empty()) {
+		this->callbacks.erase(it);
+	}
 }
 
 void EventEmitter::removeListenersByOwner(void* owner) {

--- a/src/binding/napi/event_emitter.h
+++ b/src/binding/napi/event_emitter.h
@@ -158,9 +158,12 @@ public:
 	 * @param callback The JS function to invoke when the event is emitted.
 	 * @param owner Optional weak reference to the owning object. Defaults to
 	 *              an empty weak_ptr for ownerless listeners (global emitter).
-	 * @returns The napi_ref backing the callback, suitable for later removal.
+	 * @returns The registered listener, or nullptr on failure. Callers that need
+	 *          a lifetime-safe removal handle (e.g. the user-shared-buffer
+	 *          finalizer) hold a std::weak_ptr to it; the backing napi_ref is
+	 *          reachable via `->callbackRef` while the listener is live.
 	 */
-	napi_ref addListener(
+	std::shared_ptr<ListenerCallback> addListener(
 		napi_env env,
 		const std::string& key,
 		napi_value callback,
@@ -204,6 +207,16 @@ public:
 	 * found and removed.
 	 */
 	napi_value removeListener(napi_env env, const std::string& key, napi_value callback);
+
+	/**
+	 * Removes a specific listener by identity (the shared_ptr returned from
+	 * addListener) for the given key. Env-free and does not touch the listener's
+	 * napi_ref, so it is safe to call from a finalizer during env/process
+	 * teardown -- the tsfn (and, through it, the napi_ref) is released here, but
+	 * the ref itself is deleted later on the JS thread by the tsfn finalizer.
+	 * A no-op if `target` is null or no longer registered.
+	 */
+	void removeListener(const std::string& key, const std::shared_ptr<ListenerCallback>& target);
 
 	/**
 	 * Removes all listeners owned by the given raw pointer. The pointer must

--- a/test/fixtures/fork-user-shared-buffer-shutdown.mts
+++ b/test/fixtures/fork-user-shared-buffer-shutdown.mts
@@ -1,0 +1,62 @@
+/**
+ * Repro for the user-shared-buffer finalize use-after-free observed during
+ * Harper shutdown (ctrl-C) on macOS. The reported crash:
+ *
+ *   userSharedBufferFinalize -> napi_get_reference_value  (EXC_BAD_ACCESS)
+ *   ... BufferFinalizer::FinalizeBufferCallback
+ *   ... Environment::RunCleanup
+ *   ... FreeEnvironment (worker / process teardown)
+ *
+ * Scenario (a graceful shutdown while a shared buffer is still referenced):
+ * 1. Open a DB and get one or more user-shared ArrayBuffers WITH a callback, so
+ *    a listener (napi_ref + threadsafe function) is registered for each.
+ * 2. Shut the DB down (`db.close()` -> removeListenersByOwner releases each
+ *    listener's tsfn, whose finalizer deletes the backing napi_ref).
+ * 3. Keep the ArrayBuffers referenced and let the process exit NATURALLY (no
+ *    `process.exit()`), so Environment::RunCleanup finalizes the still-live
+ *    external ArrayBuffers.
+ *
+ * `userSharedBufferFinalize` then reads `finalizeData->callbackRef` via
+ * `napi_get_reference_value` -- but that ref's ownership was transferred to the
+ * (now torn-down) listener tsfn in `addListener`, so it has already been
+ * deleted: a use-after-free. On a plain build the freed slot usually reads back
+ * benign; under an instrumented allocator (Guard Malloc on macOS, ASan on
+ * Linux) it faults, which is how the test surfaces it deterministically.
+ *
+ * Exit 0 = survived (expected once the finalizer stops touching the borrowed
+ * callbackRef); a crash/non-zero exit = the UAF reproduced.
+ */
+import { RocksDatabase } from '../../src/index.ts';
+import { mkdirSync } from 'node:fs';
+
+const dbPath = process.argv[2];
+
+if (!dbPath) {
+	console.error('Usage: fork-user-shared-buffer-shutdown.mts <dbPath>');
+	process.exit(1);
+}
+
+mkdirSync(dbPath, { recursive: true });
+
+const db = RocksDatabase.open(dbPath, { name: 'shutdown-cf' });
+
+// Retain several buffers-with-callbacks so they are still "in use" at shutdown.
+const held: ArrayBuffer[] = [];
+for (let i = 0; i < 16; i++) {
+	const buffer = db.getUserSharedBuffer(`shutdown-key-${i}`, new ArrayBuffer(8), {
+		callback() {
+			// presence of the listener is what matters, not its body
+		},
+	});
+	new DataView(buffer).setBigUint64(0, 1n);
+	held.push(buffer);
+}
+// Keep them reachable past `db.close()` so teardown must finalize them.
+(globalThis as unknown as { __heldBuffers?: ArrayBuffer[] }).__heldBuffers = held;
+
+// Graceful shutdown: tear the DB down while the buffers are still referenced.
+db.close();
+
+// Intentionally no `process.exit()`: allow a natural exit so the finalizers run
+// during Environment::RunCleanup -- the crashing path from the report.
+console.log('SUCCESS');

--- a/test/user-shared-buffer-shutdown.test.ts
+++ b/test/user-shared-buffer-shutdown.test.ts
@@ -1,6 +1,6 @@
 import { generateDBPath } from './lib/util.ts';
 import { spawn } from 'node:child_process';
-import { existsSync } from 'node:fs';
+import { existsSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
@@ -74,6 +74,11 @@ function spawnShutdownRepro(
 		child.on('close', (code, signal) => {
 			if (code !== 0 || signal) {
 				console.error(`Shutdown repro stderr:\n${stderr}`);
+			}
+			// The child creates the DB dir; clean it up so repeated runs don't
+			// accumulate databases under the temp dir (honoring KEEP_FILES).
+			if (!process.env.KEEP_FILES) {
+				rmSync(dbPath, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
 			}
 			resolve({ code, signal });
 		});

--- a/test/user-shared-buffer-shutdown.test.ts
+++ b/test/user-shared-buffer-shutdown.test.ts
@@ -1,0 +1,82 @@
+import { generateDBPath } from './lib/util.ts';
+import { spawn } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Regression repro for the user-shared-buffer finalize use-after-free seen on
+ * Harper shutdown (ctrl-C) on macOS:
+ *
+ *   userSharedBufferFinalize -> napi_get_reference_value  (SIGSEGV)
+ *   ... Environment::RunCleanup -> FreeEnvironment (teardown)
+ *
+ * `userSharedBufferFinalize` reads the buffer's borrowed `callbackRef`, but that
+ * napi_ref is owned by the listener's threadsafe function and has already been
+ * deleted once the DB (and its listeners) were torn down at shutdown. See
+ * `test/fixtures/fork-user-shared-buffer-shutdown.mts` for the full scenario.
+ *
+ * Runs in a child process because a regression SIGSEGVs rather than throwing a
+ * catchable error. On a plain build the freed napi_ref slot usually reads back
+ * benign, so the child is run under Apple's Guard Malloc to make the UAF fault
+ * deterministically. This is macOS-only: Guard Malloc is macOS-specific, ASan
+ * does not work locally on recent macOS (see AGENTS.md), and a plain run on any
+ * other platform is a false green (and can flake if the freed ref slot gets
+ * reused), so it is skipped there rather than run without instrumentation.
+ */
+describe('User shared buffer shutdown use-after-free repro (child process)', () => {
+	const fixturePath = join(__dirname, 'fixtures', 'fork-user-shared-buffer-shutdown.mts');
+	const GUARD_MALLOC = '/usr/lib/libgmalloc.dylib';
+
+	// macOS + Guard Malloc + Node only (Bun/Deno don't run this fixture under
+	// Node's native type stripping the same way).
+	const runnable =
+		process.platform === 'darwin' &&
+		existsSync(GUARD_MALLOC) &&
+		!process.versions.bun &&
+		!process.versions.deno;
+
+	it.runIf(runnable)(
+		'should survive shutdown while user shared buffers with callbacks are still in use',
+		async () => {
+			// Loop: teardown-order UAFs only fault on a fraction of runs even under
+			// Guard Malloc, so a single shot can mask a regression.
+			for (let i = 0; i < 5; i++) {
+				const { code, signal } = await spawnShutdownRepro(fixturePath);
+				expect(signal, `iteration=${i}`).toBeNull();
+				expect(code, `iteration=${i}`).toBe(0);
+			}
+		},
+		30_000
+	);
+});
+
+function spawnShutdownRepro(
+	fixturePath: string
+): Promise<{ code: number | null; signal: NodeJS.Signals | null }> {
+	return new Promise((resolve, reject) => {
+		const dbPath = generateDBPath();
+		// Fault immediately on the use-after-free instead of reading benign freed
+		// memory. MallocScribble poisons freed blocks so a stale read is more
+		// likely to be caught even outside the guard page.
+		const env = {
+			...process.env,
+			DYLD_INSERT_LIBRARIES: '/usr/lib/libgmalloc.dylib',
+			MallocScribble: '1',
+		};
+
+		const child = spawn(process.execPath, [fixturePath, dbPath], { env });
+
+		let stderr = '';
+		child.stderr?.on('data', (chunk) => {
+			stderr += chunk.toString();
+		});
+		child.on('close', (code, signal) => {
+			if (code !== 0 || signal) {
+				console.error(`Shutdown repro stderr:\n${stderr}`);
+			}
+			resolve({ code, signal });
+		});
+		child.on('error', reject);
+	});
+}


### PR DESCRIPTION
Fixes #790.

## Problem

Sending `ctrl-c` to quit Harper crashed during shutdown (SIGSEGV) on macOS. The faulting frame:

```
napi_get_reference_value                       <- EXC_BAD_ACCESS
rocksdb_js::userSharedBufferFinalize
... BufferFinalizer::FinalizeBufferCallback
... Environment::RunCleanup / FreeEnvironment  <- worker/process teardown
```

`getUserSharedBuffer(key, buf, { callback })` registers a listener whose `napi_ref` ownership is **transferred to the listener's threadsafe function** in `addListener` (the tsfn finalizer `napi_delete_reference`s it). The buffer's `UserSharedBufferFinalizeData` also stashed that same raw ref as a borrowed pointer. At shutdown the listener is torn down (`removeListenersByOwner` on `db.close()`, or `removeListenersByEnv` on env teardown) → the tsfn finalizer deletes the ref → then `userSharedBufferFinalize` calls `napi_get_reference_value` on the **freed ref**: a use-after-free.

On a plain build the freed slot usually reads back benign, so it only bit intermittently in production. It needs no worker or GC — a plain main-thread `db.close()` + natural process exit reproduces it, because the ref lifetime belongs to the tsfn, not the finalizer.

## Fix

Remove the listener **by identity** instead of re-resolving a ref the finalizer doesn't own:

- `EventEmitter::addListener` now returns the `std::shared_ptr<ListenerCallback>` it already allocates (was `napi_ref`).
- `UserSharedBufferFinalizeData` holds a `std::weak_ptr<ListenerCallback>` instead of the raw `napi_ref`.
- New env-free overload `EventEmitter::removeListener(key, target)` releases the tsfn (which queues the ref deletion on the JS thread, as before) and erases the map entry — **without touching the napi_ref**.

The finalizer locks the weak_ptr and, only if the listener is still registered, removes it by identity. If it was already torn down (`db.close()` runs `removeListenersByOwner` before `descriptor.reset()`), the lock fails and there's nothing to do. The map holds the sole strong ref to the `ListenerCallback`, and close/env-teardown/finalizer all run on the same env thread, so there's no cross-thread lifetime race.

The `buffer.cancel()` / `db.removeListener(key, fn)` path (removal by function value) and the "cleanup callbacks on GC" behavior are unchanged.

## Testing

- New macOS-only, Guard-Malloc-gated child-process regression test (`test/user-shared-buffer-shutdown.test.ts` + fixture): opens a DB, gets user-shared buffers **with callbacks**, `db.close()`, keeps them referenced, and exits naturally so `RunCleanup` finalizes them. **SIGSEGVs before this change, passes after** (verified 20+ runs under Guard Malloc across three repro variants). Gated to macOS because a plain build reads benign freed memory and can't fault deterministically.
- All existing user-shared-buffer, notify, events, global-events, notify-teardown, and shutdown suites pass. `pnpm check` (type-check, lint, format) is clean.

## Reviews

Deep review (two independent passes) and cross-model review (Codex + Gemini): **no crash-safety, concurrency, lifetime, or security blockers.** Follow-ups addressed here: repro DB dirs are now cleaned up (honoring `KEEP_FILES`), and an overbroad finalizer comment was tightened. Two Gemini "majors" were false positives (the `store.ts` layer unwraps `options.callback` before native; `.mts` type-stripping is unflagged at the repo's engines floor and existing fixtures spawn identically — the test runs green).

## Pre-existing follow-ups (out of scope, noted for tracking)

- `getUserSharedBuffer` allocates `finalizeData` before `napi_create_external_arraybuffer`; on that (rare) failure it leaks. RAII cleanup would tidy it.
- If `defaultBuffer` isn't an ArrayBuffer, the listener is registered before the validation throw, so it lingers until `close()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
