### PR TITLE
fix(txnlog): scan recovery framing from the file, not a whole-image buffer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -384,8 +384,8 @@ sufficient (env teardown does not honor tsfn acquire counts); see
     order, so an interrupted log write is always the newest thing in the log and its RocksDB commit
     never ran. Recovery walks entry headers via positional reads (never a whole-file buffer);
     payload bytes are skipped. Discarding is gated on proof that the writer sets the flag — a
-    boundary earlier in the same
-    file — plus a single timestamp across the trailing run. Callers can assign repeated timestamps,
+    boundary earlier in the same file — plus a single timestamp across the trailing run. Callers can
+    assign repeated timestamps,
     but an earlier transaction would still carry its own flag and reset the run. Without that proof
     the bytes are kept and warned about: a batch split across a rotation has no boundary in the
     active file, and a log written before the flag existed would otherwise be truncated wholesale.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -382,7 +382,9 @@ sufficient (env teardown does not honor tsfn acquire counts); see
     anything grouping on the flag. Discarding is safe because `writeBatch()` completes before
     `Transaction::Commit()` in every commit path and both commit-thread lanes preserve dispatch
     order, so an interrupted log write is always the newest thing in the log and its RocksDB commit
-    never ran. It is gated on proof that the writer sets the flag — a boundary earlier in the same
+    never ran. Recovery walks entry headers via positional reads (never a whole-file buffer);
+    payload bytes are skipped. Discarding is gated on proof that the writer sets the flag — a
+    boundary earlier in the same
     file — plus a single timestamp across the trailing run. Callers can assign repeated timestamps,
     but an earlier transaction would still carry its own flag and reset the run. Without that proof
     the bytes are kept and warned about: a batch split across a rotation has no boundary in the

--- a/src/binding/transaction_log/transaction_log_file.cpp
+++ b/src/binding/transaction_log/transaction_log_file.cpp
@@ -1,7 +1,9 @@
+#include <cerrno>
 #include <cmath>
 #include <fstream>
 #include <limits>
 #include <sstream>
+#include <string>
 #include <system_error>
 #include <vector>
 #include "napi/global_events.h"
@@ -151,6 +153,41 @@ void TransactionLogFile::open(const double latestTimestamp) {
 	}
 }
 
+bool TransactionLogFile::readFullyFromFile(uint32_t offset, void* dest, uint32_t n) {
+	auto* out = static_cast<char*>(dest);
+	uint32_t remaining = n;
+	uint32_t at = offset;
+	while (remaining > 0) {
+		int64_t got = this->readFromFile(out, remaining, static_cast<int64_t>(at));
+		if (got < 0) {
+#ifdef PLATFORM_POSIX
+			if (errno == EINTR) {
+				continue;
+			}
+#endif
+			return false;
+		}
+		if (got == 0) {
+			return false;
+		}
+		out += got;
+		at += static_cast<uint32_t>(got);
+		remaining -= static_cast<uint32_t>(got);
+	}
+	return true;
+}
+
+RecoveryScan TransactionLogFile::scanRecoveryLocked() {
+	uint32_t fileSize = this->size.load(std::memory_order_relaxed);
+	return scanTransactionLogForRecovery(
+		fileSize,
+		[](void* context, uint32_t offset, void* dest, uint32_t n) {
+			return static_cast<TransactionLogFile*>(context)->readFullyFromFile(offset, dest, n);
+		},
+		this
+	);
+}
+
 uint32_t TransactionLogFile::scanForLastCompleteTransactionEnd() {
 	std::lock_guard<std::mutex> fileLock(this->fileMutex);
 
@@ -163,17 +200,14 @@ uint32_t TransactionLogFile::scanForLastCompleteTransactionEnd() {
 		return 0; // header-only or empty: no transactions at all
 	}
 
-	std::vector<char> buffer(fileSize);
-	int64_t bytesRead = this->readFromFile(buffer.data(), fileSize, 0);
-	if (bytesRead < 0 || static_cast<uint32_t>(bytesRead) != fileSize) {
-		DEBUG_LOG("%p TransactionLogFile::scanForLastCompleteTransactionEnd Failed to read file: %s (read=%lld, size=%u)\n",
-			this, this->path.string().c_str(), static_cast<long long>(bytesRead), fileSize);
-		return 0;
+	RecoveryScan scan;
+	try {
+		scan = this->scanRecoveryLocked();
+	} catch (const DBException& error) {
+		throw DBException(std::string(error.what()) + ": " + this->path.string());
 	}
-
-	uint32_t end = findLastCompleteTransactionEnd(buffer.data(), fileSize);
-	this->lastCompleteTransactionEnd.store(end, std::memory_order_relaxed);
-	return end;
+	this->lastCompleteTransactionEnd.store(scan.lastCompleteTransactionEnd, std::memory_order_relaxed);
+	return scan.lastCompleteTransactionEnd;
 }
 
 void TransactionLogFile::recoverTail(uint32_t protectedPosition) {
@@ -188,17 +222,12 @@ void TransactionLogFile::recoverTail(uint32_t protectedPosition) {
 		return; // header-only or empty: nothing to recover
 	}
 
-	// Read the whole file image for the framing scan. This runs once, at open
-	// time, on the active log file only — never on a hot path.
-	std::vector<char> buffer(fileSize);
-	int64_t bytesRead = this->readFromFile(buffer.data(), fileSize, 0);
-	if (bytesRead < 0 || static_cast<uint32_t>(bytesRead) != fileSize) {
-		DEBUG_LOG("%p TransactionLogFile::recoverTail Failed to read file for recovery scan: %s (read=%lld, size=%u)\n",
-			this, this->path.string().c_str(), static_cast<long long>(bytesRead), fileSize);
-		return;
+	RecoveryScan scan;
+	try {
+		scan = this->scanRecoveryLocked();
+	} catch (const DBException& error) {
+		throw DBException(std::string(error.what()) + ": " + this->path.string());
 	}
-
-	RecoveryScan scan = scanTransactionLogForRecovery(buffer.data(), fileSize);
 	// Publish the complete-transaction boundary from this same scan so the store can
 	// seed its committed watermark without re-reading the file.
 	this->lastCompleteTransactionEnd.store(scan.lastCompleteTransactionEnd, std::memory_order_relaxed);

--- a/src/binding/transaction_log/transaction_log_file.cpp
+++ b/src/binding/transaction_log/transaction_log_file.cpp
@@ -158,6 +158,9 @@ bool TransactionLogFile::readFullyFromFile(uint32_t offset, void* dest, uint32_t
 	uint32_t remaining = n;
 	uint32_t at = offset;
 	while (remaining > 0) {
+#ifdef PLATFORM_POSIX
+		errno = 0;
+#endif
 		int64_t got = this->readFromFile(out, remaining, static_cast<int64_t>(at));
 		if (got < 0) {
 #ifdef PLATFORM_POSIX

--- a/src/binding/transaction_log/transaction_log_file.cpp
+++ b/src/binding/transaction_log/transaction_log_file.cpp
@@ -153,7 +153,7 @@ void TransactionLogFile::open(const double latestTimestamp) {
 	}
 }
 
-bool TransactionLogFile::readFullyFromFile(uint32_t offset, void* dest, uint32_t n) {
+bool TransactionLogFile::readBytes(uint32_t offset, void* dest, uint32_t n) {
 	auto* out = static_cast<char*>(dest);
 	uint32_t remaining = n;
 	uint32_t at = offset;
@@ -185,7 +185,7 @@ RecoveryScan TransactionLogFile::scanRecoveryLocked() {
 	return scanTransactionLogForRecovery(
 		fileSize,
 		[](void* context, uint32_t offset, void* dest, uint32_t n) {
-			return static_cast<TransactionLogFile*>(context)->readFullyFromFile(offset, dest, n);
+			return static_cast<TransactionLogFile*>(context)->readBytes(offset, dest, n);
 		},
 		this
 	);

--- a/src/binding/transaction_log/transaction_log_file.h
+++ b/src/binding/transaction_log/transaction_log_file.h
@@ -433,7 +433,7 @@ private:
 	 * Reads `n` bytes at `offset` via readFromFile, retrying short reads and EINTR.
 	 * Precondition: caller holds fileMutex. Returns false on error or unexpected EOF.
 	 */
-	bool readFullyFromFile(uint32_t offset, void* dest, uint32_t n);
+	bool readBytes(uint32_t offset, void* dest, uint32_t n);
 
 	/**
 	 * Platform specific function that writes multiple buffers to the log file.

--- a/src/binding/transaction_log/transaction_log_file.h
+++ b/src/binding/transaction_log/transaction_log_file.h
@@ -10,6 +10,7 @@
 #include "core/encoding.h"
 #include "core/exception.h"
 #include "core/platform.h"
+#include "transaction_log/transaction_log_recovery.h"
 
 #ifdef _WIN32
 	#define PLATFORM_WINDOWS
@@ -58,9 +59,6 @@ namespace rocksdb_js {
 // forward declarations
 struct MemoryMap;
 struct TransactionLogEntryBatch;
-// defined in transaction_log_recovery.h, which includes this header for the
-// framing constants — so it can only be forward declared here
-struct RecoveryScan;
 
 struct TransactionLogFile final {
 	/**
@@ -110,9 +108,10 @@ struct TransactionLogFile final {
 	 * Offset just past the last entry that closed a transaction (carried
 	 * `TRANSACTION_LOG_ENTRY_LAST_FLAG`), as observed by the open-time recovery
 	 * scan; 0 if this file holds no complete transaction or was never scanned.
-	 * Only written by recoverTail() before the store is published, and read by
-	 * TransactionLogStore::load() to seed the committed watermark — see
-	 * scanForLastCompleteTransactionEnd() for files that skip recovery.
+	 * Only written by recoverTail() / scanForLastCompleteTransactionEnd() before
+	 * the store is published, and read by TransactionLogStore::load() to seed the
+	 * committed watermark — see scanForLastCompleteTransactionEnd() for files that
+	 * skip recovery.
 	 */
 	std::atomic<uint32_t> lastCompleteTransactionEnd = 0;
 
@@ -251,6 +250,14 @@ struct TransactionLogFile final {
 	void recoverTail(uint32_t protectedPosition = 0);
 
 	/**
+	 * Open-time framing scan via positional header reads. Precondition: the caller
+	 * holds fileMutex. Throws DBException if a read fails or is short of the
+	 * requested bytes — that is not a torn tail. Recovery bounds the walk by
+	 * this->size (append-owned written extent), not the mapped/pre-extended size.
+	 */
+	RecoveryScan scanRecoveryLocked();
+
+	/**
 	 * Drops the trailing entries of a transaction that never closed, so the file
 	 * ends on a transaction boundary. Unlike the torn-tail truncation these are
 	 * whole, well-framed entries — only the batch's final entry carries
@@ -272,10 +279,11 @@ struct TransactionLogFile final {
 	void resetTimestampIndex();
 
 	/**
-	 * Reads this file and returns the offset just past its last complete
-	 * transaction (0 if it holds none). recoverTail() already computes this for
-	 * the active file; this is for the older, rotated files the store walks back
-	 * through when the active one ends mid-transaction.
+	 * Returns the offset just past this file's last complete transaction (0 if it
+	 * holds none). recoverTail() already computes this for the active file; this
+	 * is for the older, rotated files the store walks back through when the active
+	 * one ends mid-transaction. Throws DBException on I/O failure; load() catches
+	 * that and falls back toward txn.state.
 	 */
 	uint32_t scanForLastCompleteTransactionEnd();
 
@@ -420,6 +428,12 @@ private:
 	 * Platform specific function that reads data from the log file.
 	 */
 	int64_t readFromFile(void* buffer, uint32_t size, int64_t offset = -1);
+
+	/**
+	 * Reads `n` bytes at `offset` via readFromFile, retrying short reads and EINTR.
+	 * Precondition: caller holds fileMutex. Returns false on error or unexpected EOF.
+	 */
+	bool readFullyFromFile(uint32_t offset, void* dest, uint32_t n);
 
 	/**
 	 * Platform specific function that writes multiple buffers to the log file.

--- a/src/binding/transaction_log/transaction_log_file_windows.cpp
+++ b/src/binding/transaction_log/transaction_log_file_windows.cpp
@@ -331,8 +331,12 @@ std::shared_ptr<MemoryMap> TransactionLogFile::getMemoryMapLocked(uint32_t fileS
 }
 
 int64_t TransactionLogFile::readFromFile(void* buffer, uint32_t size, int64_t offset) {
-	if (offset >= 0 && ::SetFilePointer(this->fileHandle, offset, nullptr, FILE_BEGIN) == INVALID_SET_FILE_POINTER) {
-		return -1;
+	if (offset >= 0) {
+		LARGE_INTEGER distance;
+		distance.QuadPart = offset;
+		if (!::SetFilePointerEx(this->fileHandle, distance, nullptr, FILE_BEGIN)) {
+			return -1;
+		}
 	}
 
 	DWORD bytesRead;

--- a/src/binding/transaction_log/transaction_log_recovery.cpp
+++ b/src/binding/transaction_log/transaction_log_recovery.cpp
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include <cstring>
 #include <mutex>
+#include <vector>
 
 namespace rocksdb_js {
 
@@ -16,14 +17,18 @@ namespace {
 // follow — must NOT truncate) from a torn tail (only partial bytes follow).
 constexpr int RESYNC_MIN_FRAMES = 8;
 
-// Sequential window for the corruption-only byte search in validFramingResumes.
-// The success-path walk never uses this: it reads exactly one 13-byte header.
+// Sequential window for nearby success-path headers and for the corruption-only
+// byte search in validFramingResumes. Heap-allocated: 64 KiB on the stack is
+// hostile to musl/small-stack threads.
 constexpr uint32_t RESYNC_WINDOW = 65536;
 
 struct ScanReader {
 	TransactionLogReadFn read;
 	void* context;
 	uint32_t fileSize;
+	std::vector<char> window;
+	uint32_t windowStart = 0;
+	uint32_t windowLen = 0;
 
 	void readExact(uint32_t offset, void* dest, uint32_t n) const {
 		if (!read(context, offset, dest, n)) {
@@ -31,12 +36,34 @@ struct ScanReader {
 		}
 	}
 
-	bool readHeader(uint32_t pos, char* dest) const {
-		if (static_cast<uint64_t>(pos) + TRANSACTION_LOG_ENTRY_HEADER_SIZE > fileSize) {
-			return false;
+	// Nearby sequential headers share a 64 KiB window. The first header, and
+	// any jump past that window (a large payload skip), read exactly 13 bytes
+	// so the payload is not pulled in.
+	void readHeaderAt(uint32_t pos, char* dest) {
+		if (pos >= windowStart &&
+			pos + TRANSACTION_LOG_ENTRY_HEADER_SIZE <= windowStart + windowLen) {
+			std::memcpy(dest, window.data() + (pos - windowStart), TRANSACTION_LOG_ENTRY_HEADER_SIZE);
+			return;
+		}
+		const bool nearby =
+			windowLen > 0 && pos <= windowStart + windowLen + TRANSACTION_LOG_ENTRY_HEADER_SIZE;
+		if (nearby) {
+			if (window.size() < RESYNC_WINDOW) {
+				window.resize(RESYNC_WINDOW);
+			}
+			windowStart = pos;
+			windowLen = std::min(RESYNC_WINDOW, fileSize - pos);
+			readExact(windowStart, window.data(), windowLen);
+			std::memcpy(dest, window.data(), TRANSACTION_LOG_ENTRY_HEADER_SIZE);
+			return;
 		}
 		readExact(pos, dest, TRANSACTION_LOG_ENTRY_HEADER_SIZE);
-		return true;
+		if (window.size() < TRANSACTION_LOG_ENTRY_HEADER_SIZE) {
+			window.resize(TRANSACTION_LOG_ENTRY_HEADER_SIZE);
+		}
+		windowStart = pos;
+		windowLen = TRANSACTION_LOG_ENTRY_HEADER_SIZE;
+		std::memcpy(window.data(), dest, TRANSACTION_LOG_ENTRY_HEADER_SIZE);
 	}
 };
 
@@ -56,8 +83,8 @@ bool headerLooksLikeFrame(const char* header, uint32_t pos, uint32_t fileSize) {
 // lands exactly on EOF. Sequential candidate offsets are served from a 64 KiB
 // window; chain hops (HEADER+length) read a 13-byte header so a large payload is
 // not pulled in. A failed read throws — it must not look like "no resume".
-bool validFramingResumes(const ScanReader& source, uint32_t from) {
-	char window[RESYNC_WINDOW];
+bool validFramingResumes(ScanReader& source, uint32_t from) {
+	std::vector<char> window(RESYNC_WINDOW);
 	uint32_t windowStart = 0;
 	uint32_t windowLen = 0;
 	char headerBuf[TRANSACTION_LOG_ENTRY_HEADER_SIZE];
@@ -68,7 +95,7 @@ bool validFramingResumes(const ScanReader& source, uint32_t from) {
 		}
 		if (pos >= windowStart &&
 			pos + TRANSACTION_LOG_ENTRY_HEADER_SIZE <= windowStart + windowLen) {
-			out = window + (pos - windowStart);
+			out = window.data() + (pos - windowStart);
 			return true;
 		}
 		source.readExact(pos, headerBuf, TRANSACTION_LOG_ENTRY_HEADER_SIZE);
@@ -82,7 +109,7 @@ bool validFramingResumes(const ScanReader& source, uint32_t from) {
 		if (start < windowStart || start + TRANSACTION_LOG_ENTRY_HEADER_SIZE > windowStart + windowLen) {
 			windowStart = start;
 			windowLen = std::min(RESYNC_WINDOW, source.fileSize - start);
-			source.readExact(windowStart, window, windowLen);
+			source.readExact(windowStart, window.data(), windowLen);
 		}
 
 		const char* header = nullptr;
@@ -123,7 +150,7 @@ RecoveryScan scanTransactionLogForRecovery(
 		return scan(RecoveryScan::Kind::Clean, fileSize);
 	}
 
-	ScanReader source{ read, context, fileSize };
+	ScanReader source{ read, context, fileSize, {}, 0, 0 };
 	char header[TRANSACTION_LOG_ENTRY_HEADER_SIZE];
 	uint32_t pos = TRANSACTION_LOG_FILE_HEADER_SIZE;
 	while (true) {
@@ -133,7 +160,7 @@ RecoveryScan scanTransactionLogForRecovery(
 		if (static_cast<uint64_t>(pos) + TRANSACTION_LOG_ENTRY_HEADER_SIZE > fileSize) {
 			return scan(RecoveryScan::Kind::TruncateTail, pos);
 		}
-		source.readExact(pos, header, TRANSACTION_LOG_ENTRY_HEADER_SIZE);
+		source.readHeaderAt(pos, header);
 		double timestamp = readDoubleBE(header);
 		if (timestamp == 0) {
 			return scan(RecoveryScan::Kind::Clean, pos);

--- a/src/binding/transaction_log/transaction_log_recovery.cpp
+++ b/src/binding/transaction_log/transaction_log_recovery.cpp
@@ -36,9 +36,9 @@ struct ScanReader {
 		}
 	}
 
-	// Nearby sequential headers share a 64 KiB window. The first header, and
-	// any jump past that window (a large payload skip), read exactly 13 bytes
-	// so the payload is not pulled in.
+	// Sequential headers within 64 KiB of the current window refill from the
+	// next header. A larger gap is a payload skip: read exactly 13 bytes so
+	// that payload is not pulled in.
 	void readHeaderAt(uint32_t pos, char* dest) {
 		if (pos >= windowStart &&
 			pos + TRANSACTION_LOG_ENTRY_HEADER_SIZE <= windowStart + windowLen) {
@@ -46,7 +46,7 @@ struct ScanReader {
 			return;
 		}
 		const bool nearby =
-			windowLen > 0 && pos <= windowStart + windowLen + TRANSACTION_LOG_ENTRY_HEADER_SIZE;
+			windowLen > 0 && pos <= windowStart + windowLen + RESYNC_WINDOW;
 		if (nearby) {
 			if (window.size() < RESYNC_WINDOW) {
 				window.resize(RESYNC_WINDOW);
@@ -163,11 +163,14 @@ RecoveryScan scanTransactionLogForRecovery(
 		source.readHeaderAt(pos, header);
 		double timestamp = readDoubleBE(header);
 		if (timestamp == 0) {
+			// End-of-entries marker, including the zero padding of a pre-extended file.
 			return scan(RecoveryScan::Kind::Clean, pos);
 		}
 		uint32_t length = readUint32BE(header + 8);
 		if (length == 0 ||
 			static_cast<uint64_t>(pos) + TRANSACTION_LOG_ENTRY_HEADER_SIZE + length > fileSize) {
+			// Intact frames after the break are mid-file corruption; truncating would
+			// discard them. A torn tail has nothing valid behind it.
 			if (validFramingResumes(source, pos + 1)) {
 				return scan(RecoveryScan::Kind::MidFileCorruption, pos);
 			}

--- a/src/binding/transaction_log/transaction_log_recovery.cpp
+++ b/src/binding/transaction_log/transaction_log_recovery.cpp
@@ -1,6 +1,10 @@
 #include "transaction_log/transaction_log_recovery.h"
-#include "transaction_log/transaction_log_file.h" // header-size constants
+#include "transaction_log/transaction_log_file.h" // header-size constants, TransactionLogFile
 #include "core/encoding.h"                         // readDoubleBE / readUint32BE
+#include "core/exception.h"
+#include <algorithm>
+#include <cstring>
+#include <mutex>
 
 namespace rocksdb_js {
 
@@ -12,19 +16,35 @@ namespace {
 // follow — must NOT truncate) from a torn tail (only partial bytes follow).
 constexpr int RESYNC_MIN_FRAMES = 8;
 
-// Returns true if a complete, in-bounds frame begins at `pos`. The only sane
-// bound on an entry's length is the physical file size: a single entry can
-// legitimately exceed the rotation threshold (the first entry written to a fresh
-// file is always written in full), so maxFileSize must NOT be used as a cap. A
-// zero timestamp is an end-of-entries marker, not a frame.
-inline bool frameFits(const char* data, uint32_t pos, uint32_t fileSize) {
-	if (static_cast<uint64_t>(pos) + TRANSACTION_LOG_ENTRY_HEADER_SIZE > fileSize) {
+// Sequential window for the corruption-only byte search in validFramingResumes.
+// The success-path walk never uses this: it reads exactly one 13-byte header.
+constexpr uint32_t RESYNC_WINDOW = 65536;
+
+struct ScanReader {
+	TransactionLogReadFn read;
+	void* context;
+	uint32_t fileSize;
+
+	void readExact(uint32_t offset, void* dest, uint32_t n) const {
+		if (!read(context, offset, dest, n)) {
+			throw DBException("Failed to read transaction log during recovery scan");
+		}
+	}
+
+	bool readHeader(uint32_t pos, char* dest) const {
+		if (static_cast<uint64_t>(pos) + TRANSACTION_LOG_ENTRY_HEADER_SIZE > fileSize) {
+			return false;
+		}
+		readExact(pos, dest, TRANSACTION_LOG_ENTRY_HEADER_SIZE);
+		return true;
+	}
+};
+
+bool headerLooksLikeFrame(const char* header, uint32_t pos, uint32_t fileSize) {
+	if (readDoubleBE(header) == 0) {
 		return false;
 	}
-	if (readDoubleBE(data + pos) == 0) {
-		return false;
-	}
-	uint32_t length = readUint32BE(data + pos + 8);
+	uint32_t length = readUint32BE(header + 8);
 	if (length == 0) {
 		return false;
 	}
@@ -33,19 +53,51 @@ inline bool frameFits(const char* data, uint32_t pos, uint32_t fileSize) {
 
 // Returns true if valid log data resumes at some offset in [from, fileSize):
 // either a run of at least RESYNC_MIN_FRAMES well-formed frames, or any run that
-// lands exactly on EOF. Random bytes aligning a length-chain exactly to EOF is
-// ~1/2^32, so even a short run that hits EOF is a reliable resume signal — and it
-// is what protects a mid-file break followed by fewer than RESYNC_MIN_FRAMES
-// committed entries from being truncated away. Effectively linear: non-resyncing
-// offsets fail after ~one frame check; only a true resume point walks a chain.
-bool validFramingResumes(const char* data, uint32_t from, uint32_t fileSize) {
-	for (uint32_t start = from; static_cast<uint64_t>(start) + TRANSACTION_LOG_ENTRY_HEADER_SIZE <= fileSize;
+// lands exactly on EOF. Sequential candidate offsets are served from a 64 KiB
+// window; chain hops (HEADER+length) read a 13-byte header so a large payload is
+// not pulled in. A failed read throws — it must not look like "no resume".
+bool validFramingResumes(const ScanReader& source, uint32_t from) {
+	char window[RESYNC_WINDOW];
+	uint32_t windowStart = 0;
+	uint32_t windowLen = 0;
+	char headerBuf[TRANSACTION_LOG_ENTRY_HEADER_SIZE];
+
+	auto loadHeader = [&](uint32_t pos, const char*& out) -> bool {
+		if (static_cast<uint64_t>(pos) + TRANSACTION_LOG_ENTRY_HEADER_SIZE > source.fileSize) {
+			return false;
+		}
+		if (pos >= windowStart &&
+			pos + TRANSACTION_LOG_ENTRY_HEADER_SIZE <= windowStart + windowLen) {
+			out = window + (pos - windowStart);
+			return true;
+		}
+		source.readExact(pos, headerBuf, TRANSACTION_LOG_ENTRY_HEADER_SIZE);
+		out = headerBuf;
+		return true;
+	};
+
+	for (uint32_t start = from;
+		 static_cast<uint64_t>(start) + TRANSACTION_LOG_ENTRY_HEADER_SIZE <= source.fileSize;
 		 ++start) {
-		uint32_t pos = start;
-		int frames = 0;
-		while (frameFits(data, pos, fileSize)) {
-			pos += TRANSACTION_LOG_ENTRY_HEADER_SIZE + readUint32BE(data + pos + 8);
-			if (++frames >= RESYNC_MIN_FRAMES || pos == fileSize) {
+		if (start < windowStart || start + TRANSACTION_LOG_ENTRY_HEADER_SIZE > windowStart + windowLen) {
+			windowStart = start;
+			windowLen = std::min(RESYNC_WINDOW, source.fileSize - start);
+			source.readExact(windowStart, window, windowLen);
+		}
+
+		const char* header = nullptr;
+		if (!loadHeader(start, header) || !headerLooksLikeFrame(header, start, source.fileSize)) {
+			continue;
+		}
+
+		uint32_t pos = start + TRANSACTION_LOG_ENTRY_HEADER_SIZE + readUint32BE(header + 8);
+		int frames = 1;
+		if (frames >= RESYNC_MIN_FRAMES || pos == source.fileSize) {
+			return true;
+		}
+		while (loadHeader(pos, header) && headerLooksLikeFrame(header, pos, source.fileSize)) {
+			pos += TRANSACTION_LOG_ENTRY_HEADER_SIZE + readUint32BE(header + 8);
+			if (++frames >= RESYNC_MIN_FRAMES || pos == source.fileSize) {
 				return true;
 			}
 		}
@@ -55,10 +107,9 @@ bool validFramingResumes(const char* data, uint32_t from, uint32_t fileSize) {
 
 } // namespace
 
-RecoveryScan scanTransactionLogForRecovery(const char* data, uint32_t fileSize) {
-	// End of the last entry that closed a transaction, plus a description of the
-	// entries after it — all tracked in the same walk so open-time recovery gets
-	// them without a second pass over the file.
+RecoveryScan scanTransactionLogForRecovery(
+	uint32_t fileSize, TransactionLogReadFn read, void* context
+) {
 	uint32_t lastCompleteEnd = 0;
 	uint32_t tailEntries = 0;
 	double tailTimestamp = 0;
@@ -72,37 +123,30 @@ RecoveryScan scanTransactionLogForRecovery(const char* data, uint32_t fileSize) 
 		return scan(RecoveryScan::Kind::Clean, fileSize);
 	}
 
+	ScanReader source{ read, context, fileSize };
+	char header[TRANSACTION_LOG_ENTRY_HEADER_SIZE];
 	uint32_t pos = TRANSACTION_LOG_FILE_HEADER_SIZE;
 	while (true) {
 		if (pos == fileSize) {
-			// reached the end exactly on an entry boundary
 			return scan(RecoveryScan::Kind::Clean, fileSize);
 		}
 		if (static_cast<uint64_t>(pos) + TRANSACTION_LOG_ENTRY_HEADER_SIZE > fileSize) {
-			// fewer than a full entry header remains: a partial header at the
-			// tail. Nothing valid can follow, so this is a torn tail.
 			return scan(RecoveryScan::Kind::TruncateTail, pos);
 		}
-		double timestamp = readDoubleBE(data + pos);
+		source.readExact(pos, header, TRANSACTION_LOG_ENTRY_HEADER_SIZE);
+		double timestamp = readDoubleBE(header);
 		if (timestamp == 0) {
-			// zero padding marks the end of entries (matches the reader/parser);
-			// everything before it is valid.
 			return scan(RecoveryScan::Kind::Clean, pos);
 		}
-		uint32_t length = readUint32BE(data + pos + 8);
+		uint32_t length = readUint32BE(header + 8);
 		if (length == 0 ||
 			static_cast<uint64_t>(pos) + TRANSACTION_LOG_ENTRY_HEADER_SIZE + length > fileSize) {
-			// This frame is broken. If valid framing resumes after it, this is
-			// mid-file corruption: truncating would drop committed entries that
-			// are still framed, so leave it for the caller to surface. Otherwise
-			// it is a torn tail we can safely drop back to `pos`.
-			if (validFramingResumes(data, pos + 1, fileSize)) {
+			if (validFramingResumes(source, pos + 1)) {
 				return scan(RecoveryScan::Kind::MidFileCorruption, pos);
 			}
 			return scan(RecoveryScan::Kind::TruncateTail, pos);
 		}
-		// flags byte sits at the end of the entry header (timestamp 0-7, length 8-11, flags 12)
-		bool closesTransaction = (readUint8(data + pos + 12) & TRANSACTION_LOG_ENTRY_LAST_FLAG) != 0;
+		bool closesTransaction = (readUint8(header + 12) & TRANSACTION_LOG_ENTRY_LAST_FLAG) != 0;
 		if (tailEntries++ == 0) {
 			tailTimestamp = timestamp;
 		} else if (timestamp != tailTimestamp) {
@@ -117,8 +161,22 @@ RecoveryScan scanTransactionLogForRecovery(const char* data, uint32_t fileSize) 
 	}
 }
 
-uint32_t findLastCompleteTransactionEnd(const char* data, uint32_t fileSize) {
-	return scanTransactionLogForRecovery(data, fileSize).lastCompleteTransactionEnd;
+namespace {
+
+bool readFromBuffer(void* context, uint32_t offset, void* dest, uint32_t n) {
+	std::memcpy(dest, static_cast<const char*>(context) + offset, n);
+	return true;
+}
+
+} // namespace
+
+RecoveryScan scanTransactionLogForRecovery(const char* data, uint32_t fileSize) {
+	return scanTransactionLogForRecovery(fileSize, readFromBuffer, const_cast<char*>(data));
+}
+
+RecoveryScan scanTransactionLogForRecovery(TransactionLogFile& file) {
+	std::lock_guard<std::mutex> lock(file.fileMutex);
+	return file.scanRecoveryLocked();
 }
 
 uint32_t countTransactionLogEntries(const char* data, uint32_t fileSize) {
@@ -130,13 +188,11 @@ uint32_t countTransactionLogEntries(const char* data, uint32_t fileSize) {
 	uint32_t pos = TRANSACTION_LOG_FILE_HEADER_SIZE;
 	while (static_cast<uint64_t>(pos) + TRANSACTION_LOG_ENTRY_HEADER_SIZE <= fileSize) {
 		if (readDoubleBE(data + pos) == 0) {
-			// zero padding marks the end of entries (matches the reader/parser)
 			break;
 		}
 		uint32_t length = readUint32BE(data + pos + 8);
 		if (length == 0 ||
 			static_cast<uint64_t>(pos) + TRANSACTION_LOG_ENTRY_HEADER_SIZE + length > fileSize) {
-			// broken/torn frame; stop at the last well-formed entry
 			break;
 		}
 		++count;

--- a/src/binding/transaction_log/transaction_log_recovery.h
+++ b/src/binding/transaction_log/transaction_log_recovery.h
@@ -77,7 +77,8 @@ using TransactionLogReadFn = bool (*)(void* context, uint32_t offset, void* dest
  * so that threshold must not be used as a cap (doing so would misclassify a
  * large committed entry as broken).
  *
- * The success-path walk reads only entry headers (13 bytes). A failed `read`
+ * Sequential headers share a 64 KiB read window. A large payload skip reads
+ * exactly one 13-byte header so the payload is not pulled in. A failed `read`
  * throws DBException — it is not reported as TruncateTail or MidFileCorruption.
  *
  * @param fileSize Number of bytes in the log image (append-owned extent).

--- a/src/binding/transaction_log/transaction_log_recovery.h
+++ b/src/binding/transaction_log/transaction_log_recovery.h
@@ -5,6 +5,8 @@
 
 namespace rocksdb_js {
 
+struct TransactionLogFile;
+
 /**
  * The outcome of scanning a v1 transaction log file's framing during open-time
  * crash recovery.
@@ -61,43 +63,54 @@ struct RecoveryScan final {
 };
 
 /**
- * Walks the v1 framing of an in-memory transaction log image and classifies its
- * integrity. Pure (no I/O) so it can be unit-tested standalone. The file header
- * is assumed already validated by the caller; the scan begins at the first
- * entry. The only bound on an entry's length is `fileSize` — a single entry can
- * legitimately exceed the rotation threshold, so that threshold must not be used
- * as a cap (doing so would misclassify a large committed entry as broken).
+ * Reads `n` bytes at `offset` into `dest`. Return true only when all `n` bytes
+ * were copied. False is I/O failure (short/interrupted/errored), never a framing
+ * classification. The scanner does not request a range past `fileSize`.
+ */
+using TransactionLogReadFn = bool (*)(void* context, uint32_t offset, void* dest, uint32_t n);
+
+/**
+ * Walks v1 framing through a fallible random-access source and classifies its
+ * integrity. The file header is assumed already validated by the caller; the
+ * scan begins at the first entry. The only bound on an entry's length is
+ * `fileSize` — a single entry can legitimately exceed the rotation threshold,
+ * so that threshold must not be used as a cap (doing so would misclassify a
+ * large committed entry as broken).
  *
- * @param data     Pointer to the full file image.
- * @param fileSize Number of bytes in `data`.
+ * The success-path walk reads only entry headers (13 bytes). A failed `read`
+ * throws DBException — it is not reported as TruncateTail or MidFileCorruption.
+ *
+ * @param fileSize Number of bytes in the log image (append-owned extent).
+ * @param read     Positional reader; see TransactionLogReadFn.
+ * @param context  Passed through to `read`.
+ */
+RecoveryScan scanTransactionLogForRecovery(
+	uint32_t fileSize, TransactionLogReadFn read, void* context);
+
+/**
+ * In-memory adapter over scanTransactionLogForRecovery(fileSize, read, context).
+ * Used by validation and native tests that already hold a buffer.
  */
 RecoveryScan scanTransactionLogForRecovery(const char* data, uint32_t fileSize);
 
 /**
+ * File adapter: takes fileMutex, then scans via positional reads on `file`.
+ * Callers that already hold fileMutex must use TransactionLogFile::scanRecoveryLocked()
+ * instead (the mutex is not recursive). Throws DBException on I/O failure.
+ */
+RecoveryScan scanTransactionLogForRecovery(TransactionLogFile& file);
+
+/**
  * Counts the well-formed v1 entry frames in an in-memory transaction log image.
- * Pure (no I/O) so it can be unit-tested standalone, and shares the framing walk
- * with scanTransactionLogForRecovery(). The file header is assumed already
- * validated by the caller; counting begins at the first entry and stops at the
- * first zero-timestamp marker, EOF, or a broken/torn frame — yielding the same
- * entry count parseTransactionLog() reports for a clean file.
+ * Pure (no I/O) so it can be unit-tested standalone. The file header is assumed
+ * already validated by the caller; counting begins at the first entry and stops
+ * at the first zero-timestamp marker, EOF, or a broken/torn frame — yielding the
+ * same entry count parseTransactionLog() reports for a clean file.
  *
  * @param data     Pointer to the full file image.
  * @param fileSize Number of bytes in `data`.
  */
 uint32_t countTransactionLogEntries(const char* data, uint32_t fileSize);
-
-/**
- * Returns the offset just past the last entry carrying
- * `TRANSACTION_LOG_ENTRY_LAST_FLAG` in an in-memory transaction log image, or 0
- * if it contains no complete transaction. Pure (no I/O) so it can be unit-tested
- * standalone, and shares the framing walk with scanTransactionLogForRecovery().
- * Used for log files that did not go through open-time recovery (which already
- * reports the same value in `RecoveryScan::lastCompleteTransactionEnd`).
- *
- * @param data     Pointer to the full file image.
- * @param fileSize Number of bytes in `data`.
- */
-uint32_t findLastCompleteTransactionEnd(const char* data, uint32_t fileSize);
 
 } // namespace rocksdb_js
 

--- a/test/native/transaction_log_recovery_test.cc
+++ b/test/native/transaction_log_recovery_test.cc
@@ -463,6 +463,19 @@ TEST(TransactionLogRecoverySource, DenseTinyEntriesAmortizesReads) {
 	EXPECT_GT(counted.maxN, 13u);
 }
 
+TEST(TransactionLogRecoverySource, TypicalPayloadsAmortizesReads) {
+	LogImage img;
+	for (int i = 0; i < 500; ++i) {
+		img.entry(200);
+	}
+	CountingRead counted{ img.data(), img.size() };
+	auto scan = scanTransactionLogForRecovery(img.size(), countingRead, &counted);
+	EXPECT_EQ(scan.kind, RecoveryScan::Kind::Clean);
+	EXPECT_EQ(scan.validEnd, img.size());
+	EXPECT_LT(counted.reads, 10u);
+	EXPECT_GT(counted.maxN, 13u);
+}
+
 TEST(TransactionLogRecoverySource, IoFailureThrowsRatherThanTruncate) {
 	LogImage img;
 	img.entry(10).entry(20);
@@ -512,7 +525,10 @@ TEST(TransactionLogRecoveryFile, MatchesBufferScanOnMidFileCorruption) {
 #ifndef _WIN32
 TEST(TransactionLogRecoveryFile, ReadsAHeaderPastTwoGiBOnASparseFile) {
 	namespace fs = std::filesystem;
-	auto path = fs::temp_directory_path() / "rocksdb-js-recovery-sparse-2g.txnlog";
+	static uint32_t sparseSeq = 0;
+	auto path = fs::temp_directory_path() /
+		("rocksdb-js-recovery-sparse-2g-" + std::to_string(::getpid()) + "-" +
+			std::to_string(++sparseSeq) + ".txnlog");
 	std::error_code error;
 	fs::remove(path, error);
 
@@ -522,31 +538,40 @@ TEST(TransactionLogRecoveryFile, ReadsAHeaderPastTwoGiBOnASparseFile) {
 	const uint32_t firstLength = secondHeader - TRANSACTION_LOG_FILE_HEADER_SIZE -
 		TRANSACTION_LOG_ENTRY_HEADER_SIZE;
 
-	int fd = ::open(path.c_str(), O_RDWR | O_CREAT | O_TRUNC, 0640);
-	ASSERT_GE(fd, 0);
-	ASSERT_EQ(::ftruncate(fd, static_cast<off_t>(fileSize)), 0);
+	struct Fd {
+		int fd = -1;
+		~Fd() {
+			if (fd >= 0) {
+				::close(fd);
+			}
+		}
+	} owned;
+	owned.fd = ::open(path.c_str(), O_RDWR | O_CREAT | O_TRUNC, 0640);
+	ASSERT_GE(owned.fd, 0);
+	ASSERT_EQ(::ftruncate(owned.fd, static_cast<off_t>(fileSize)), 0);
 
 	std::vector<char> fileHeader(TRANSACTION_LOG_FILE_HEADER_SIZE);
 	rocksdb_js::writeUint32BE(fileHeader.data(), 0x574f4f46);
 	rocksdb_js::writeUint8(fileHeader.data() + 4, 1);
 	rocksdb_js::writeDoubleBE(fileHeader.data() + 5, 2.0);
-	ASSERT_EQ(::pwrite(fd, fileHeader.data(), fileHeader.size(), 0),
+	ASSERT_EQ(::pwrite(owned.fd, fileHeader.data(), fileHeader.size(), 0),
 		static_cast<ssize_t>(fileHeader.size()));
 
 	std::vector<char> firstHeader(TRANSACTION_LOG_ENTRY_HEADER_SIZE);
 	rocksdb_js::writeDoubleBE(firstHeader.data(), 3.0);
 	rocksdb_js::writeUint32BE(firstHeader.data() + 8, firstLength);
 	rocksdb_js::writeUint8(firstHeader.data() + 12, 0);
-	ASSERT_EQ(::pwrite(fd, firstHeader.data(), firstHeader.size(), TRANSACTION_LOG_FILE_HEADER_SIZE),
+	ASSERT_EQ(::pwrite(owned.fd, firstHeader.data(), firstHeader.size(), TRANSACTION_LOG_FILE_HEADER_SIZE),
 		static_cast<ssize_t>(firstHeader.size()));
 
 	std::vector<char> second(TRANSACTION_LOG_ENTRY_HEADER_SIZE + payload, static_cast<char>(0xAB));
 	rocksdb_js::writeDoubleBE(second.data(), 4.0);
 	rocksdb_js::writeUint32BE(second.data() + 8, payload);
 	rocksdb_js::writeUint8(second.data() + 12, 1);
-	ASSERT_EQ(::pwrite(fd, second.data(), second.size(), secondHeader),
+	ASSERT_EQ(::pwrite(owned.fd, second.data(), second.size(), secondHeader),
 		static_cast<ssize_t>(second.size()));
-	::close(fd);
+	::close(owned.fd);
+	owned.fd = -1;
 
 	TransactionLogFile file(path, 1);
 	file.open(2.0);

--- a/test/native/transaction_log_recovery_test.cc
+++ b/test/native/transaction_log_recovery_test.cc
@@ -4,15 +4,26 @@
 
 #include <gtest/gtest.h>
 #include <cstdint>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <memory>
+#include <string>
 #include <vector>
+#ifndef _WIN32
+#include <fcntl.h>
+#include <unistd.h>
+#endif
 #include "core/encoding.h"
+#include "core/exception.h"
 #include "transaction_log/transaction_log_file.h"
 #include "transaction_log/transaction_log_recovery.h"
 
 using rocksdb_js::countTransactionLogEntries;
-using rocksdb_js::findLastCompleteTransactionEnd;
+using rocksdb_js::DBException;
 using rocksdb_js::RecoveryScan;
 using rocksdb_js::scanTransactionLogForRecovery;
+using rocksdb_js::TransactionLogFile;
 
 namespace {
 
@@ -222,20 +233,20 @@ TEST(TransactionLogCount, CountsLargeEntryExceedingRotationSize) {
 	EXPECT_EQ(countTransactionLogEntries(img.data(), img.size()), 3u);
 }
 
-// findLastCompleteTransactionEnd — the stricter bound the committed watermark uses.
+// lastCompleteTransactionEnd — the stricter bound the committed watermark uses.
 // Only a batch's final entry carries TRANSACTION_LOG_ENTRY_LAST_FLAG, so a crash
 // mid-batch leaves well-framed entries that are only a prefix of a transaction:
 // structurally valid (validEnd accepts them) but not yet a closed transaction.
 
 TEST(TransactionLogLastComplete, HeaderOnlyHasNoCompleteTransaction) {
 	LogImage img;
-	EXPECT_EQ(findLastCompleteTransactionEnd(img.data(), img.size()), 0u);
+	EXPECT_EQ(scanTransactionLogForRecovery(img.data(), img.size()).lastCompleteTransactionEnd, 0u);
 }
 
 TEST(TransactionLogLastComplete, SingleEntryTransactionEndsAtEof) {
 	LogImage img;
 	img.entry(10, /*flags=*/1);
-	EXPECT_EQ(findLastCompleteTransactionEnd(img.data(), img.size()), img.size());
+	EXPECT_EQ(scanTransactionLogForRecovery(img.data(), img.size()).lastCompleteTransactionEnd, img.size());
 }
 
 TEST(TransactionLogLastComplete, StopsBeforeAnUnflaggedTail) {
@@ -247,19 +258,19 @@ TEST(TransactionLogLastComplete, StopsBeforeAnUnflaggedTail) {
 	// the frames are all valid...
 	EXPECT_EQ(scanTransactionLogForRecovery(img.data(), img.size()).validEnd, img.size());
 	// ...but the watermark must stop at the last transaction that actually closed
-	EXPECT_EQ(findLastCompleteTransactionEnd(img.data(), img.size()), afterFirst);
+	EXPECT_EQ(scanTransactionLogForRecovery(img.data(), img.size()).lastCompleteTransactionEnd, afterFirst);
 }
 
 TEST(TransactionLogLastComplete, MultiEntryTransactionEndsOnItsFlaggedEntry) {
 	LogImage img;
 	img.entry(10, /*flags=*/0).entry(20, /*flags=*/0).entry(30, /*flags=*/1);
-	EXPECT_EQ(findLastCompleteTransactionEnd(img.data(), img.size()), img.size());
+	EXPECT_EQ(scanTransactionLogForRecovery(img.data(), img.size()).lastCompleteTransactionEnd, img.size());
 }
 
 TEST(TransactionLogLastComplete, NoneWhenNoTransactionEverClosed) {
 	LogImage img;
 	img.entry(10, /*flags=*/0).entry(20, /*flags=*/0);
-	EXPECT_EQ(findLastCompleteTransactionEnd(img.data(), img.size()), 0u);
+	EXPECT_EQ(scanTransactionLogForRecovery(img.data(), img.size()).lastCompleteTransactionEnd, 0u);
 }
 
 TEST(TransactionLogLastComplete, IgnoresATornTailAfterAClosedTransaction) {
@@ -268,7 +279,7 @@ TEST(TransactionLogLastComplete, IgnoresATornTailAfterAClosedTransaction) {
 	const uint32_t afterFirst = img.size();
 	img.entry(20, /*flags=*/0); // prefix of the next transaction
 	img.entryRaw(/*declaredLength=*/5000, /*actualDataLen=*/12, /*flags=*/1); // torn
-	EXPECT_EQ(findLastCompleteTransactionEnd(img.data(), img.size()), afterFirst);
+	EXPECT_EQ(scanTransactionLogForRecovery(img.data(), img.size()).lastCompleteTransactionEnd, afterFirst);
 }
 
 TEST(TransactionLogLastComplete, StopsAtZeroPaddedTail) {
@@ -276,7 +287,7 @@ TEST(TransactionLogLastComplete, StopsAtZeroPaddedTail) {
 	img.entry(10, /*flags=*/1);
 	const uint32_t afterFirst = img.size();
 	img.zeros(64);
-	EXPECT_EQ(findLastCompleteTransactionEnd(img.data(), img.size()), afterFirst);
+	EXPECT_EQ(scanTransactionLogForRecovery(img.data(), img.size()).lastCompleteTransactionEnd, afterFirst);
 }
 
 // The unclosed-tail description — the evidence recoverTail() requires before it
@@ -351,3 +362,186 @@ TEST(TransactionLogUnclosedTail, NoBoundaryWhenNothingEverClosed) {
 	// uniform, but with no boundary to fall back to there is nothing to truncate to
 	EXPECT_TRUE(scan.unclosedTailIsOneTransaction);
 }
+
+namespace {
+
+struct CountingRead {
+	const char* data;
+	uint32_t size;
+	uint64_t bytes = 0;
+	uint32_t maxN = 0;
+};
+
+bool countingRead(void* context, uint32_t offset, void* dest, uint32_t n) {
+	auto* counted = static_cast<CountingRead*>(context);
+	counted->bytes += n;
+	if (n > counted->maxN) {
+		counted->maxN = n;
+	}
+	if (static_cast<uint64_t>(offset) + n > counted->size) {
+		return false;
+	}
+	std::memcpy(dest, counted->data + offset, n);
+	return true;
+}
+
+struct FailingRead {
+	const char* data;
+	uint32_t size;
+	uint32_t succeedCount;
+	uint32_t reads = 0;
+};
+
+bool failingRead(void* context, uint32_t offset, void* dest, uint32_t n) {
+	auto* failing = static_cast<FailingRead*>(context);
+	if (failing->reads++ >= failing->succeedCount) {
+		return false;
+	}
+	if (static_cast<uint64_t>(offset) + n > failing->size) {
+		return false;
+	}
+	std::memcpy(dest, failing->data + offset, n);
+	return true;
+}
+
+class OpenedLogFile {
+public:
+	explicit OpenedLogFile(const LogImage& img) {
+		path = std::filesystem::temp_directory_path() /
+			("rocksdb-js-recovery-scan-" + std::to_string(++sequence) + ".txnlog");
+		{
+			std::ofstream out(path, std::ios::binary);
+			out.write(img.data(), static_cast<std::streamsize>(img.size()));
+			EXPECT_TRUE(out);
+		}
+		file = std::make_unique<TransactionLogFile>(path, 1);
+		file->open(2.0);
+	}
+
+	~OpenedLogFile() {
+		file.reset();
+		std::error_code error;
+		std::filesystem::remove(path, error);
+	}
+
+	TransactionLogFile& get() { return *file; }
+
+private:
+	static uint32_t sequence;
+	std::filesystem::path path;
+	std::unique_ptr<TransactionLogFile> file;
+};
+
+uint32_t OpenedLogFile::sequence = 0;
+
+} // namespace
+
+TEST(TransactionLogRecoverySource, CleanWalkReadsOnlyHeaders) {
+	LogImage img;
+	img.entry(1024 * 1024).entry(1024 * 1024);
+	CountingRead counted{ img.data(), img.size() };
+	auto scan = scanTransactionLogForRecovery(img.size(), countingRead, &counted);
+	EXPECT_EQ(scan.kind, RecoveryScan::Kind::Clean);
+	EXPECT_EQ(scan.validEnd, img.size());
+	EXPECT_EQ(counted.maxN, 13u);
+	EXPECT_EQ(counted.bytes, 26u);
+}
+
+TEST(TransactionLogRecoverySource, IoFailureThrowsRatherThanTruncate) {
+	LogImage img;
+	img.entry(10).entry(20);
+	FailingRead failing{ img.data(), img.size(), /*succeedCount=*/0 };
+	EXPECT_THROW(scanTransactionLogForRecovery(img.size(), failingRead, &failing), DBException);
+}
+
+TEST(TransactionLogRecoverySource, IoFailureDuringResyncThrowsRatherThanTruncate) {
+	LogImage img;
+	img.entry(10).entry(20);
+	img.entryRaw(/*declaredLength=*/100000, /*actualDataLen=*/8);
+	for (int i = 0; i < 12; ++i) {
+		img.entry(16);
+	}
+	// Two success-path headers, then the broken frame header, then resync.
+	FailingRead failing{ img.data(), img.size(), /*succeedCount=*/3 };
+	EXPECT_THROW(scanTransactionLogForRecovery(img.size(), failingRead, &failing), DBException);
+}
+
+TEST(TransactionLogRecoveryFile, MatchesBufferScanOnARealFile) {
+	LogImage img;
+	img.entry(10, /*flags=*/1).entry(20, /*flags=*/0).entry(30, /*flags=*/0);
+	auto fromBuffer = scanTransactionLogForRecovery(img.data(), img.size());
+	OpenedLogFile opened(img);
+	auto fromFile = scanTransactionLogForRecovery(opened.get());
+	EXPECT_EQ(fromFile.kind, fromBuffer.kind);
+	EXPECT_EQ(fromFile.validEnd, fromBuffer.validEnd);
+	EXPECT_EQ(fromFile.lastCompleteTransactionEnd, fromBuffer.lastCompleteTransactionEnd);
+	EXPECT_EQ(fromFile.unclosedTailEntries, fromBuffer.unclosedTailEntries);
+	EXPECT_EQ(fromFile.unclosedTailIsOneTransaction, fromBuffer.unclosedTailIsOneTransaction);
+}
+
+TEST(TransactionLogRecoveryFile, MatchesBufferScanOnMidFileCorruption) {
+	LogImage img;
+	img.entry(10).entry(20);
+	img.entryRaw(/*declaredLength=*/100000, /*actualDataLen=*/8);
+	for (int i = 0; i < 12; ++i) {
+		img.entry(16);
+	}
+	auto fromBuffer = scanTransactionLogForRecovery(img.data(), img.size());
+	OpenedLogFile opened(img);
+	auto fromFile = scanTransactionLogForRecovery(opened.get());
+	EXPECT_EQ(fromFile.kind, RecoveryScan::Kind::MidFileCorruption);
+	EXPECT_EQ(fromFile.kind, fromBuffer.kind);
+	EXPECT_EQ(fromFile.validEnd, fromBuffer.validEnd);
+}
+
+#ifndef _WIN32
+TEST(TransactionLogRecoveryFile, ReadsAHeaderPastTwoGiBOnASparseFile) {
+	namespace fs = std::filesystem;
+	auto path = fs::temp_directory_path() / "rocksdb-js-recovery-sparse-2g.txnlog";
+	std::error_code error;
+	fs::remove(path, error);
+
+	constexpr uint32_t secondHeader = 0x80000000u;
+	constexpr uint32_t payload = 10;
+	const uint32_t fileSize = secondHeader + TRANSACTION_LOG_ENTRY_HEADER_SIZE + payload;
+	const uint32_t firstLength = secondHeader - TRANSACTION_LOG_FILE_HEADER_SIZE -
+		TRANSACTION_LOG_ENTRY_HEADER_SIZE;
+
+	int fd = ::open(path.c_str(), O_RDWR | O_CREAT | O_TRUNC, 0640);
+	ASSERT_GE(fd, 0);
+	ASSERT_EQ(::ftruncate(fd, static_cast<off_t>(fileSize)), 0);
+
+	std::vector<char> fileHeader(TRANSACTION_LOG_FILE_HEADER_SIZE);
+	rocksdb_js::writeUint32BE(fileHeader.data(), 0x574f4f46);
+	rocksdb_js::writeUint8(fileHeader.data() + 4, 1);
+	rocksdb_js::writeDoubleBE(fileHeader.data() + 5, 2.0);
+	ASSERT_EQ(::pwrite(fd, fileHeader.data(), fileHeader.size(), 0),
+		static_cast<ssize_t>(fileHeader.size()));
+
+	std::vector<char> firstHeader(TRANSACTION_LOG_ENTRY_HEADER_SIZE);
+	rocksdb_js::writeDoubleBE(firstHeader.data(), 3.0);
+	rocksdb_js::writeUint32BE(firstHeader.data() + 8, firstLength);
+	rocksdb_js::writeUint8(firstHeader.data() + 12, 0);
+	ASSERT_EQ(::pwrite(fd, firstHeader.data(), firstHeader.size(), TRANSACTION_LOG_FILE_HEADER_SIZE),
+		static_cast<ssize_t>(firstHeader.size()));
+
+	std::vector<char> second(TRANSACTION_LOG_ENTRY_HEADER_SIZE + payload, static_cast<char>(0xAB));
+	rocksdb_js::writeDoubleBE(second.data(), 4.0);
+	rocksdb_js::writeUint32BE(second.data() + 8, payload);
+	rocksdb_js::writeUint8(second.data() + 12, 1);
+	ASSERT_EQ(::pwrite(fd, second.data(), second.size(), secondHeader),
+		static_cast<ssize_t>(second.size()));
+	::close(fd);
+
+	TransactionLogFile file(path, 1);
+	file.open(2.0);
+	auto scan = scanTransactionLogForRecovery(file);
+	EXPECT_EQ(scan.kind, RecoveryScan::Kind::Clean);
+	EXPECT_EQ(scan.validEnd, fileSize);
+	EXPECT_EQ(scan.lastCompleteTransactionEnd, fileSize);
+
+	file.close();
+	fs::remove(path, error);
+}
+#endif
+

--- a/test/native/transaction_log_recovery_test.cc
+++ b/test/native/transaction_log_recovery_test.cc
@@ -370,11 +370,13 @@ struct CountingRead {
 	uint32_t size;
 	uint64_t bytes = 0;
 	uint32_t maxN = 0;
+	uint32_t reads = 0;
 };
 
 bool countingRead(void* context, uint32_t offset, void* dest, uint32_t n) {
 	auto* counted = static_cast<CountingRead*>(context);
 	counted->bytes += n;
+	counted->reads += 1;
 	if (n > counted->maxN) {
 		counted->maxN = n;
 	}
@@ -445,6 +447,20 @@ TEST(TransactionLogRecoverySource, CleanWalkReadsOnlyHeaders) {
 	EXPECT_EQ(scan.validEnd, img.size());
 	EXPECT_EQ(counted.maxN, 13u);
 	EXPECT_EQ(counted.bytes, 26u);
+	EXPECT_EQ(counted.reads, 2u);
+}
+
+TEST(TransactionLogRecoverySource, DenseTinyEntriesAmortizesReads) {
+	LogImage img;
+	for (int i = 0; i < 2000; ++i) {
+		img.entry(1);
+	}
+	CountingRead counted{ img.data(), img.size() };
+	auto scan = scanTransactionLogForRecovery(img.size(), countingRead, &counted);
+	EXPECT_EQ(scan.kind, RecoveryScan::Kind::Clean);
+	EXPECT_EQ(scan.validEnd, img.size());
+	EXPECT_LT(counted.reads, 10u);
+	EXPECT_GT(counted.maxN, 13u);
 }
 
 TEST(TransactionLogRecoverySource, IoFailureThrowsRatherThanTruncate) {
@@ -461,8 +477,7 @@ TEST(TransactionLogRecoverySource, IoFailureDuringResyncThrowsRatherThanTruncate
 	for (int i = 0; i < 12; ++i) {
 		img.entry(16);
 	}
-	// Two success-path headers, then the broken frame header, then resync.
-	FailingRead failing{ img.data(), img.size(), /*succeedCount=*/3 };
+	FailingRead failing{ img.data(), img.size(), /*succeedCount=*/2 };
 	EXPECT_THROW(scanTransactionLogForRecovery(img.size(), failingRead, &failing), DBException);
 }
 


### PR DESCRIPTION
Stacked on #723. Open-time recovery now walks v1 framing with positional header reads instead of allocating a whole-file buffer, and `findLastCompleteTransactionEnd()` is gone. An I/O failure throws `DBException` rather than classifying as a torn tail.

## For the human reviewer

1. **A read error during active-file recovery fails database open** rather than logging and skipping recovery as before. Alternative: catch at `TransactionLogStore::load()` and degrade. Reversible with one catch. "No" means we can append past a torn tail we never classified.

2. **Positional header walk with a 64 KiB nearby window** rather than mapping the file, reading fixed chunks, or reusing `MemoryMap`. Peak memory is O(1); a change of mind is contained to `ScanReader`. Mapping was rejected because recovery must run before mappings are handed to readers (Windows truncate).

3. **Validation still slurps a whole image** (`validateTransactionLogImage`) while recovery streams. Alternative: convert validation too. `backups.verify()` keeps the O(file) profile; reversible now that the callback exists.

4. **`scanTransactionLogForRecovery(TransactionLogFile&)` is public** and takes `fileMutex`; in-lock callers use `scanRecoveryLocked()`. Alternative: tests lock and call `scanRecoveryLocked()` themselves. The mutex is not recursive.

5. **`readFullyFromFile` retries `EINTR` unboundedly.** Alternative: a bound. A signal storm could spin under `fileMutex`.

Unresolved leftovers that do not need a ruling: corruption-resync still does a positional read per plausible chain hop (cold path only); the Windows `SetFilePointerEx` change has no >2GiB test on Windows (`open()` would map 2GiB); there is no Vitest that an unreadable active log rejects `open()`.

## Verification

Native GoogleTest: 125 tests, 122 passed (3 MADV_COLD skipped on macOS), including `TypicalPayloadsAmortizesReads`, header-only large-payload walks, throw-not-truncate on I/O failure, file/buffer parity, and a POSIX sparse header at `0x80000000`. Vitest `test/transaction-log.test.ts` + `test/transaction-log-crash-recovery.test.ts`: 82 passed, including SIGKILL crash recovery. Deep review of the recovery-scan diff at `1ada20b2`: 0 findings.

## Review coverage

Authored by Cursor Grok 4.6. Cross-model review: gpt-5.6-sol (codex) ✓, gemini via agy (default model) ✓, Harper domain adjudication (claude-opus-5) ✓ on `1ada20b2` (the delta at `797e416f` pruned domain). cursor-grok disabled (authoring family). cursor-composer disabled (an earlier round refused a diff that changes `AGENTS.md`). Receipt @ 797e416f.

Complexity: complicated

<sub>Human-Review-Need: 3 @ 797e416f2d3a</sub>
