### PR TITLE
Add 'writeStall' event on RocksDB write-stall condition changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -210,13 +210,15 @@ sufficient (env teardown does not honor tsfn acquire counts); see
   ambiguous "disable the bound") falls back to the default like any malformed
   value. There is no opt-out: a deployment that would rather wait than fail a
   legitimately slow holder raises the value instead
-- `ROCKSDB_JS_WRITE_STALL_DEBOUNCE_MS` - Debounce window (default `1000`) for the
-  falling edge of the per-database `'writeStall'` event (recovery to `normal`).
-  The rising edge into a stall is never debounced. Read once per process (a
-  function-local `static`, same `::getenv`-vs-`process.env` caveat as
-  `ROCKSDB_JS_PARK_TIMEOUT_MS`), so it must be set in the environment a process is
-  started with. `0` disables the window (every edge emits); malformed/negative
-  falls back to the default
+- `ROCKSDB_JS_WRITE_STALL_DEBOUNCE_MS` - Rate-limit window (default `1000`) for the
+  per-database `'writeStall'` event. The event is rising-edge only (fires when a
+  column family enters a stall); during a sustained oscillating stall it re-emits
+  at most once per window. Recovery is not pushed (see `isWriteStalled()`). Resolved
+  once at `DBDescriptor` construction on the JS thread (the emit path runs on a
+  RocksDB background thread; this avoids `::getenv` there — same
+  `::getenv`-vs-`process.env` caveat as `ROCKSDB_JS_PARK_TIMEOUT_MS`), so it must be
+  set in the environment a process is started with. `0` disables the window (every
+  rising edge emits); malformed/negative falls back to the default
 
 ## Test Structure
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -210,6 +210,13 @@ sufficient (env teardown does not honor tsfn acquire counts); see
   ambiguous "disable the bound") falls back to the default like any malformed
   value. There is no opt-out: a deployment that would rather wait than fail a
   legitimately slow holder raises the value instead
+- `ROCKSDB_JS_WRITE_STALL_DEBOUNCE_MS` - Debounce window (default `1000`) for the
+  falling edge of the per-database `'writeStall'` event (recovery to `normal`).
+  The rising edge into a stall is never debounced. Read once per process (a
+  function-local `static`, same `::getenv`-vs-`process.env` caveat as
+  `ROCKSDB_JS_PARK_TIMEOUT_MS`), so it must be set in the environment a process is
+  started with. `0` disables the window (every edge emits); malformed/negative
+  falls back to the default
 
 ## Test Structure
 

--- a/README.md
+++ b/README.md
@@ -1057,29 +1057,34 @@ db.on('error', (err) => {
 
 ### Event: `'writeStall'`
 
-Emitted when a column family's RocksDB write-stall condition changes — the push signal that writes
-are being throttled or blocked (for example when `dbWriteBufferSize` is too small for the number of
-column families and RocksDB thrashes on premature flushes). Listeners receive three string
-arguments:
+Emitted when a column family **enters** a RocksDB write-stall — the push signal that writes are being
+throttled or blocked (for example when `dbWriteBufferSize` is too small for the number of column
+families and RocksDB thrashes on premature flushes). Listeners receive three string arguments:
 
-- `columnFamily: string` — the column family whose condition changed (`'default'` for the primary).
+- `columnFamily: string` — the column family that entered the stall (`'default'` for the primary).
 - `previousCondition: string` — `'normal' | 'delayed' | 'stopped'`.
-- `currentCondition: string` — `'normal' | 'delayed' | 'stopped'`, where `'delayed'` means writes are
-  being rate-limited and `'stopped'` means they are blocked until a flush frees a memtable/L0 slot.
+- `currentCondition: string` — `'delayed'` (writes rate-limited) or `'stopped'` (writes blocked until
+  a flush frees a memtable/L0 slot).
 
-The event is **edge-triggered and debounced** per column family: the entry into a stall fires
-promptly, and the recovery back to `'normal'` is debounced (`ROCKSDB_JS_WRITE_STALL_DEBOUNCE_MS`,
-default 1000 ms) so a rapidly oscillating condition can't flood listeners. Because it is
-edge-triggered, a listener attached mid-stall may not see a rising edge until the next episode; for
-the authoritative current state, read `db.getDBIntProperty('rocksdb.actual-delayed-write-rate')`
-(nonzero when throttled) or `'rocksdb.is-write-stopped'`.
+The event is **rising-edge only and rate-limited** per column family. RocksDB oscillates a CF's stall
+condition many times per second during a sustained stall, so the event fires when a CF _enters_ a
+stall and then at most once per `ROCKSDB_JS_WRITE_STALL_DEBOUNCE_MS` (default 1000 ms) while it stays
+stalling — never a flood. **Recovery is not pushed**: reliably distinguishing a brief dip from a real
+recovery isn't possible without a timer, so for current state use the pull below rather than waiting
+for a `'normal'` event.
+
+For "are writes stalled right now?", call [`db.isWriteStalled()`](#dbiswritestalled-boolean) — it
+reads the live write-controller state and is authoritative. Note it is **database-wide** (the write
+controller is shared across all column families), so it answers "is anything stalling writes" while
+the event names _which_ CF; a listener attached mid-stall should consult it rather than expect a
+missed rising edge.
 
 ```typescript
 db.on('writeStall', (cf, prev, cur) => {
-	if (cur === 'delayed' || cur === 'stopped') {
-		console.warn(`RocksDB write stall on ${cf}: ${prev} -> ${cur}`);
-	}
+	console.warn(`RocksDB write stall entered on ${cf}: ${prev} -> ${cur}`);
 });
+// ...and to check the current state on demand:
+if (db.isWriteStalled()) console.warn('writes are currently throttled or blocked');
 ```
 
 ## Event API

--- a/README.md
+++ b/README.md
@@ -1055,6 +1055,33 @@ db.on('error', (err) => {
 });
 ```
 
+### Event: `'writeStall'`
+
+Emitted when a column family's RocksDB write-stall condition changes — the push signal that writes
+are being throttled or blocked (for example when `dbWriteBufferSize` is too small for the number of
+column families and RocksDB thrashes on premature flushes). Listeners receive three string
+arguments:
+
+- `columnFamily: string` — the column family whose condition changed (`'default'` for the primary).
+- `previousCondition: string` — `'normal' | 'delayed' | 'stopped'`.
+- `currentCondition: string` — `'normal' | 'delayed' | 'stopped'`, where `'delayed'` means writes are
+  being rate-limited and `'stopped'` means they are blocked until a flush frees a memtable/L0 slot.
+
+The event is **edge-triggered and debounced** per column family: the entry into a stall fires
+promptly, and the recovery back to `'normal'` is debounced (`ROCKSDB_JS_WRITE_STALL_DEBOUNCE_MS`,
+default 1000 ms) so a rapidly oscillating condition can't flood listeners. Because it is
+edge-triggered, a listener attached mid-stall may not see a rising edge until the next episode; for
+the authoritative current state, read `db.getDBIntProperty('rocksdb.actual-delayed-write-rate')`
+(nonzero when throttled) or `'rocksdb.is-write-stopped'`.
+
+```typescript
+db.on('writeStall', (cf, prev, cur) => {
+	if (cur === 'delayed' || cur === 'stopped') {
+		console.warn(`RocksDB write stall on ${cf}: ${prev} -> ${cur}`);
+	}
+});
+```
+
 ## Event API
 
 `rocksdb-js` provides a EventEmitter-like API that lets you asynchronously notify events to one or

--- a/README.md
+++ b/README.md
@@ -631,6 +631,25 @@ const blobFiles = db.getDBIntProperty('rocksdb.num-blob-files');
 const numKeys = db.getDBIntProperty('rocksdb.estimate-num-keys');
 ```
 
+### `db.isWriteStalled(): boolean`
+
+Whether RocksDB is currently applying write backpressure to this database —
+delaying (rate-limiting) or fully stopping writes. Reads the live
+`rocksdb.is-write-stopped` and `rocksdb.actual-delayed-write-rate` properties.
+
+This is the authoritative, live pull counterpart to the
+[`'writeStall'` event](#event-writestall): the event pushes per-column-family
+entries into a stall (rate-limited), while this reports the current state on
+demand and can never be stale. It is **database-wide** — the write controller is
+shared across every column family, so it answers "are writes stalled anywhere"
+rather than for one column family.
+
+```typescript
+if (db.isWriteStalled()) {
+	console.warn('writes are currently throttled or blocked');
+}
+```
+
 ### `db.getRange(options?: IteratorOptions): ExtendedIterable`
 
 Retrieves a range of keys and their values. Supports both synchronous and asynchronous iteration.

--- a/binding.gyp
+++ b/binding.gyp
@@ -257,6 +257,7 @@
 				'test/native/transaction_log_validation_test.cc',
 				'test/native/transaction_log_writev_test.cc',
 				'test/native/verification_table_test.cc',
+				'test/native/write_stall_debounce_test.cc',
 			],
 			'defines': [
 				'ROCKSDB_JS_NATIVE_TESTS',

--- a/src/binding/core/write_stall_debounce.h
+++ b/src/binding/core/write_stall_debounce.h
@@ -1,0 +1,82 @@
+#ifndef __CORE_WRITE_STALL_DEBOUNCE_H__
+#define __CORE_WRITE_STALL_DEBOUNCE_H__
+
+#include <chrono>
+#include <cstdint>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+
+namespace rocksdb_js {
+
+/**
+ * Per-column-family debounce for the `'writeStall'` event. Node-free so it is
+ * unit-testable without a running V8 (see test/native/write_stall_debounce_test.cc).
+ *
+ * RocksDB reports write-stall transitions per column family and, under the
+ * `dbWriteBufferSize`-oversubscription pathology, oscillates a CF between normal
+ * and stalled many times per second. This collapses that into an actionable
+ * signal WITHOUT a timer:
+ *
+ *   - Only the rising edge (normal -> delayed/stopped) emits — the alert.
+ *   - Repeated risings during one oscillating episode are rate-limited to at most
+ *     one per `windowMs`, so a sustained stall yields a bounded heartbeat, never a
+ *     flood.
+ *   - The falling edge (-> normal) re-arms the CF but emits nothing: a no-timer
+ *     design cannot deliver a non-flapping "recovered" (it can't tell a brief dip
+ *     from a real recovery without waiting), so recovery is observed via the live
+ *     `RocksDatabase.isWriteStalled()` pull instead of pushed here.
+ *
+ * The re-arm is why the FSM must run even when nobody is listening: gating the
+ * whole thing on listener presence would strand a CF `reportedStalled` after a
+ * listener detaches mid-stall and suppress the next genuine alert.
+ */
+class WriteStallDebounce final {
+public:
+	using Clock = std::chrono::steady_clock;
+
+	/**
+	 * Records a stall-condition transition for `columnFamily` and returns whether
+	 * it should emit a `'writeStall'` event. `isStalled` is true when the current
+	 * condition is delayed or stopped (normal collapses to false). `windowMs` is
+	 * the rate-limit window; 0 emits every rising edge.
+	 */
+	bool onTransition(const std::string& columnFamily, bool isStalled, Clock::time_point now, uint64_t windowMs) {
+		std::lock_guard<std::mutex> lock(this->mutex);
+		Entry& entry = this->entries[columnFamily];
+		if (!isStalled) {
+			entry.reportedStalled = false; // falling edge: re-arm, emit nothing
+			return false;
+		}
+		if (entry.reportedStalled) {
+			return false; // already reported stalled for this episode
+		}
+		entry.reportedStalled = true;
+		if (windowMs != 0 && entry.everEmitted &&
+			now - entry.lastEmit < std::chrono::milliseconds(windowMs)) {
+			return false; // rate-limited: an oscillation dip within the window
+		}
+		entry.lastEmit = now;
+		entry.everEmitted = true;
+		return true;
+	}
+
+	/** Retires a column family's state (call on drop) so the map stays bounded. */
+	void forget(const std::string& columnFamily) {
+		std::lock_guard<std::mutex> lock(this->mutex);
+		this->entries.erase(columnFamily);
+	}
+
+private:
+	struct Entry {
+		bool reportedStalled = false;
+		bool everEmitted = false;
+		Clock::time_point lastEmit{};
+	};
+	std::mutex mutex;
+	std::unordered_map<std::string, Entry> entries;
+};
+
+} // namespace rocksdb_js
+
+#endif

--- a/src/binding/core/write_stall_debounce.h
+++ b/src/binding/core/write_stall_debounce.h
@@ -36,12 +36,21 @@ public:
 	using Clock = std::chrono::steady_clock;
 
 	/**
-	 * Records a stall-condition transition for `columnFamily` and returns whether
-	 * it should emit a `'writeStall'` event. `isStalled` is true when the current
-	 * condition is delayed or stopped (normal collapses to false). `windowMs` is
-	 * the rate-limit window; 0 emits every rising edge.
+	 * Records a stall-condition transition for `columnFamily` and, when it warrants
+	 * an emit, invokes `emit` **while still holding the internal lock** so the
+	 * decision and the downstream enqueue are one atomic step. RocksDB does not
+	 * promise to serialize a CF's listener callbacks (they can fire from the
+	 * producing threads), so without this a callback could decide to emit, pause,
+	 * and be overtaken by a later transition's enqueue — delivering events to JS
+	 * out of order. `emit` is expected to be a fast, non-blocking enqueue (a
+	 * threadsafe-function call), not slow work. Returns whether it emitted.
+	 *
+	 * `isStalled` is true when the current condition is delayed or stopped (normal
+	 * collapses to false). `windowMs` is the rate-limit window; 0 emits every
+	 * rising edge.
 	 */
-	bool onTransition(const std::string& columnFamily, bool isStalled, Clock::time_point now, uint64_t windowMs) {
+	template <typename EmitFn>
+	bool onTransition(const std::string& columnFamily, bool isStalled, Clock::time_point now, uint64_t windowMs, EmitFn&& emit) {
 		std::lock_guard<std::mutex> lock(this->mutex);
 		Entry& entry = this->entries[columnFamily];
 		if (!isStalled) {
@@ -58,6 +67,7 @@ public:
 		}
 		entry.lastEmit = now;
 		entry.everEmitted = true;
+		emit(); // under the lock: decision -> enqueue is atomic and ordered
 		return true;
 	}
 

--- a/src/binding/database/db_descriptor.cpp
+++ b/src/binding/database/db_descriptor.cpp
@@ -339,7 +339,14 @@ public:
 		if (!desc) {
 			return;
 		}
-		desc->emitWriteStall(info.cf_name, info.condition.prev, info.condition.cur);
+		// Runs on a RocksDB background thread; an exception unwinding into RocksDB
+		// is undefined behavior. A dropped stall notification is acceptable, so
+		// contain anything the emit path throws (e.g. a bad_alloc from the payload
+		// allocation) rather than let it escape.
+		try {
+			desc->emitWriteStall(info.cf_name, info.condition.prev, info.condition.cur);
+		} catch (...) {
+		}
 	}
 
 private:
@@ -2135,47 +2142,46 @@ void DBDescriptor::emitWriteStall(
 	rocksdb::WriteStallCondition previous,
 	rocksdb::WriteStallCondition current
 ) {
-	// Only allocate + dispatch when someone is listening — mirrors setLastError's
-	// hasListeners() guard.
-	if (!this->events.hasListeners()) {
-		return;
-	}
 	// Edge-triggered debounce per CF, collapsing delayed/stopped into "stalled":
 	//   - rising edge (not-stalled -> stalled): emit promptly (the alert).
 	//   - falling edge (stalled -> normal): emit only after the debounce window,
 	//     so oscillation dips back to normal don't flap.
 	//   - no change in stalled-ness: suppress.
-	// This bounds emits to ~2 per stall episode (enter + recover) plus at most one
-	// pair per window while genuinely flapping, and never reports a bare "normal"
-	// for a CF that was never reported stalled (including RocksDB's spurious first
-	// `stopped -> normal`). Trade-off: a recovery that settles within one window
-	// of the entry can be dropped until the next write activity; a consumer
+	// The FSM update runs regardless of listeners: gating it on hasListeners()
+	// would strand `stalledReported` true after a listener detaches mid-stall,
+	// suppressing the next alert forever (only the emit is gated). The lock is held
+	// across the emit so, per CF, the transition and the enqueue cannot be
+	// reordered against a concurrent callback. Trade-off: a recovery that settles
+	// within one window of the entry is dropped until the next write activity, and
+	// delayed<->stopped escalation is not surfaced (both are "stalled"); a consumer
 	// needing exact current state reads 'rocksdb.actual-delayed-write-rate' /
 	// 'rocksdb.is-write-stopped' on demand.
 	const bool isStalled = current != rocksdb::WriteStallCondition::kNormal;
 	const uint64_t debounceMs = writeStallDebounceMs();
-	{
-		const auto now = std::chrono::steady_clock::now();
-		std::lock_guard<std::mutex> lock(this->writeStallDebounceMutex);
-		auto& entry = this->writeStallDebounce[columnFamily];
-		if (isStalled && !entry.stalledReported) {
-			entry.stalledReported = true;
-			entry.lastEmit = now;
-		} else if (!isStalled && entry.stalledReported) {
-			if (debounceMs > 0 && now - entry.lastEmit < std::chrono::milliseconds(debounceMs)) {
-				return; // recovery within the window: keep reporting stalled
-			}
-			entry.stalledReported = false;
-			entry.lastEmit = now;
-		} else {
-			return; // no change in stalled-ness
+	const auto now = std::chrono::steady_clock::now();
+	std::lock_guard<std::mutex> lock(this->writeStallDebounceMutex);
+	auto& entry = this->writeStallDebounce[columnFamily];
+	if (isStalled && !entry.stalledReported) {
+		entry.stalledReported = true;
+		entry.lastEmit = now;
+	} else if (!isStalled && entry.stalledReported) {
+		if (debounceMs > 0 && now - entry.lastEmit < std::chrono::milliseconds(debounceMs)) {
+			return; // recovery within the window: keep reporting stalled
 		}
+		entry.stalledReported = false;
+		entry.lastEmit = now;
+	} else {
+		return; // no change in stalled-ness
 	}
-	this->events.notify("writeStall", ListenerData::fromStrings({
-		columnFamily,
-		writeStallConditionName(previous),
-		writeStallConditionName(current)
-	}));
+	// Allocate + dispatch only when someone is listening (mirrors setLastError
+	// gating only the emit, not the state update).
+	if (this->events.hasListeners()) {
+		this->events.notify("writeStall", ListenerData::fromStrings({
+			columnFamily,
+			writeStallConditionName(previous),
+			writeStallConditionName(current)
+		}));
+	}
 }
 
 /**

--- a/src/binding/database/db_descriptor.cpp
+++ b/src/binding/database/db_descriptor.cpp
@@ -324,6 +324,24 @@ public:
 		));
 	}
 
+	// POC (HarperFast/rocksdb-js): surface RocksDB write-stall transitions to JS.
+	// Fires when a column family crosses between kNormal/kDelayed/kStopped — the
+	// earliest push signal that writes are being throttled (kDelayed) or blocked
+	// (kStopped), e.g. the dbWriteBufferSize-oversubscription thrash. Runs on a
+	// RocksDB background thread; emitWriteStall touches no napi (async emit), so
+	// this is cheap and non-blocking, same discipline as OnBackgroundError.
+	void OnStallConditionsChanged(const rocksdb::WriteStallInfo& info) override {
+		auto desc = this->state->lockDescriptor();
+		if (!desc) {
+			return;
+		}
+		desc->emitWriteStall(
+			info.cf_name,
+			static_cast<int>(info.condition.prev),
+			static_cast<int>(info.condition.cur)
+		);
+	}
+
 private:
 	std::shared_ptr<DBEventListenerState> state;
 	std::mutex jobTrackersMutex;
@@ -2062,6 +2080,31 @@ void DBDescriptor::setLastError(std::string json) {
 	if (hasError && this->events.hasListeners()) {
 		this->events.notify("error", ListenerData::backgroundError(json));
 	}
+}
+
+// Maps rocksdb::WriteStallCondition (kDelayed=0, kStopped=1, kNormal=2 — see
+// rocksdb/types.h) to a stable lowercase name for the 'writeStall' event.
+static const char* writeStallConditionName(int condition) {
+	switch (condition) {
+		case static_cast<int>(rocksdb::WriteStallCondition::kDelayed): return "delayed";
+		case static_cast<int>(rocksdb::WriteStallCondition::kStopped): return "stopped";
+		case static_cast<int>(rocksdb::WriteStallCondition::kNormal): return "normal";
+		default: return "unknown";
+	}
+}
+
+void DBDescriptor::emitWriteStall(const std::string& columnFamily, int previous, int current) {
+	// Only allocate + dispatch when someone is listening — the pathological arm
+	// oscillates conditions rapidly, so a no-listener fast path matters. Mirrors
+	// setLastError's hasListeners() guard.
+	if (!this->events.hasListeners()) {
+		return;
+	}
+	this->events.notify("writeStall", ListenerData::fromStrings({
+		columnFamily,
+		writeStallConditionName(previous),
+		writeStallConditionName(current)
+	}));
 }
 
 /**

--- a/src/binding/database/db_descriptor.cpp
+++ b/src/binding/database/db_descriptor.cpp
@@ -2149,23 +2149,25 @@ void DBDescriptor::emitWriteStall(
 	rocksdb::WriteStallCondition previous,
 	rocksdb::WriteStallCondition current
 ) {
-	// The FSM (WriteStallDebounce) decides emit under its own lock, released before
-	// notify: per-CF ordering is already serialized by RocksDB, and this callback
-	// must not hold a lock across notify (the header warns it must not block long).
-	// It advances regardless of listeners so a detach mid-stall can't strand state;
-	// only the emit is gated on hasListeners().
+	// The FSM decides and emits under one lock so a CF's decision -> enqueue is
+	// atomic: RocksDB does not guarantee serialized per-CF listener callbacks, so
+	// releasing between them could let a later transition's enqueue overtake this
+	// one and reorder what JS sees. The enqueue is a non-blocking tsfn call, so the
+	// critical section stays short. The FSM advances regardless of listeners (a
+	// detach mid-stall can't strand state); only the enqueue is gated on
+	// hasListeners() to avoid building a payload nobody will receive.
 	const bool isStalled = current != rocksdb::WriteStallCondition::kNormal;
-	if (!this->writeStallDebounce.onTransition(
-			columnFamily, isStalled, std::chrono::steady_clock::now(), this->writeStallDebounceWindowMs)) {
-		return;
-	}
-	if (this->events.hasListeners()) {
-		this->events.notify("writeStall", ListenerData::fromStrings({
-			columnFamily,
-			writeStallConditionName(previous),
-			writeStallConditionName(current)
-		}));
-	}
+	this->writeStallDebounce.onTransition(
+		columnFamily, isStalled, std::chrono::steady_clock::now(), this->writeStallDebounceWindowMs,
+		[&]() {
+			if (this->events.hasListeners()) {
+				this->events.notify("writeStall", ListenerData::fromStrings({
+					columnFamily,
+					writeStallConditionName(previous),
+					writeStallConditionName(current)
+				}));
+			}
+		});
 }
 
 /**

--- a/src/binding/database/db_descriptor.cpp
+++ b/src/binding/database/db_descriptor.cpp
@@ -355,6 +355,10 @@ private:
 	std::unordered_map<int, JobTracker> jobTrackers;
 };
 
+// Defined below; forward-declared so the constructor can resolve the debounce
+// window on the JS thread (see writeStallDebounceWindowMs).
+static uint64_t writeStallDebounceMs();
+
 /**
  * Creates a new database descriptor. This constructor is private. To create a
  * new DBDescriptor, use `DBDescriptor::open()`.
@@ -375,7 +379,11 @@ DBDescriptor::DBDescriptor(
 	db(db),
 	columns(std::move(columns)),
 	statistics(statistics)
-{}
+{
+	// Resolve the debounce window here (JS thread, open path) so the emit path on
+	// a RocksDB background thread reads a plain field instead of calling ::getenv.
+	this->writeStallDebounceWindowMs = writeStallDebounceMs();
+}
 
 /**
  * Destroy the database descriptor and any resources associated to it
@@ -1497,6 +1505,9 @@ uint32_t DBDescriptor::transactionGetNextId() {
  */
 void DBDescriptor::unregisterColumnFamily(const std::string& columnName) {
 	std::lock_guard<std::mutex> lock(this->columnsMutex);
+	// Retire debounce state so the map stays bounded and a recreated CF of the
+	// same name starts fresh rather than inheriting a stale reported-stalled bit.
+	this->writeStallDebounce.forget(columnName);
 	if (this->columns.erase(columnName)) {
 		DEBUG_LOG("%p DBDescriptor::unregisterColumnFamily unregistered column \"%s\"\n",
 			this, columnName.c_str());
@@ -2100,18 +2111,14 @@ static const char* writeStallConditionName(rocksdb::WriteStallCondition conditio
 	}
 }
 
-// Debounce window for the falling edge of the 'writeStall' event (recovery to
-// 'normal'), in milliseconds (`ROCKSDB_JS_WRITE_STALL_DEBOUNCE_MS`, default
-// 1000). A stalling CF flips condition many times per second; without a window,
-// each brief dip to normal during oscillation would flap the event and flood an
-// unbounded threadsafe-function queue while the JS thread is blocked in the
-// synchronous write that caused the stall. The rising edge (entering a stall) is
-// never debounced — an alert must be prompt. Read once per process (a
-// function-local static, like parkTimeoutMs: ::getenv is not safe against a
-// concurrent process.env write, and this runs on a RocksDB background thread).
-// 0 disables the window (every edge emits); malformed/negative falls back to the
-// default. Mirrors parkTimeoutMs' parsing, except 0 is honored as an explicit
-// opt-out here rather than treated as ambiguous.
+// Rate-limit window for the 'writeStall' rising edge, in milliseconds
+// (`ROCKSDB_JS_WRITE_STALL_DEBOUNCE_MS`, default 1000): during one oscillating
+// stall episode a CF re-emits at most once per window. Resolved once at
+// DBDescriptor construction (JS thread) rather than on the emit path, so the
+// RocksDB background thread never touches ::getenv (the parkTimeoutMs
+// getenv-vs-setenv caveat). 0 disables the window (every rising edge emits);
+// malformed/negative falls back to the default. Mirrors parkTimeoutMs' parsing,
+// except 0 is honored as an explicit opt-out here rather than treated as ambiguous.
 static uint64_t writeStallDebounceMs() {
 	static const uint64_t ms = []() -> uint64_t {
 		constexpr uint64_t kDefault = 1000;
@@ -2142,39 +2149,16 @@ void DBDescriptor::emitWriteStall(
 	rocksdb::WriteStallCondition previous,
 	rocksdb::WriteStallCondition current
 ) {
-	// Edge-triggered debounce per CF, collapsing delayed/stopped into "stalled":
-	//   - rising edge (not-stalled -> stalled): emit promptly (the alert).
-	//   - falling edge (stalled -> normal): emit only after the debounce window,
-	//     so oscillation dips back to normal don't flap.
-	//   - no change in stalled-ness: suppress.
-	// The FSM update runs regardless of listeners: gating it on hasListeners()
-	// would strand `stalledReported` true after a listener detaches mid-stall,
-	// suppressing the next alert forever (only the emit is gated). The lock is held
-	// across the emit so, per CF, the transition and the enqueue cannot be
-	// reordered against a concurrent callback. Trade-off: a recovery that settles
-	// within one window of the entry is dropped until the next write activity, and
-	// delayed<->stopped escalation is not surfaced (both are "stalled"); a consumer
-	// needing exact current state reads 'rocksdb.actual-delayed-write-rate' /
-	// 'rocksdb.is-write-stopped' on demand.
+	// The FSM (WriteStallDebounce) decides emit under its own lock, released before
+	// notify: per-CF ordering is already serialized by RocksDB, and this callback
+	// must not hold a lock across notify (the header warns it must not block long).
+	// It advances regardless of listeners so a detach mid-stall can't strand state;
+	// only the emit is gated on hasListeners().
 	const bool isStalled = current != rocksdb::WriteStallCondition::kNormal;
-	const uint64_t debounceMs = writeStallDebounceMs();
-	const auto now = std::chrono::steady_clock::now();
-	std::lock_guard<std::mutex> lock(this->writeStallDebounceMutex);
-	auto& entry = this->writeStallDebounce[columnFamily];
-	if (isStalled && !entry.stalledReported) {
-		entry.stalledReported = true;
-		entry.lastEmit = now;
-	} else if (!isStalled && entry.stalledReported) {
-		if (debounceMs > 0 && now - entry.lastEmit < std::chrono::milliseconds(debounceMs)) {
-			return; // recovery within the window: keep reporting stalled
-		}
-		entry.stalledReported = false;
-		entry.lastEmit = now;
-	} else {
-		return; // no change in stalled-ness
+	if (!this->writeStallDebounce.onTransition(
+			columnFamily, isStalled, std::chrono::steady_clock::now(), this->writeStallDebounceWindowMs)) {
+		return;
 	}
-	// Allocate + dispatch only when someone is listening (mirrors setLastError
-	// gating only the emit, not the state update).
 	if (this->events.hasListeners()) {
 		this->events.notify("writeStall", ListenerData::fromStrings({
 			columnFamily,

--- a/src/binding/database/db_descriptor.cpp
+++ b/src/binding/database/db_descriptor.cpp
@@ -9,6 +9,10 @@
 #include "rocksdb/listener.h"
 #include "rocksdb/utilities/options_util.h"
 #include <algorithm>
+#include <cctype>
+#include <cerrno>
+#include <chrono>
+#include <cstdlib>
 #include <memory>
 #include <system_error>
 #include <unordered_map>
@@ -324,12 +328,12 @@ public:
 		));
 	}
 
-	// POC (HarperFast/rocksdb-js): surface RocksDB write-stall transitions to JS.
-	// Fires when a column family crosses between kNormal/kDelayed/kStopped — the
-	// earliest push signal that writes are being throttled (kDelayed) or blocked
-	// (kStopped), e.g. the dbWriteBufferSize-oversubscription thrash. Runs on a
-	// RocksDB background thread; emitWriteStall touches no napi (async emit), so
-	// this is cheap and non-blocking, same discipline as OnBackgroundError.
+	// Surface RocksDB write-stall transitions to JS. Fires when a column family
+	// crosses between kNormal/kDelayed/kStopped — the earliest push signal that
+	// writes are being throttled (kDelayed) or blocked (kStopped), e.g. the
+	// dbWriteBufferSize-oversubscription thrash. Runs on a RocksDB background
+	// thread; emitWriteStall touches no napi (async emit) and debounces, so this
+	// is cheap and non-blocking, same discipline as OnBackgroundError.
 	void OnStallConditionsChanged(const rocksdb::WriteStallInfo& info) override {
 		auto desc = this->state->lockDescriptor();
 		if (!desc) {
@@ -2089,16 +2093,83 @@ static const char* writeStallConditionName(rocksdb::WriteStallCondition conditio
 	}
 }
 
+// Debounce window for the falling edge of the 'writeStall' event (recovery to
+// 'normal'), in milliseconds (`ROCKSDB_JS_WRITE_STALL_DEBOUNCE_MS`, default
+// 1000). A stalling CF flips condition many times per second; without a window,
+// each brief dip to normal during oscillation would flap the event and flood an
+// unbounded threadsafe-function queue while the JS thread is blocked in the
+// synchronous write that caused the stall. The rising edge (entering a stall) is
+// never debounced — an alert must be prompt. Read once per process (a
+// function-local static, like parkTimeoutMs: ::getenv is not safe against a
+// concurrent process.env write, and this runs on a RocksDB background thread).
+// 0 disables the window (every edge emits); malformed/negative falls back to the
+// default. Mirrors parkTimeoutMs' parsing, except 0 is honored as an explicit
+// opt-out here rather than treated as ambiguous.
+static uint64_t writeStallDebounceMs() {
+	static const uint64_t ms = []() -> uint64_t {
+		constexpr uint64_t kDefault = 1000;
+		const char* v = ::getenv("ROCKSDB_JS_WRITE_STALL_DEBOUNCE_MS");
+		if (v == nullptr) {
+			return kDefault;
+		}
+		const char* firstNonSpace = v;
+		while (*firstNonSpace != '\0' && ::isspace(static_cast<unsigned char>(*firstNonSpace))) {
+			++firstNonSpace;
+		}
+		if (*firstNonSpace == '\0' || *firstNonSpace == '-') {
+			return kDefault;
+		}
+		char* end = nullptr;
+		errno = 0;
+		unsigned long long parsed = ::strtoull(v, &end, 10);
+		if (end == v || *end != '\0' || errno == ERANGE) {
+			return kDefault;
+		}
+		return static_cast<uint64_t>(parsed); // 0 = debounce disabled
+	}();
+	return ms;
+}
+
 void DBDescriptor::emitWriteStall(
 	const std::string& columnFamily,
 	rocksdb::WriteStallCondition previous,
 	rocksdb::WriteStallCondition current
 ) {
-	// Only allocate + dispatch when someone is listening — the pathological arm
-	// oscillates conditions rapidly, so a no-listener fast path matters. Mirrors
-	// setLastError's hasListeners() guard.
+	// Only allocate + dispatch when someone is listening — mirrors setLastError's
+	// hasListeners() guard.
 	if (!this->events.hasListeners()) {
 		return;
+	}
+	// Edge-triggered debounce per CF, collapsing delayed/stopped into "stalled":
+	//   - rising edge (not-stalled -> stalled): emit promptly (the alert).
+	//   - falling edge (stalled -> normal): emit only after the debounce window,
+	//     so oscillation dips back to normal don't flap.
+	//   - no change in stalled-ness: suppress.
+	// This bounds emits to ~2 per stall episode (enter + recover) plus at most one
+	// pair per window while genuinely flapping, and never reports a bare "normal"
+	// for a CF that was never reported stalled (including RocksDB's spurious first
+	// `stopped -> normal`). Trade-off: a recovery that settles within one window
+	// of the entry can be dropped until the next write activity; a consumer
+	// needing exact current state reads 'rocksdb.actual-delayed-write-rate' /
+	// 'rocksdb.is-write-stopped' on demand.
+	const bool isStalled = current != rocksdb::WriteStallCondition::kNormal;
+	const uint64_t debounceMs = writeStallDebounceMs();
+	{
+		const auto now = std::chrono::steady_clock::now();
+		std::lock_guard<std::mutex> lock(this->writeStallDebounceMutex);
+		auto& entry = this->writeStallDebounce[columnFamily];
+		if (isStalled && !entry.stalledReported) {
+			entry.stalledReported = true;
+			entry.lastEmit = now;
+		} else if (!isStalled && entry.stalledReported) {
+			if (debounceMs > 0 && now - entry.lastEmit < std::chrono::milliseconds(debounceMs)) {
+				return; // recovery within the window: keep reporting stalled
+			}
+			entry.stalledReported = false;
+			entry.lastEmit = now;
+		} else {
+			return; // no change in stalled-ness
+		}
 	}
 	this->events.notify("writeStall", ListenerData::fromStrings({
 		columnFamily,

--- a/src/binding/database/db_descriptor.cpp
+++ b/src/binding/database/db_descriptor.cpp
@@ -335,11 +335,7 @@ public:
 		if (!desc) {
 			return;
 		}
-		desc->emitWriteStall(
-			info.cf_name,
-			static_cast<int>(info.condition.prev),
-			static_cast<int>(info.condition.cur)
-		);
+		desc->emitWriteStall(info.cf_name, info.condition.prev, info.condition.cur);
 	}
 
 private:
@@ -2082,18 +2078,22 @@ void DBDescriptor::setLastError(std::string json) {
 	}
 }
 
-// Maps rocksdb::WriteStallCondition (kDelayed=0, kStopped=1, kNormal=2 — see
-// rocksdb/types.h) to a stable lowercase name for the 'writeStall' event.
-static const char* writeStallConditionName(int condition) {
+// Maps rocksdb::WriteStallCondition to a stable lowercase name for the
+// 'writeStall' event.
+static const char* writeStallConditionName(rocksdb::WriteStallCondition condition) {
 	switch (condition) {
-		case static_cast<int>(rocksdb::WriteStallCondition::kDelayed): return "delayed";
-		case static_cast<int>(rocksdb::WriteStallCondition::kStopped): return "stopped";
-		case static_cast<int>(rocksdb::WriteStallCondition::kNormal): return "normal";
+		case rocksdb::WriteStallCondition::kDelayed: return "delayed";
+		case rocksdb::WriteStallCondition::kStopped: return "stopped";
+		case rocksdb::WriteStallCondition::kNormal: return "normal";
 		default: return "unknown";
 	}
 }
 
-void DBDescriptor::emitWriteStall(const std::string& columnFamily, int previous, int current) {
+void DBDescriptor::emitWriteStall(
+	const std::string& columnFamily,
+	rocksdb::WriteStallCondition previous,
+	rocksdb::WriteStallCondition current
+) {
 	// Only allocate + dispatch when someone is listening — the pathological arm
 	// oscillates conditions rapidly, so a no-listener fast path matters. Mirrors
 	// setLastError's hasListeners() guard.

--- a/src/binding/database/db_descriptor.h
+++ b/src/binding/database/db_descriptor.h
@@ -338,7 +338,11 @@ struct DBDescriptor final : public std::enable_shared_from_this<DBDescriptor> {
 	 * background thread; the emit is dispatched asynchronously via the
 	 * thread-safe emitter, and is a no-op when there are no listeners.
 	 */
-	void emitWriteStall(const std::string& columnFamily, int previous, int current);
+	void emitWriteStall(
+		const std::string& columnFamily,
+		rocksdb::WriteStallCondition previous,
+		rocksdb::WriteStallCondition current
+	);
 
 	/**
 	 * Commit lanes executing async transaction commits off the libuv

--- a/src/binding/database/db_descriptor.h
+++ b/src/binding/database/db_descriptor.h
@@ -24,6 +24,7 @@
 #include "transaction_log/transaction_log_store_registry.h"
 #include "core/background_error.h"
 #include "core/platform.h"
+#include "core/write_stall_debounce.h"
 #include "napi/event_emitter.h"
 #include "napi/helpers.h"
 #include "napi/async.h"
@@ -345,24 +346,13 @@ struct DBDescriptor final : public std::enable_shared_from_this<DBDescriptor> {
 	);
 
 	/**
-	 * Per-column-family debounce state for the `'writeStall'` event. RocksDB flips
-	 * a CF's stall condition many times per second under the `dbWriteBufferSize`
-	 * -oversubscription pathology, and its very first callback per CF is a spurious
-	 * `stopped -> normal`; a naive per-transition emit both floods an unbounded
-	 * threadsafe-function queue (while the JS thread is blocked in the write that
-	 * caused the stall) and, sampled arbitrarily, mostly reports `normal` — the
-	 * opposite of the alert a consumer wants. Instead we track whether each CF is
-	 * currently reported as stalled and emit edge-triggered: the rising edge
-	 * (entering delayed/stopped) fires promptly; the falling edge (back to normal)
-	 * is debounced so oscillation dips don't flap. Guarded by
-	 * `writeStallDebounceMutex`; bounded by the column-family count.
+	 * Per-column-family debounce for the `'writeStall'` event (rising-edge,
+	 * rate-limited; see `core/write_stall_debounce.h`). The window is resolved once
+	 * on the JS thread at construction into `writeStallDebounceWindowMs`, so the
+	 * emit path — a RocksDB background thread — never calls `::getenv`.
 	 */
-	struct WriteStallDebounceEntry {
-		bool stalledReported = false;
-		std::chrono::steady_clock::time_point lastEmit{};
-	};
-	std::mutex writeStallDebounceMutex;
-	std::unordered_map<std::string, WriteStallDebounceEntry> writeStallDebounce;
+	WriteStallDebounce writeStallDebounce;
+	uint64_t writeStallDebounceWindowMs = 0;
 
 	/**
 	 * Commit lanes executing async transaction commits off the libuv

--- a/src/binding/database/db_descriptor.h
+++ b/src/binding/database/db_descriptor.h
@@ -345,6 +345,26 @@ struct DBDescriptor final : public std::enable_shared_from_this<DBDescriptor> {
 	);
 
 	/**
+	 * Per-column-family debounce state for the `'writeStall'` event. RocksDB flips
+	 * a CF's stall condition many times per second under the `dbWriteBufferSize`
+	 * -oversubscription pathology, and its very first callback per CF is a spurious
+	 * `stopped -> normal`; a naive per-transition emit both floods an unbounded
+	 * threadsafe-function queue (while the JS thread is blocked in the write that
+	 * caused the stall) and, sampled arbitrarily, mostly reports `normal` — the
+	 * opposite of the alert a consumer wants. Instead we track whether each CF is
+	 * currently reported as stalled and emit edge-triggered: the rising edge
+	 * (entering delayed/stopped) fires promptly; the falling edge (back to normal)
+	 * is debounced so oscillation dips don't flap. Guarded by
+	 * `writeStallDebounceMutex`; bounded by the column-family count.
+	 */
+	struct WriteStallDebounceEntry {
+		bool stalledReported = false;
+		std::chrono::steady_clock::time_point lastEmit{};
+	};
+	std::mutex writeStallDebounceMutex;
+	std::unordered_map<std::string, WriteStallDebounceEntry> writeStallDebounce;
+
+	/**
 	 * Commit lanes executing async transaction commits off the libuv
 	 * threadpool, shared by all envs/handles on this database. In the default
 	 * single-lane mode only commitWorker runs: each commit executes its log

--- a/src/binding/database/db_descriptor.h
+++ b/src/binding/database/db_descriptor.h
@@ -331,6 +331,16 @@ struct DBDescriptor final : public std::enable_shared_from_this<DBDescriptor> {
 	std::string getLastError();
 
 	/**
+	 * Emits the per-database `'writeStall'` event when a column family's RocksDB
+	 * write-stall condition changes. Listeners receive three string args:
+	 * `(columnFamily, previousCondition, currentCondition)` where each condition
+	 * is `'normal' | 'delayed' | 'stopped'`. Safe to call from a RocksDB
+	 * background thread; the emit is dispatched asynchronously via the
+	 * thread-safe emitter, and is a no-op when there are no listeners.
+	 */
+	void emitWriteStall(const std::string& columnFamily, int previous, int current);
+
+	/**
 	 * Commit lanes executing async transaction commits off the libuv
 	 * threadpool, shared by all envs/handles on this database. In the default
 	 * single-lane mode only commitWorker runs: each commit executes its log

--- a/src/database.ts
+++ b/src/database.ts
@@ -575,6 +575,33 @@ export class RocksDatabase extends DBI<DBITransactional> {
 	}
 
 	/**
+	 * Whether RocksDB is currently applying write backpressure to this database —
+	 * either delaying (rate-limiting) or fully stopping writes. This is the
+	 * authoritative, live pull counterpart to the `'writeStall'`
+	 * [event](../README.md#event-writestall): the event pushes per-column-family
+	 * transitions (and is rate-limited), while this reads the current state on
+	 * demand and can never be stale.
+	 *
+	 * The write controller is database-wide (shared across every column family),
+	 * so this reflects the database as a whole, not a single column family — a
+	 * stall triggered by any column family stops writes for all of them. Reads
+	 * `rocksdb.is-write-stopped` and `rocksdb.actual-delayed-write-rate`.
+	 *
+	 * @example
+	 * ```typescript
+	 * db.on('writeStall', (cf) => {
+	 * 	if (db.isWriteStalled()) log.warn(`writes throttled/blocked (triggered by ${cf})`);
+	 * });
+	 * ```
+	 */
+	isWriteStalled(): boolean {
+		return (
+			this.getDBIntProperty('rocksdb.is-write-stopped') === 1 ||
+			(this.getDBIntProperty('rocksdb.actual-delayed-write-rate') ?? 0) > 0
+		);
+	}
+
+	/**
 	 * Retrieves the estimated number of keys in the database. This is an alias
 	 * for `db.estimateCount().count`; use `estimateCount()` for range support
 	 * and a confidence indicator.

--- a/test/fixtures/fork-write-stall-relisten.mts
+++ b/test/fixtures/fork-write-stall-relisten.mts
@@ -1,15 +1,14 @@
 /**
- * Regression fixture for the writeStall debounce blocker: the per-CF debounce
- * FSM must advance even while no one is listening, otherwise a CF marked stalled
- * while a listener was attached stays stuck `stalledReported` after the listener
- * detaches and the CF recovers unobserved — permanently suppressing the rising
- * edge for any listener attached later.
+ * The per-CF debounce FSM must advance even while no one is listening, otherwise
+ * a CF that stalled while a listener was attached stays stuck "reported stalled"
+ * after the listener detaches and the CF recovers unobserved — suppressing the
+ * rising edge for any listener attached later.
  *
- * Run with ROCKSDB_JS_WRITE_STALL_DEBOUNCE_MS=0 so recovery clears the FSM
- * immediately (no window), making the outcome independent of flush timing:
+ * Run with ROCKSDB_JS_WRITE_STALL_DEBOUNCE_MS=0 so the re-arm is independent of
+ * flush timing:
  *   1. attach a listener, provoke a stall (rising edge observed),
  *   2. detach it, stop writing so the CFs recover with no listener attached,
- *   3. re-attach and provoke a stall again — a fixed implementation re-emits.
+ *   3. re-attach and provoke a stall again — the rising edge must re-emit.
  */
 import { RocksDatabase, shutdown } from '../../src/index.ts';
 import { rmSync } from 'node:fs';

--- a/test/fixtures/fork-write-stall-relisten.mts
+++ b/test/fixtures/fork-write-stall-relisten.mts
@@ -1,0 +1,64 @@
+/**
+ * Regression fixture for the writeStall debounce blocker: the per-CF debounce
+ * FSM must advance even while no one is listening, otherwise a CF marked stalled
+ * while a listener was attached stays stuck `stalledReported` after the listener
+ * detaches and the CF recovers unobserved — permanently suppressing the rising
+ * edge for any listener attached later.
+ *
+ * Run with ROCKSDB_JS_WRITE_STALL_DEBOUNCE_MS=0 so recovery clears the FSM
+ * immediately (no window), making the outcome independent of flush timing:
+ *   1. attach a listener, provoke a stall (rising edge observed),
+ *   2. detach it, stop writing so the CFs recover with no listener attached,
+ *   3. re-attach and provoke a stall again — a fixed implementation re-emits.
+ */
+import { RocksDatabase, shutdown } from '../../src/index.ts';
+import { rmSync } from 'node:fs';
+import { setTimeout as delay } from 'node:timers/promises';
+
+const dbPath = process.argv[2];
+const CF_COUNT = 8;
+const opts = { writeBufferSize: 64 * 1024, maxWriteBufferNumber: 2, dbWriteBufferSize: 256 * 1024 };
+const dbs: RocksDatabase[] = [];
+for (let i = 0; i < CF_COUNT; i++) {
+	const db = new RocksDatabase(dbPath, i === 0 ? opts : { ...opts, name: `cf-${i}` });
+	db.open();
+	dbs.push(db);
+}
+
+const value = Buffer.alloc(4096, 0x61);
+let record = 0;
+async function driveUntilStall(events: unknown[], maxMs: number): Promise<boolean> {
+	const start = performance.now();
+	while (performance.now() - start < maxMs) {
+		for (let i = 0; i < 50; i++, record++) {
+			dbs[record % CF_COUNT].putSync(`k-${record.toString().padStart(8, '0')}`, value);
+		}
+		await delay(0);
+		if (events.length > 0) return true;
+	}
+	return false;
+}
+
+// Phase 1: listener attached, provoke a stall.
+const e1: { cf: string; prev: string; cur: string }[] = [];
+const l1 = (...a: any[]) => void e1.push({ cf: a[0], prev: a[1], cur: a[2] });
+dbs[0].addListener('writeStall', l1);
+const firstStall = await driveUntilStall(e1, 5000);
+
+// Phase 2: detach, then stop writing so the CFs recover with nothing listening.
+dbs[0].removeListener('writeStall', l1);
+await delay(1000);
+
+// Phase 3: re-attach and provoke a stall again.
+const e2: { cf: string; prev: string; cur: string }[] = [];
+const l2 = (...a: any[]) => void e2.push({ cf: a[0], prev: a[1], cur: a[2] });
+dbs[0].addListener('writeStall', l2);
+const secondStall = await driveUntilStall(e2, 5000);
+
+console.log('RESULT ' + JSON.stringify({ firstStall, secondStall, e2sample: e2.slice(0, 3) }));
+
+for (let i = dbs.length - 1; i >= 0; i--) {
+	dbs[i].close();
+}
+shutdown();
+rmSync(dbPath, { force: true, recursive: true, maxRetries: 3 });

--- a/test/native/write_stall_debounce_test.cc
+++ b/test/native/write_stall_debounce_test.cc
@@ -1,5 +1,8 @@
 #include <gtest/gtest.h>
+#include <atomic>
 #include <chrono>
+#include <thread>
+#include <vector>
 #include "core/write_stall_debounce.h"
 
 using rocksdb_js::WriteStallDebounce;
@@ -15,68 +18,109 @@ Clock::time_point at(long long ms) {
 
 constexpr uint64_t kWindow = 1000;
 
+// Most tests only care about the emit decision (the bool), not the callback.
+auto noop = [] {};
+
 } // namespace
 
 TEST(WriteStallDebounce, RisingEmitsFallingDoesNot) {
 	WriteStallDebounce d;
-	EXPECT_TRUE(d.onTransition("cf", true, at(0), kWindow));   // rising -> emit
-	EXPECT_FALSE(d.onTransition("cf", false, at(50), kWindow)); // falling -> no emit
+	EXPECT_TRUE(d.onTransition("cf", true, at(0), kWindow, noop));   // rising -> emit
+	EXPECT_FALSE(d.onTransition("cf", false, at(50), kWindow, noop)); // falling -> no emit
 }
 
 TEST(WriteStallDebounce, StaysStalledDoesNotReEmit) {
 	WriteStallDebounce d;
-	EXPECT_TRUE(d.onTransition("cf", true, at(0), kWindow));
+	EXPECT_TRUE(d.onTransition("cf", true, at(0), kWindow, noop));
 	// A second "stalled" with no intervening normal is not a rising edge.
-	EXPECT_FALSE(d.onTransition("cf", true, at(10), kWindow));
+	EXPECT_FALSE(d.onTransition("cf", true, at(10), kWindow, noop));
 }
 
 TEST(WriteStallDebounce, OscillationIsRateLimitedToOnePerWindow) {
 	WriteStallDebounce d;
-	EXPECT_TRUE(d.onTransition("cf", true, at(0), kWindow)); // first rising emits
+	EXPECT_TRUE(d.onTransition("cf", true, at(0), kWindow, noop)); // first rising emits
 	// Dips and re-entries inside the window are suppressed.
-	EXPECT_FALSE(d.onTransition("cf", false, at(50), kWindow));
-	EXPECT_FALSE(d.onTransition("cf", true, at(100), kWindow));
-	EXPECT_FALSE(d.onTransition("cf", false, at(150), kWindow));
-	EXPECT_FALSE(d.onTransition("cf", true, at(900), kWindow));
+	EXPECT_FALSE(d.onTransition("cf", false, at(50), kWindow, noop));
+	EXPECT_FALSE(d.onTransition("cf", true, at(100), kWindow, noop));
+	EXPECT_FALSE(d.onTransition("cf", false, at(150), kWindow, noop));
+	EXPECT_FALSE(d.onTransition("cf", true, at(900), kWindow, noop));
 	// A rising a full window after the last emit is allowed through (heartbeat).
-	EXPECT_FALSE(d.onTransition("cf", false, at(1050), kWindow));
-	EXPECT_TRUE(d.onTransition("cf", true, at(1100), kWindow));
+	EXPECT_FALSE(d.onTransition("cf", false, at(1050), kWindow, noop));
+	EXPECT_TRUE(d.onTransition("cf", true, at(1100), kWindow, noop));
 }
 
 TEST(WriteStallDebounce, BlipDoesNotSwallowTheNextRealStall) {
 	WriteStallDebounce d;
 	// Short blip: stall then quick recovery within the window.
-	EXPECT_TRUE(d.onTransition("cf", true, at(0), kWindow));
-	EXPECT_FALSE(d.onTransition("cf", false, at(200), kWindow));
+	EXPECT_TRUE(d.onTransition("cf", true, at(0), kWindow, noop));
+	EXPECT_FALSE(d.onTransition("cf", false, at(200), kWindow, noop));
 	// A genuine, much-later stall must still alert (the regression: it used to be
 	// swallowed because the reported-stalled bit was stranded).
-	EXPECT_TRUE(d.onTransition("cf", true, at(600000), kWindow));
+	EXPECT_TRUE(d.onTransition("cf", true, at(600000), kWindow, noop));
 }
 
 TEST(WriteStallDebounce, ZeroWindowEmitsEveryRisingEdge) {
 	WriteStallDebounce d;
-	EXPECT_TRUE(d.onTransition("cf", true, at(0), 0));
-	EXPECT_FALSE(d.onTransition("cf", false, at(1), 0));
-	EXPECT_TRUE(d.onTransition("cf", true, at(2), 0));
-	EXPECT_FALSE(d.onTransition("cf", false, at(3), 0));
-	EXPECT_TRUE(d.onTransition("cf", true, at(4), 0));
+	EXPECT_TRUE(d.onTransition("cf", true, at(0), 0, noop));
+	EXPECT_FALSE(d.onTransition("cf", false, at(1), 0, noop));
+	EXPECT_TRUE(d.onTransition("cf", true, at(2), 0, noop));
+	EXPECT_FALSE(d.onTransition("cf", false, at(3), 0, noop));
+	EXPECT_TRUE(d.onTransition("cf", true, at(4), 0, noop));
 }
 
 TEST(WriteStallDebounce, ForgetResetsState) {
 	WriteStallDebounce d;
-	EXPECT_TRUE(d.onTransition("cf", true, at(0), kWindow));
+	EXPECT_TRUE(d.onTransition("cf", true, at(0), kWindow, noop));
 	// Without forget, a re-stall inside the window would be suppressed.
 	d.forget("cf");
 	// After forget, the CF is fresh: the next rising emits immediately.
-	EXPECT_TRUE(d.onTransition("cf", true, at(10), kWindow));
+	EXPECT_TRUE(d.onTransition("cf", true, at(10), kWindow, noop));
 }
 
 TEST(WriteStallDebounce, ColumnFamiliesAreIndependent) {
 	WriteStallDebounce d;
-	EXPECT_TRUE(d.onTransition("a", true, at(0), kWindow));
+	EXPECT_TRUE(d.onTransition("a", true, at(0), kWindow, noop));
 	// A different CF has its own state and emits its own rising edge.
-	EXPECT_TRUE(d.onTransition("b", true, at(1), kWindow));
+	EXPECT_TRUE(d.onTransition("b", true, at(1), kWindow, noop));
 	// Neither re-emits without a falling edge first.
-	EXPECT_FALSE(d.onTransition("a", true, at(2), kWindow));
-	EXPECT_FALSE(d.onTransition("b", true, at(3), kWindow));
+	EXPECT_FALSE(d.onTransition("a", true, at(2), kWindow, noop));
+	EXPECT_FALSE(d.onTransition("b", true, at(3), kWindow, noop));
+}
+
+TEST(WriteStallDebounce, EmitRunsUnderTheLockAndNeverOverlaps) {
+	// RocksDB may fire a CF's callbacks from multiple threads without serializing
+	// them; the FSM must still run each decision->emit atomically so enqueues can't
+	// interleave and reorder. Hammer one CF from many threads and assert the emit
+	// callback is never entered concurrently.
+	WriteStallDebounce d;
+	std::atomic<int> concurrentlyInEmit{0};
+	std::atomic<bool> overlapSeen{false};
+	std::atomic<int> emitCount{0};
+	auto emit = [&]() {
+		if (concurrentlyInEmit.fetch_add(1, std::memory_order_acq_rel) != 0) {
+			overlapSeen.store(true);
+		}
+		std::this_thread::yield(); // widen any overlap window
+		if (concurrentlyInEmit.fetch_sub(1, std::memory_order_acq_rel) != 1) {
+			overlapSeen.store(true);
+		}
+		emitCount.fetch_add(1, std::memory_order_relaxed);
+	};
+
+	std::vector<std::thread> threads;
+	for (int t = 0; t < 8; t++) {
+		threads.emplace_back([&, t]() {
+			for (int i = 0; i < 2000; i++) {
+				const bool stalled = (i & 1) == 0;
+				// windowMs = 0 so every rising edge attempts an emit (max contention).
+				d.onTransition("cf", stalled, at(t * 100000LL + i), 0, emit);
+			}
+		});
+	}
+	for (auto& th : threads) {
+		th.join();
+	}
+
+	EXPECT_FALSE(overlapSeen.load()) << "emit callback ran concurrently — decision/enqueue not atomic";
+	EXPECT_GT(emitCount.load(), 0) << "no emits observed under contention";
 }

--- a/test/native/write_stall_debounce_test.cc
+++ b/test/native/write_stall_debounce_test.cc
@@ -1,0 +1,82 @@
+#include <gtest/gtest.h>
+#include <chrono>
+#include "core/write_stall_debounce.h"
+
+using rocksdb_js::WriteStallDebounce;
+
+namespace {
+
+using Clock = WriteStallDebounce::Clock;
+
+// A fixed base so tests can express times as millisecond offsets.
+Clock::time_point at(long long ms) {
+	return Clock::time_point{} + std::chrono::milliseconds(ms);
+}
+
+constexpr uint64_t kWindow = 1000;
+
+} // namespace
+
+TEST(WriteStallDebounce, RisingEmitsFallingDoesNot) {
+	WriteStallDebounce d;
+	EXPECT_TRUE(d.onTransition("cf", true, at(0), kWindow));   // rising -> emit
+	EXPECT_FALSE(d.onTransition("cf", false, at(50), kWindow)); // falling -> no emit
+}
+
+TEST(WriteStallDebounce, StaysStalledDoesNotReEmit) {
+	WriteStallDebounce d;
+	EXPECT_TRUE(d.onTransition("cf", true, at(0), kWindow));
+	// A second "stalled" with no intervening normal is not a rising edge.
+	EXPECT_FALSE(d.onTransition("cf", true, at(10), kWindow));
+}
+
+TEST(WriteStallDebounce, OscillationIsRateLimitedToOnePerWindow) {
+	WriteStallDebounce d;
+	EXPECT_TRUE(d.onTransition("cf", true, at(0), kWindow)); // first rising emits
+	// Dips and re-entries inside the window are suppressed.
+	EXPECT_FALSE(d.onTransition("cf", false, at(50), kWindow));
+	EXPECT_FALSE(d.onTransition("cf", true, at(100), kWindow));
+	EXPECT_FALSE(d.onTransition("cf", false, at(150), kWindow));
+	EXPECT_FALSE(d.onTransition("cf", true, at(900), kWindow));
+	// A rising a full window after the last emit is allowed through (heartbeat).
+	EXPECT_FALSE(d.onTransition("cf", false, at(1050), kWindow));
+	EXPECT_TRUE(d.onTransition("cf", true, at(1100), kWindow));
+}
+
+TEST(WriteStallDebounce, BlipDoesNotSwallowTheNextRealStall) {
+	WriteStallDebounce d;
+	// Short blip: stall then quick recovery within the window.
+	EXPECT_TRUE(d.onTransition("cf", true, at(0), kWindow));
+	EXPECT_FALSE(d.onTransition("cf", false, at(200), kWindow));
+	// A genuine, much-later stall must still alert (the regression: it used to be
+	// swallowed because the reported-stalled bit was stranded).
+	EXPECT_TRUE(d.onTransition("cf", true, at(600000), kWindow));
+}
+
+TEST(WriteStallDebounce, ZeroWindowEmitsEveryRisingEdge) {
+	WriteStallDebounce d;
+	EXPECT_TRUE(d.onTransition("cf", true, at(0), 0));
+	EXPECT_FALSE(d.onTransition("cf", false, at(1), 0));
+	EXPECT_TRUE(d.onTransition("cf", true, at(2), 0));
+	EXPECT_FALSE(d.onTransition("cf", false, at(3), 0));
+	EXPECT_TRUE(d.onTransition("cf", true, at(4), 0));
+}
+
+TEST(WriteStallDebounce, ForgetResetsState) {
+	WriteStallDebounce d;
+	EXPECT_TRUE(d.onTransition("cf", true, at(0), kWindow));
+	// Without forget, a re-stall inside the window would be suppressed.
+	d.forget("cf");
+	// After forget, the CF is fresh: the next rising emits immediately.
+	EXPECT_TRUE(d.onTransition("cf", true, at(10), kWindow));
+}
+
+TEST(WriteStallDebounce, ColumnFamiliesAreIndependent) {
+	WriteStallDebounce d;
+	EXPECT_TRUE(d.onTransition("a", true, at(0), kWindow));
+	// A different CF has its own state and emits its own rising edge.
+	EXPECT_TRUE(d.onTransition("b", true, at(1), kWindow));
+	// Neither re-emits without a falling edge first.
+	EXPECT_FALSE(d.onTransition("a", true, at(2), kWindow));
+	EXPECT_FALSE(d.onTransition("b", true, at(3), kWindow));
+}

--- a/test/write-stall-relisten.test.ts
+++ b/test/write-stall-relisten.test.ts
@@ -1,0 +1,49 @@
+import { generateDBPath } from './lib/util.ts';
+import { spawn } from 'node:child_process';
+import { rmSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Regression for the writeStall debounce blocker (both cross-model reviewers): the
+ * per-CF FSM must advance while unobserved, so a listener attached after a stall
+ * episode still gets the rising edge on the next stall. Runs in a child process so
+ * ROCKSDB_JS_WRITE_STALL_DEBOUNCE_MS=0 reaches native `::getenv` (a worker_threads
+ * `process.env` write would not), making recovery clear the FSM deterministically.
+ */
+describe('writeStall listener re-registration', () => {
+	it('re-emits after a listener detaches, the CF recovers unobserved, and one re-attaches', async () => {
+		const dbPath = generateDBPath();
+		const fixture = join(__dirname, 'fixtures', 'fork-write-stall-relisten.mts');
+		try {
+			const output = await new Promise<string>((resolve, reject) => {
+				let out = '';
+				const child = spawn(process.execPath, [fixture, dbPath], {
+					env: { ...process.env, ROCKSDB_JS_WRITE_STALL_DEBOUNCE_MS: '0' },
+				});
+				child.stdout.setEncoding('utf8');
+				child.stderr.setEncoding('utf8');
+				child.stdout.on('data', (c) => (out += c));
+				child.stderr.on('data', (c) => (out += c));
+				child.on('error', reject);
+				child.on('close', (code) =>
+					code === 0 ? resolve(out) : reject(new Error(`fixture exited ${code}: ${out}`))
+				);
+			});
+
+			const line = output.split('\n').find((l) => l.startsWith('RESULT '));
+			expect(line, `no RESULT line in fixture output: ${output}`).toBeTruthy();
+			const result = JSON.parse(line!.slice('RESULT '.length));
+
+			expect(result.firstStall).toBe(true);
+			// The blocker: without the fix, the FSM never advances while unobserved,
+			// so the re-attached listener never sees the next stall's rising edge.
+			expect(result.secondStall).toBe(true);
+		} finally {
+			rmSync(dbPath, { force: true, recursive: true, maxRetries: 3 });
+		}
+	}, 30_000);
+});

--- a/test/write-stall-relisten.test.ts
+++ b/test/write-stall-relisten.test.ts
@@ -8,11 +8,11 @@ import { describe, expect, it } from 'vitest';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
 /**
- * Regression for the writeStall debounce blocker (both cross-model reviewers): the
- * per-CF FSM must advance while unobserved, so a listener attached after a stall
- * episode still gets the rising edge on the next stall. Runs in a child process so
- * ROCKSDB_JS_WRITE_STALL_DEBOUNCE_MS=0 reaches native `::getenv` (a worker_threads
- * `process.env` write would not), making recovery clear the FSM deterministically.
+ * The per-CF debounce FSM must advance while unobserved, so a listener attached
+ * after a stall episode still gets the rising edge on the next stall (rather than
+ * having it suppressed by state stranded when no one was listening). Runs in a
+ * child process so ROCKSDB_JS_WRITE_STALL_DEBOUNCE_MS=0 reaches native `::getenv`
+ * (a worker_threads `process.env` write would not), making the re-arm deterministic.
  */
 describe('writeStall listener re-registration', () => {
 	it('re-emits after a listener detaches, the CF recovers unobserved, and one re-attaches', async () => {

--- a/test/write-stall.test.ts
+++ b/test/write-stall.test.ts
@@ -5,22 +5,29 @@ import { setTimeout as delay } from 'node:timers/promises';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 /**
- * POC coverage for the per-database `'writeStall'` event (HarperFast/rocksdb-js).
+ * Coverage for the per-database `'writeStall'` event, emitted from RocksDB's
+ * `EventListener::OnStallConditionsChanged` when a column family crosses between
+ * write-stall conditions (`normal`/`delayed`/`stopped`).
  *
- * The event is emitted from RocksDB's `EventListener::OnStallConditionsChanged`, which fires when a
- * column family crosses between write-stall conditions (`normal`/`delayed`/`stopped`). We provoke a
- * per-CF stall the same way the `dbWriteBufferSize`-oversubscription pathology does, but at micro
- * scale so it fires in well under a second instead of the ~20-minute production arm:
+ * We provoke a real per-CF stall the same way the `dbWriteBufferSize`
+ * -oversubscription pathology does, but at micro scale so it fires in ~1s instead
+ * of the ~20-minute production arm: tiny per-CF memtables (`writeBufferSize`
+ * 64 KiB) that fill in a few writes, a queue depth of 2 (`maxWriteBufferNumber`)
+ * so a CF stalls after 2 unflushed memtables, and several column families sharing
+ * a tiny global budget (`dbWriteBufferSize` 256 KiB) so atomic-flush triggers
+ * fire constantly. A tight synchronous `putSync` burst outruns the flush
+ * pipeline; the emit is dispatched asynchronously, so we yield between chunks to
+ * receive events.
  *
- *   - tiny per-CF memtables (`writeBufferSize` 64 KiB) that fill in a handful of writes,
- *   - a low queue depth (`maxWriteBufferNumber` 2) so a CF stalls after 2 unflushed memtables,
- *   - several column families sharing a tiny global budget (`dbWriteBufferSize` 256 KiB) so
- *     atomic-flush triggers fire constantly and immutable memtables pile up faster than the single
- *     flush pipeline drains them.
- *
- * A tight synchronous `putSync` burst outruns background flushes and trips the stall; the emit is
- * dispatched asynchronously, so we yield between chunks to let queued events arrive and stop as soon
- * as one is observed (bounding runtime regardless of machine speed).
+ * The native emit is edge-triggered debounced per CF (falling-edge window default
+ * 1000 ms via `ROCKSDB_JS_WRITE_STALL_DEBOUNCE_MS`): the rising edge into a stall
+ * fires promptly, the recovery to normal is debounced, and a CF flipping
+ * condition thousands of times/sec cannot flood the threadsafe-function queue.
+ * The test relies on that default: it drives the stall for well under one window
+ * (~500 ms), during which each CF transitions many times but only its rising edge
+ * emits — so `count === 1 per CF` proves both the emit and the debounce (without
+ * it this would be hundreds per CF), and every emit's `cur` is a stalling state
+ * (`delayed`/`stopped`), never a bare `normal`.
  */
 describe('writeStall event', () => {
 	const CF_COUNT = 8;
@@ -51,7 +58,7 @@ describe('writeStall event', () => {
 		rmSync(dbPath, { force: true, recursive: true, maxRetries: 3, retryDelay: 500 });
 	});
 
-	it('emits writeStall with column family and condition transition when a CF stalls', async () => {
+	it('emits a debounced writeStall per column family with the condition transition', async () => {
 		type StallEvent = { cfName: string; prev: string; cur: string };
 		const events: StallEvent[] = [];
 		dbs[0].addListener('writeStall', (cfName: string, prev: string, cur: string) => {
@@ -59,29 +66,47 @@ describe('writeStall event', () => {
 		});
 
 		const value = Buffer.alloc(4096, 0x61);
-		const CHUNK = 500;
-		const MAX_RECORDS = 40_000; // upper bound; we break as soon as a stall is seen
+		// Drive the stall in small chunks, staying strictly inside one debounce
+		// window (< 1000 ms) so the debounce permits at most one emit per CF. Small
+		// chunks keep any single stalled putSync from overshooting the window.
+		const WINDOW_MS = 500;
+		const CHUNK = 50;
+		const FAIL_DEADLINE_MS = 5000;
+		const start = performance.now();
 		let record = 0;
-		while (record < MAX_RECORDS && events.length === 0) {
+		for (;;) {
 			for (let i = 0; i < CHUNK; i++, record++) {
 				dbs[record % CF_COUNT].putSync(`k-${record.toString().padStart(8, '0')}`, value);
 			}
-			// Yield so the async-dispatched writeStall events can be delivered.
-			await delay(0);
+			await delay(0); // yield so async-dispatched events are delivered
+			const elapsed = performance.now() - start;
+			if (events.length > 0 && elapsed >= WINDOW_MS) break; // stalled, still within one window
+			if (elapsed >= FAIL_DEADLINE_MS) break; // fail-loud: no stall materialized
 		}
-		// Give any in-flight emits a moment to land after the final chunk.
-		await delay(50);
+		await delay(50); // let any in-flight emit from the final chunk land
 
+		// A stall must have occurred (fail-loud rather than silently skipping).
 		expect(events.length).toBeGreaterThan(0);
+
+		// Debounce: within one <1000 ms window a CF transitions many times but is
+		// permitted at most one emit. count===1 proves both the emit and the
+		// debounce; without debouncing this would be hundreds per CF.
+		const perCf = new Map<string, number>();
+		for (const e of events) {
+			perCf.set(e.cfName, (perCf.get(e.cfName) ?? 0) + 1);
+		}
+		for (const [cf, count] of perCf) {
+			expect(count, `CF ${cf} emitted ${count}x within one debounce window`).toBe(1);
+		}
 
 		const conditions = new Set(['normal', 'delayed', 'stopped']);
 		for (const e of events) {
 			expect(e.cfName).toBeTypeOf('string');
 			expect(conditions.has(e.prev)).toBe(true);
 			expect(conditions.has(e.cur)).toBe(true);
-			expect(e.prev).not.toBe(e.cur); // only fires on a real transition
+			expect(e.prev).not.toBe(e.cur); // fires only on a real transition
+			// Every emit here is a rising edge into a stall — never a bare recovery.
+			expect(e.cur === 'delayed' || e.cur === 'stopped', `unexpected cur=${e.cur}`).toBe(true);
 		}
-		// At least one event must report throttling/blocking, not just a return to normal.
-		expect(events.some((e) => e.cur === 'delayed' || e.cur === 'stopped')).toBe(true);
 	}, 30_000);
 });

--- a/test/write-stall.test.ts
+++ b/test/write-stall.test.ts
@@ -1,0 +1,87 @@
+import { RocksDatabase } from '../src/index.ts';
+import { generateDBPath } from './lib/util.ts';
+import { rmSync } from 'node:fs';
+import { setTimeout as delay } from 'node:timers/promises';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+/**
+ * POC coverage for the per-database `'writeStall'` event (HarperFast/rocksdb-js).
+ *
+ * The event is emitted from RocksDB's `EventListener::OnStallConditionsChanged`, which fires when a
+ * column family crosses between write-stall conditions (`normal`/`delayed`/`stopped`). We provoke a
+ * per-CF stall the same way the `dbWriteBufferSize`-oversubscription pathology does, but at micro
+ * scale so it fires in well under a second instead of the ~20-minute production arm:
+ *
+ *   - tiny per-CF memtables (`writeBufferSize` 64 KiB) that fill in a handful of writes,
+ *   - a low queue depth (`maxWriteBufferNumber` 2) so a CF stalls after 2 unflushed memtables,
+ *   - several column families sharing a tiny global budget (`dbWriteBufferSize` 256 KiB) so
+ *     atomic-flush triggers fire constantly and immutable memtables pile up faster than the single
+ *     flush pipeline drains them.
+ *
+ * A tight synchronous `putSync` burst outruns background flushes and trips the stall; the emit is
+ * dispatched asynchronously, so we yield between chunks to let queued events arrive and stop as soon
+ * as one is observed (bounding runtime regardless of machine speed).
+ */
+describe('writeStall event', () => {
+	const CF_COUNT = 8;
+	const dbPath = generateDBPath();
+	const pathological = {
+		writeBufferSize: 64 * 1024,
+		maxWriteBufferNumber: 2,
+		dbWriteBufferSize: 256 * 1024,
+	};
+	let dbs: RocksDatabase[] = [];
+
+	beforeEach(() => {
+		dbs = [];
+		for (let i = 0; i < CF_COUNT; i++) {
+			const db = new RocksDatabase(
+				dbPath,
+				i === 0 ? pathological : { ...pathological, name: `cf-${i}` }
+			);
+			db.open();
+			dbs.push(db);
+		}
+	});
+
+	afterEach(() => {
+		for (let i = dbs.length - 1; i >= 0; i--) {
+			dbs[i].close();
+		}
+		rmSync(dbPath, { force: true, recursive: true, maxRetries: 3, retryDelay: 500 });
+	});
+
+	it('emits writeStall with column family and condition transition when a CF stalls', async () => {
+		type StallEvent = { cfName: string; prev: string; cur: string };
+		const events: StallEvent[] = [];
+		dbs[0].addListener('writeStall', (cfName: string, prev: string, cur: string) => {
+			events.push({ cfName, prev, cur });
+		});
+
+		const value = Buffer.alloc(4096, 0x61);
+		const CHUNK = 500;
+		const MAX_RECORDS = 40_000; // upper bound; we break as soon as a stall is seen
+		let record = 0;
+		while (record < MAX_RECORDS && events.length === 0) {
+			for (let i = 0; i < CHUNK; i++, record++) {
+				dbs[record % CF_COUNT].putSync(`k-${record.toString().padStart(8, '0')}`, value);
+			}
+			// Yield so the async-dispatched writeStall events can be delivered.
+			await delay(0);
+		}
+		// Give any in-flight emits a moment to land after the final chunk.
+		await delay(50);
+
+		expect(events.length).toBeGreaterThan(0);
+
+		const conditions = new Set(['normal', 'delayed', 'stopped']);
+		for (const e of events) {
+			expect(e.cfName).toBeTypeOf('string');
+			expect(conditions.has(e.prev)).toBe(true);
+			expect(conditions.has(e.cur)).toBe(true);
+			expect(e.prev).not.toBe(e.cur); // only fires on a real transition
+		}
+		// At least one event must report throttling/blocking, not just a return to normal.
+		expect(events.some((e) => e.cur === 'delayed' || e.cur === 'stopped')).toBe(true);
+	}, 30_000);
+});

--- a/test/write-stall.test.ts
+++ b/test/write-stall.test.ts
@@ -5,29 +5,18 @@ import { setTimeout as delay } from 'node:timers/promises';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 /**
- * Coverage for the per-database `'writeStall'` event, emitted from RocksDB's
- * `EventListener::OnStallConditionsChanged` when a column family crosses between
- * write-stall conditions (`normal`/`delayed`/`stopped`).
+ * End-to-end wiring for the per-database `'writeStall'` event and the
+ * `isWriteStalled()` pull. The debounce state machine itself is unit-tested
+ * deterministically in `test/native/write_stall_debounce_test.cc`; this only
+ * proves the RocksDB `OnStallConditionsChanged` hook reaches JS with a valid
+ * per-CF payload and that `isWriteStalled()` reflects the live condition.
  *
- * We provoke a real per-CF stall the same way the `dbWriteBufferSize`
- * -oversubscription pathology does, but at micro scale so it fires in ~1s instead
- * of the ~20-minute production arm: tiny per-CF memtables (`writeBufferSize`
- * 64 KiB) that fill in a few writes, a queue depth of 2 (`maxWriteBufferNumber`)
- * so a CF stalls after 2 unflushed memtables, and several column families sharing
- * a tiny global budget (`dbWriteBufferSize` 256 KiB) so atomic-flush triggers
- * fire constantly. A tight synchronous `putSync` burst outruns the flush
- * pipeline; the emit is dispatched asynchronously, so we yield between chunks to
- * receive events.
- *
- * The native emit is edge-triggered debounced per CF (falling-edge window default
- * 1000 ms via `ROCKSDB_JS_WRITE_STALL_DEBOUNCE_MS`): the rising edge into a stall
- * fires promptly, the recovery to normal is debounced, and a CF flipping
- * condition thousands of times/sec cannot flood the threadsafe-function queue.
- * The test relies on that default: it drives the stall for well under one window
- * (~500 ms), during which each CF transitions many times but only its rising edge
- * emits — so `count === 1 per CF` proves both the emit and the debounce (without
- * it this would be hundreds per CF), and every emit's `cur` is a stalling state
- * (`delayed`/`stopped`), never a bare `normal`.
+ * A real stall is provoked at micro scale (64 KiB write buffers,
+ * `maxWriteBufferNumber` 2, several CFs, tiny `dbWriteBufferSize`) so a tight
+ * synchronous `putSync` burst outruns the flush pipeline in ~1s. Assertions avoid
+ * timing/count bounds (the event is rate-limited, so a slow run may see a
+ * heartbeat re-emit — that's the FSM's job to bound, covered natively); it only
+ * requires that a stall was observed and every emitted event is a rising edge.
  */
 describe('writeStall event', () => {
 	const CF_COUNT = 8;
@@ -58,7 +47,7 @@ describe('writeStall event', () => {
 		rmSync(dbPath, { force: true, recursive: true, maxRetries: 3, retryDelay: 500 });
 	});
 
-	it('emits a debounced writeStall per column family with the condition transition', async () => {
+	it('emits a per-CF rising edge, and isWriteStalled() is wired', async () => {
 		type StallEvent = { cfName: string; prev: string; cur: string };
 		const events: StallEvent[] = [];
 		dbs[0].addListener('writeStall', (cfName: string, prev: string, cur: string) => {
@@ -66,38 +55,25 @@ describe('writeStall event', () => {
 		});
 
 		const value = Buffer.alloc(4096, 0x61);
-		// Drive the stall in small chunks, staying strictly inside one debounce
-		// window (< 1000 ms) so the debounce permits at most one emit per CF. Small
-		// chunks keep any single stalled putSync from overshooting the window.
-		const WINDOW_MS = 500;
-		const CHUNK = 50;
-		const FAIL_DEADLINE_MS = 5000;
-		const start = performance.now();
+		const CHUNK = 100;
+		const MAX_RECORDS = 40_000; // fail-loud bound; a stall is near-certain well before this
 		let record = 0;
-		for (;;) {
+		while (record < MAX_RECORDS && events.length === 0) {
 			for (let i = 0; i < CHUNK; i++, record++) {
 				dbs[record % CF_COUNT].putSync(`k-${record.toString().padStart(8, '0')}`, value);
 			}
 			await delay(0); // yield so async-dispatched events are delivered
-			const elapsed = performance.now() - start;
-			if (events.length > 0 && elapsed >= WINDOW_MS) break; // stalled, still within one window
-			if (elapsed >= FAIL_DEADLINE_MS) break; // fail-loud: no stall materialized
 		}
-		await delay(50); // let any in-flight emit from the final chunk land
+		await delay(50); // let any in-flight emit land
 
 		// A stall must have occurred (fail-loud rather than silently skipping).
 		expect(events.length).toBeGreaterThan(0);
-
-		// Debounce: within one <1000 ms window a CF transitions many times but is
-		// permitted at most one emit. count===1 proves both the emit and the
-		// debounce; without debouncing this would be hundreds per CF.
-		const perCf = new Map<string, number>();
-		for (const e of events) {
-			perCf.set(e.cfName, (perCf.get(e.cfName) ?? 0) + 1);
-		}
-		for (const [cf, count] of perCf) {
-			expect(count, `CF ${cf} emitted ${count}x within one debounce window`).toBe(1);
-		}
+		// isWriteStalled() reads live DB-wide properties; observing `true` is racy
+		// from the same thread that does the synchronous writes (the thread only
+		// runs between stalls), so assert the wiring (returns a boolean) rather than
+		// a flaky live-true. The event above is the stall proof; the FSM itself is
+		// covered in test/native/write_stall_debounce_test.cc.
+		expect(typeof dbs[0].isWriteStalled()).toBe('boolean');
 
 		const conditions = new Set(['normal', 'delayed', 'stopped']);
 		for (const e of events) {
@@ -105,7 +81,7 @@ describe('writeStall event', () => {
 			expect(conditions.has(e.prev)).toBe(true);
 			expect(conditions.has(e.cur)).toBe(true);
 			expect(e.prev).not.toBe(e.cur); // fires only on a real transition
-			// Every emit here is a rising edge into a stall — never a bare recovery.
+			// Rising-edge only: every emit is an entry into a stall, never a bare recovery.
 			expect(e.cur === 'delayed' || e.cur === 'stopped', `unexpected cur=${e.cur}`).toBe(true);
 		}
 	}, 30_000);


### PR DESCRIPTION
## Summary

Adds a per-database `'writeStall'` event plus a `db.isWriteStalled()` pull, so an application can detect that RocksDB is throttling or blocking writes instead of discovering it as an unexplained throughput collapse. This is the observability surface for the `dbWriteBufferSize`-oversubscription pathology found while testing #788 (an undersized global memtable budget shared by many column families → constant premature flushes → write stall).

## The event: `'writeStall'` (push, per column family)

Fires when a column family **enters** a stall, with `(columnFamily, previousCondition, currentCondition)` — `currentCondition` is `'delayed'` (rate-limited) or `'stopped'` (blocked).

RocksDB oscillates a CF's stall condition many times per second during a sustained stall, so the event is **rising-edge only and rate-limited**: it fires on entry and then at most once per `ROCKSDB_JS_WRITE_STALL_DEBOUNCE_MS` (default 1000 ms) while the CF keeps stalling. It does **not** push recovery — reliably distinguishing a brief dip from a real recovery isn't possible without a timer thread (deliberately avoided), so recovery is a pull.

The debounce is a Node-free FSM (`core/write_stall_debounce.h`) that advances regardless of listeners (so a detach mid-stall can't strand state) and is unit-tested deterministically in `test/native/write_stall_debounce_test.cc`.

## The pull: `db.isWriteStalled(): boolean`

Authoritative live check over the DB-wide `rocksdb.is-write-stopped` / `rocksdb.actual-delayed-write-rate`. `true` when writes are delayed or stopped. It's the recovery/current-state counterpart to the event, and it's the push/pull mirror of stats that already exist (`getStats()` exposes `rocksdb.stall.micros` and the `rocksdb.db.write.stall` histogram). Database-wide (the write controller is shared across CFs), so it answers "is anything stalling writes" while the event names *which* CF.

```js
db.on('writeStall', (cf, prev, cur) => log.warn(`stall entered on ${cf}: ${prev} -> ${cur}`));
if (db.isWriteStalled()) log.warn('writes currently throttled or blocked');
```

## How it works

`OnStallConditionsChanged` on the existing `TransactionLogEventListener` → `DBDescriptor::emitWriteStall` → the FSM decides (under its own lock, released before `notify`; per-CF ordering is already RocksDB-serialized) → emit via the per-db event emitter. No napi on the background thread; the emit is wrapped so a `bad_alloc` can't unwind into RocksDB. The debounce window is resolved once at `open()` on the JS thread (no `::getenv` on the background thread). Per-CF state is retired on column-family drop.

## Tests

- `test/native/write_stall_debounce_test.cc` — the FSM: rising emits, oscillation rate-limit, blip-doesn't-swallow-next-stall, zero-window, forget, per-CF independence.
- `test/write-stall.test.ts` — end-to-end wiring: a real stall fires a valid rising-edge event; `isWriteStalled()` is wired.
- `test/write-stall-relisten.test.ts` — the detach → recover-unobserved → re-attach → re-emit path (child process, `DEBOUNCE_MS=0`, deterministic).

## Review

Two cross-model rounds (codex + gemini + Harper-domain) plus a human review from @kriszyp. Resolved: the debounce latch/flap (redesign above), the round-1 lock-across-notify over-correction, `::getenv` on the background thread, CF-drop map growth, and the flaky wall-clock test. Documented in README (event + `isWriteStalled`) and AGENTS.md (env var).

Known follow-up (not introduced here): `OnStallConditionsChanged` / `OnFlushBegin` / `OnFlushCompleted` all take a transient `lockDescriptor()` pin without the purge-retry the registry's ownership contract calls for — a pre-existing hazard shared by all three listener callbacks, tracked separately.

## Open decision

Recovery is intentionally pull-only (`isWriteStalled()`), not a pushed `'normal'` event. Punctual pushed recovery would need a per-descriptor timer; can add it if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
