### PR TITLE
Keep transaction-log flush tests compatible with Node.js 26.8

### DIFF
--- a/test/transaction-log.test.ts
+++ b/test/transaction-log.test.ts
@@ -2384,7 +2384,7 @@ describe('Transaction Log', () => {
 
 					db.flushSync();
 					const contents = readFileSync(join(dbPath, 'transaction_logs', 'foo', 'txn.state'));
-					const u32s = new Uint32Array(contents.buffer, contents.byteOffset);
+					const u32s = new Uint32Array(contents.buffer, contents.byteOffset, 2);
 					expect(u32s[1]).toBe(1);
 					expect(u32s[0]).toBeGreaterThan(1);
 
@@ -2418,7 +2418,7 @@ describe('Transaction Log', () => {
 
 				await db.flush();
 				let contents = readFileSync(join(dbPath, 'transaction_logs', 'foo', 'txn.state'));
-				let u32s = new Uint32Array(contents.buffer, contents.byteOffset);
+				let u32s = new Uint32Array(contents.buffer, contents.byteOffset, 2);
 				expect(u32s[1]).toBe(1);
 				expect(u32s[0]).toBeGreaterThan(1);
 
@@ -2454,7 +2454,7 @@ describe('Transaction Log', () => {
 				queryResults = Array.from(log.query({ startFromLastFlushed: true }));
 				expect(queryResults.length).toBe(0);
 				contents = readFileSync(join(dbPath, 'transaction_logs', 'foo', 'txn.state'));
-				u32s = new Uint32Array(contents.buffer, contents.byteOffset);
+				u32s = new Uint32Array(contents.buffer, contents.byteOffset, 2);
 				expect(u32s[1]).toBe(1);
 				expect(u32s[0]).toBeGreaterThan(200);
 			}));


### PR DESCRIPTION
Limit the [synchronous transaction-state view](https://github.com/HarperFast/rocksdb-js/pull/802/changes?w=1#diff-22a3c4e9b693561b0d3d6534ae81880ea0dec05f14fc12b7bbc837a5748e59e5R2387), [asynchronous view](https://github.com/HarperFast/rocksdb-js/pull/802/changes?w=1#diff-22a3c4e9b693561b0d3d6534ae81880ea0dec05f14fc12b7bbc837a5748e59e5R2421), and [post-query reread](https://github.com/HarperFast/rocksdb-js/pull/802/changes?w=1#diff-22a3c4e9b693561b0d3d6534ae81880ea0dec05f14fc12b7bbc837a5748e59e5R2457) to the two words in each `readFileSync()` Buffer slice. This keeps the flush tests compatible with Node.js 26.8's padded Buffer pool without changing production behavior.

## For the human reviewer

1. Keep the three bounded views inline rather than introduce a decoder helper. The reads are local and host-endian, and extracting a helper would only trade three explicit constructions for additional test abstraction; changing this later is a mechanical refactor with no behavior cost.

## Verification

- Node.js 26.8.1 focused flush tests: 2 passed; the same command fails on `origin/main` with the two reported `RangeError`s.
- Node.js 26.7.0 focused flush tests: 2 passed.
- `pnpm build`, `pnpm check`, and `pnpm test:native`: passed (148 passed, 3 platform skips for native tests).
- `pnpm test`: 822 passed and 2 skipped; three unrelated load-induced timeouts passed immediately when rerun individually.

Complexity: easy

<sub>Review-Coverage: authored=codex; ran=cursor-composer; adjudicated=domain; blocked=claude(not-installed),gemini(exit-1); declined=cursor-grok; rounds=1 @ 0c49cb80c918</sub>

<sub>Human-Review-Need: 3 (decisions: inline-bounded-views) @ 0c49cb80c918</sub>
