### PR TITLE
Allow shared dependency versions to dedupe

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,9 +58,9 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@harperfast/extended-iterable": "1.0.3",
-    "msgpackr": "2.0.6",
-    "ordered-binary": "1.6.1"
+    "@harperfast/extended-iterable": "^1.0.3",
+    "msgpackr": "^2.0.6",
+    "ordered-binary": "^1.6.1"
   },
   "devDependencies": {
     "@rollup/plugin-replace": "6.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,13 +9,13 @@ importers:
   .:
     dependencies:
       '@harperfast/extended-iterable':
-        specifier: 1.0.3
+        specifier: ^1.0.3
         version: 1.0.3
       msgpackr:
-        specifier: 2.0.6
+        specifier: ^2.0.6
         version: 2.0.6
       ordered-binary:
-        specifier: 1.6.1
+        specifier: ^1.6.1
         version: 1.6.1
     devDependencies:
       '@rollup/plugin-replace':


### PR DESCRIPTION
Right now, if we update a shared dependency (like msgpackr) in Harper, rocksdb-js can end up loading a different version, creating multiple deps which can have dangerous consequences for any singletons. Or we are forced to publish a newer version rocksdb-js for every release of any other package. Both are pretty bad options. I'll let codex give its description below: 

Relax the [shared runtime dependency range block](https://github.com/HarperFast/rocksdb-js/pull/803/changes?w=1#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R61) to caret ranges so npm can hoist compatible copies for consuming applications. This lets Harper's `msgpackr.addExtension()` registrations be observed by rocksdb-js instead of being isolated in a nested module instance, addressing the issue identified in [HarperFast/harper#2368](https://github.com/HarperFast/harper/pull/2368) review round 4.

The pnpm lockfile keeps the current resolved versions; only the manifest ranges and matching importer specifiers change. The cross-model review flagged the deliberately accepted boundary: `ordered-binary` writes durable key bytes, so a future consumer-selected 1.x version relies on its upstream compatibility contract rather than this repository's lockfile.

## For the human reviewer

1. **Codec-range contract:** accept [`ordered-binary`'s compatible 1.x range](https://github.com/HarperFast/rocksdb-js/pull/803/changes?w=1#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R63) rather than retain its exact pin. This is necessary for a compatible consumer copy to be shared, but it means a future consumer install can choose a later 1.x codec; the current lockfile remains on 1.6.1 and existing round-trip tests do not prove cross-version key-byte compatibility. Reverting this decision restores the exact pin but also restores duplicate-module pressure.
2. **Singleton contract:** permit compatible dependency hoisting with caret ranges rather than switch these packages to peer dependencies. Peers would enforce a stronger consumer-owned singleton contract, but change standalone installation behavior and are a broader packaging decision. Carets enable, rather than guarantee, a single instance when every consumer range is compatible.
3. **Consumer proof ownership:** validate the hoisted dependency graph and Harper blob/bigint extension behavior in the paired Harper consumer work rather than add a packed-consumer fixture here. That keeps this metadata-only change focused, but resolver-specific duplication can escape this repository's test suite; adding that fixture later is low cost.

A second full pre-push round ran on the rebased head (claude + gemini + cursor-grok + Harper-domain adjudication). It re-raised the durable-codec exposure in decision 1 and the mirror concern for `msgpackr`'s persisted `sharedStructuresKey` blob; adjudication dropped both, on the grounds that this build changes no resolved codec version and each scenario requires a future same-major release to break its own compatibility contract — so decision 1 is still the live call, unchanged. One reviewer question was settled by checking rather than deciding: `@harperfast/extended-iterable` is absent from `deps.neverBundle` in `tsdown.config.ts`, but tsdown externalizes runtime dependencies by default and `dist/index.mjs` does keep `import { ExtendedIterable } from "@harperfast/extended-iterable"`, so that third caret is not inert. Nothing survived to fix; the rebase is the only change in this update.

## Verification

End-to-end behavior is not observable in rocksdb-js alone because the relevant module-resolution topology belongs to the consuming application. The complete local package gates passed:

- `pnpm test` — 824 passed, 3 skipped.
- `pnpm test:native` — 151 passed.
- `pnpm check` — type-check, lint, and formatting passed.

**Rebase (Node.js 26 CI failure).** Rebased onto `main` at [`6d73d81b`](https://github.com/HarperFast/rocksdb-js/commit/6d73d81b9df923ddf446f10cf03f5517a55e5135). The Node 26 failure was not caused by this change and reproduces on `main` before that commit: `test/transaction-log.test.ts` built an unbounded `new Uint32Array(contents.buffer, contents.byteOffset)` over a pooled `readFileSync` buffer, and Node 26.8.x sizes its `Buffer` pool `ArrayBuffer` at 65599 bytes (Node 24: 65536, Node 26.2: 8192), so `buffer.byteLength - byteOffset` stopped being a multiple of 4 and the view constructor threw `RangeError: byte length of Uint32Array should be a multiple of 4`. Reproduced locally under Node 26.8.1 — the two tests fail with the unbounded view and pass with the bounded one — and `pnpm test` (824 passed, 3 skipped) plus `pnpm check` were re-run green on the rebased head under that version.

Complexity: medium

Co-Authored-By: GPT-5 Codex <noreply@openai.com>

🤖 Generated with GPT-5 Codex

<sub>Review-Coverage: authored=codex; ran=gemini,cursor-grok,claude; adjudicated=domain; declined=cursor-composer; rounds=2 @ 0a244690647b</sub>

<sub>Human-Review-Need: 4 (decisions: dependency-range-width, singleton-mechanism, proof-location) @ 0a244690647b</sub>
