### PR TITLE
fix(txnlog): resume the recovery scan and timestamp index past a mid-file framing break

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -466,7 +466,11 @@ sufficient (env teardown does not honor tsfn acquire counts); see
     there means "not in this map", not "not in this file". It must then stay at the break and report
     an unindexed tail — the same treatment the walk already gives a header the map does not cover —
     and only park `lastIndexedPosition` at the written extent when the whole extent was searchable
-    and the break is therefore a torn tail. Skipping to the extent is permanent: a later, larger map
+    and the break is therefore a torn tail. A short map also disqualifies the "chain lands on the
+    written extent" signal (`endIsWrittenExtent`): the region ends on an arbitrary cut, so a chain
+    landing there proves nothing, and accepting one lets a garbage chain in the corrupt gap pass as
+    the resume — whose bogus timestamp then caps this running-maxima index and hides every real
+    entry behind it. The frame-run signal is the only one left. Skipping to the extent is permanent: a later, larger map
     resumes from `lastIndexedPosition` and never looks below it, so those entries stay unindexed and
     every seek into them reports "past this file". Staying at the break costs nothing per seek: the
     extent that failed is remembered (`resyncSearchedExtent`), since only a larger map can change

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -294,7 +294,7 @@ sufficient (env teardown does not honor tsfn acquire counts); see
    **The physical extent tracks `size` on POSIX only.** There the fd is `O_APPEND`,
    so writes go to physical EOF, not to `size`, and leaving orphaned bytes makes every later
    append land after a partial entry: a mid-file framing break that `recoverTail()` deliberately
-   will not repair, so every entry after it is unreachable (HarperFast/rocksdb-js#748). On
+   will not repair and every later read must resync past (invariant 11; HarperFast/rocksdb-js#748). On
    Windows `size` is the logical end of entries only — an active segment is pre-extended to
    `maxFileSize` with `SetEndOfFile` so it can be mapped (`getMemoryMapLocked`), its physical
    size stays `maxFileSize` for its whole life with a zero-padded tail, and end-of-entries is
@@ -431,12 +431,22 @@ sufficient (env teardown does not honor tsfn acquire counts); see
     entries appended _after_ it; `recoverTail()` deliberately leaves such a file alone rather than
     discard them, and rotated files are never rescanned at all. `query()` therefore reports the
     break as a `CorruptFrameError` carrying `resyncPosition` (where framing resumes, per the same
-    heuristic as `validFramingResumes()`) and **leaves iteration positioned there**, so a caller
+    heuristic as `findFramingResumeOffset()`) and **leaves iteration positioned there**, so a caller
     that calls `next()` again recovers the entries past it. Treating the throw as terminal amputates
     every later entry in the file permanently — each drain restarts from the same resume cursor and
     re-throws at the same offset, which is how HarperFast/harper#2016 lost 2.2 days of acknowledged
     writes and #2063 starved a replication stream for 11 days. Keep `RESYNC_MIN_FRAMES` in
     `transaction-log-reader.ts` and `transaction_log_recovery.cpp` in step.
+
+    The engine owes the same discipline, or the reader's resync is moot. Every native walk of the
+    framing — the open-time recovery scan and `findPositionByTimestamp`'s index walk — resumes at
+    `findFramingResumeOffset()` instead of stopping at the break, so the committed-read watermark
+    (`lastCompleteTransactionEnd`, which may therefore exceed `validEnd` for `MidFileCorruption`)
+    and the timestamp index both cover the entries past it. Stopping at the break clamped every
+    committed read to the entries _before_ it (39 of 60 rows reached the replica) and froze the index
+    so every seek at or after the break reported "past this file". Striding through a broken frame's
+    declared length is never an in-flight append: `size` is bumped only after the bytes land, so a
+    nonzero header below `size` is a complete entry and a length overrunning it is a break.
 
     The resync scan must be bounded by the **written extent** (`getLogFileSize`, which returns the
     append-owned `TransactionLogFile::size` — see invariant 5 — not the physical or mapped size).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -454,7 +454,11 @@ sufficient (env teardown does not honor tsfn acquire counts); see
     fill reads as an end-of-entries marker: scanning against it both loses the exact-end signal and,
     if a zero were taken as a terminator, would let a chain "end" anywhere in megabytes of padding.
     Resolve it only on a break — `getLogFileSize` crosses into native and takes the store mutex, so
-    a per-frame call would tax every healthy read.
+    a per-frame call would tax every healthy read. The native walks run before `size` has been
+    corrected on a pre-extended (Windows) segment, so `findFramingResumeOffset()` also accepts a
+    chain landing exactly on the **end of the nonzero bytes** — a single offset, as conclusive as
+    EOF — otherwise a run shorter than `RESYNC_MIN_FRAMES` in front of the padding classifies as a
+    torn tail and recovery truncates its committed entries.
 
 12. **Coordinated retry parks on a lock, bounded by a descriptor-owned timeout**: a `coordinatedRetry`
     commit that loses a conflict (`IsBusy`) parks instead of rejecting immediately —

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -468,7 +468,10 @@ sufficient (env teardown does not honor tsfn acquire counts); see
     and only park `lastIndexedPosition` at the written extent when the whole extent was searchable
     and the break is therefore a torn tail. Skipping to the extent is permanent: a later, larger map
     resumes from `lastIndexedPosition` and never looks below it, so those entries stay unindexed and
-    every seek into them reports "past this file".
+    every seek into them reports "past this file". Staying at the break costs nothing per seek: the
+    extent that failed is remembered (`resyncSearchedExtent`), since only a larger map can change
+    the answer and the byte-wise search spans the whole corrupt gap under the store's
+    `dataSetsMutex`.
 
 12. **Coordinated retry parks on a lock, bounded by a descriptor-owned timeout**: a `coordinatedRetry`
     commit that loses a conflict (`IsBusy`) parks instead of rejecting immediately —

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -460,6 +460,16 @@ sufficient (env teardown does not honor tsfn acquire counts); see
     EOF — otherwise a run shorter than `RESYNC_MIN_FRAMES` in front of the padding classifies as a
     torn tail and recovery truncates its committed entries.
 
+    A resync that finds nothing is only conclusive over the bytes it could actually read. The index
+    walk searches the mapped region (`min(size, mapSize)`), which is short of the written extent
+    whenever one batch exceeded `transactionLogMaxSize` or the limit was lowered, so an empty result
+    there means "not in this map", not "not in this file". It must then stay at the break and report
+    an unindexed tail — the same treatment the walk already gives a header the map does not cover —
+    and only park `lastIndexedPosition` at the written extent when the whole extent was searchable
+    and the break is therefore a torn tail. Skipping to the extent is permanent: a later, larger map
+    resumes from `lastIndexedPosition` and never looks below it, so those entries stay unindexed and
+    every seek into them reports "past this file".
+
 12. **Coordinated retry parks on a lock, bounded by a descriptor-owned timeout**: a `coordinatedRetry`
     commit that loses a conflict (`IsBusy`) parks instead of rejecting immediately —
     `completeCommitWork` (`src/binding/transaction/transaction.cpp`) registers a wake callback on the

--- a/src/binding/transaction_log/transaction_log_file.cpp
+++ b/src/binding/transaction_log/transaction_log_file.cpp
@@ -713,7 +713,15 @@ uint32_t TransactionLogFile::findPositionByTimestamp(double timestamp, uint32_t 
 	// Set when indexing stops early at a committed-but-not-yet-visible tail (a concurrent append we
 	// couldn't read this pass); used below to start the scan at lastIndexedPosition rather than EOF.
 	bool stoppedAtUnindexedTail = false;
-	while (this->lastIndexedPosition < this->size) {
+	while (true) {
+		uint32_t writtenExtent = this->size.load(std::memory_order_relaxed);
+		if (this->lastIndexedPosition >= writtenExtent) {
+			break;
+		}
+		if (static_cast<uint64_t>(this->lastIndexedPosition) + TRANSACTION_LOG_ENTRY_HEADER_SIZE > memoryMap->mapSize) {
+			stoppedAtUnindexedTail = true;
+			break;
+		}
 		double entryTimestamp = readDoubleBE(mappedFile + this->lastIndexedPosition);
 		// The header's own timestamp slot is not an entry, so a legitimate value of exactly
 		// zero there (e.g. an unset/epoch file timestamp) must not be mistaken for the
@@ -745,6 +753,20 @@ uint32_t TransactionLogFile::findPositionByTimestamp(double timestamp, uint32_t 
 			}
 			break;
 		}
+		uint32_t entryLength = readUint32BE(mappedFile + this->lastIndexedPosition + 8);
+		if (entryLength == 0 ||
+			static_cast<uint64_t>(this->lastIndexedPosition) + TRANSACTION_LOG_ENTRY_HEADER_SIZE + entryLength > writtenExtent) {
+			// A framing break. It cannot be an in-flight append: size is bumped only after the
+			// bytes are written, so a non-zero header inside the written extent is a complete
+			// entry. Striding through the declared length would carry the walk past every
+			// later entry and freeze the index there, so resume where framing does (the same
+			// rule readers use for CorruptFrameError.resyncPosition) or, for a torn tail, at
+			// the written extent so later appends still get indexed.
+			uint32_t searchable = std::min(writtenExtent, static_cast<uint32_t>(memoryMap->mapSize));
+			uint32_t resume = findFramingResumeOffset(mappedFile, searchable, this->lastIndexedPosition + 1);
+			this->lastIndexedPosition = resume != 0 ? resume : writtenExtent;
+			continue;
+		}
 		// check that the timestamp is greater than any previously indexed timestamp,
 		// otherwise we don't record it, because we want to start at the first position with a timestamp that
 		// is greater than the requested timestamp:
@@ -752,8 +774,7 @@ uint32_t TransactionLogFile::findPositionByTimestamp(double timestamp, uint32_t 
 			// insert with a hint to go at the end (constant time?)
 			positionByTimestampIndex.insert(positionByTimestampIndex.end(), {entryTimestamp, this->lastIndexedPosition});
 		}
-		// read size of the entry and move on
-		this->lastIndexedPosition += TRANSACTION_LOG_ENTRY_HEADER_SIZE + readUint32BE(mappedFile + this->lastIndexedPosition + 8);
+		this->lastIndexedPosition += TRANSACTION_LOG_ENTRY_HEADER_SIZE + entryLength;
 	}
 	// now do the actual search: just a search for the lower bound
 	auto it = this->positionByTimestampIndex.lower_bound(timestamp);

--- a/src/binding/transaction_log/transaction_log_file.cpp
+++ b/src/binding/transaction_log/transaction_log_file.cpp
@@ -768,6 +768,9 @@ uint32_t TransactionLogFile::findPositionByTimestamp(double timestamp, uint32_t 
 				stoppedAtUnindexedTail = true;
 				break;
 			}
+#ifdef ROCKSDB_JS_NATIVE_TESTS
+			++this->resyncSearchCountForTests;
+#endif
 			uint32_t resume = findFramingResumeOffset(mappedFile, searchable, this->lastIndexedPosition + 1);
 			if (resume != 0) {
 				this->lastIndexedPosition = resume;

--- a/src/binding/transaction_log/transaction_log_file.cpp
+++ b/src/binding/transaction_log/transaction_log_file.cpp
@@ -470,6 +470,7 @@ void TransactionLogFile::resetTimestampIndex() {
 	std::lock_guard<std::mutex> indexLock(this->indexMutex);
 	this->positionByTimestampIndex.clear();
 	this->lastIndexedPosition = TRANSACTION_LOG_FILE_TIMESTAMP_POSITION;
+	this->resyncSearchedExtent = 0;
 }
 
 uint32_t TransactionLogFile::countEntries() const {
@@ -760,9 +761,17 @@ uint32_t TransactionLogFile::findPositionByTimestamp(double timestamp, uint32_t 
 			// land, so a nonzero header below the written extent is a complete entry. Resume
 			// where framing does, or at the written extent so later appends are still indexed.
 			uint32_t searchable = std::min(writtenExtent, static_cast<uint32_t>(memoryMap->mapSize));
+			if (searchable <= this->resyncSearchedExtent) {
+				// These bytes already failed to yield a resume for this same break; only a larger
+				// map can change the answer, and the search spans the whole corrupt gap under the
+				// store's dataSetsMutex, so repeating it per seek would stall the store.
+				stoppedAtUnindexedTail = true;
+				break;
+			}
 			uint32_t resume = findFramingResumeOffset(mappedFile, searchable, this->lastIndexedPosition + 1);
 			if (resume != 0) {
 				this->lastIndexedPosition = resume;
+				this->resyncSearchedExtent = 0;
 				continue;
 			}
 			if (searchable < writtenExtent) {
@@ -772,12 +781,14 @@ uint32_t TransactionLogFile::findPositionByTimestamp(double timestamp, uint32_t 
 				// never look below it, so entries there stay unindexed and seeks past them report
 				// past-file. Stop at the break instead (the same treatment the header bound-check
 				// above gives a tail the map doesn't cover) and re-search once the map grows.
+				this->resyncSearchedExtent = searchable;
 				stoppedAtUnindexedTail = true;
 				break;
 			}
 			// The whole written extent was searchable and nothing resumes: a torn tail. Park at
 			// the written extent so later appends are still indexed; the torn bytes never are.
 			this->lastIndexedPosition = writtenExtent;
+			this->resyncSearchedExtent = 0;
 			continue;
 		}
 		// check that the timestamp is greater than any previously indexed timestamp,

--- a/src/binding/transaction_log/transaction_log_file.cpp
+++ b/src/binding/transaction_log/transaction_log_file.cpp
@@ -761,7 +761,23 @@ uint32_t TransactionLogFile::findPositionByTimestamp(double timestamp, uint32_t 
 			// where framing does, or at the written extent so later appends are still indexed.
 			uint32_t searchable = std::min(writtenExtent, static_cast<uint32_t>(memoryMap->mapSize));
 			uint32_t resume = findFramingResumeOffset(mappedFile, searchable, this->lastIndexedPosition + 1);
-			this->lastIndexedPosition = resume != 0 ? resume : writtenExtent;
+			if (resume != 0) {
+				this->lastIndexedPosition = resume;
+				continue;
+			}
+			if (searchable < writtenExtent) {
+				// The map stops short of the written extent, so "nothing resumes" only rules out
+				// the bytes we could read. Parking at the written extent would strand the rest
+				// permanently — a later, larger map resumes from lastIndexedPosition and would
+				// never look below it, so entries there stay unindexed and seeks past them report
+				// past-file. Stop at the break instead (the same treatment the header bound-check
+				// above gives a tail the map doesn't cover) and re-search once the map grows.
+				stoppedAtUnindexedTail = true;
+				break;
+			}
+			// The whole written extent was searchable and nothing resumes: a torn tail. Park at
+			// the written extent so later appends are still indexed; the torn bytes never are.
+			this->lastIndexedPosition = writtenExtent;
 			continue;
 		}
 		// check that the timestamp is greater than any previously indexed timestamp,

--- a/src/binding/transaction_log/transaction_log_file.cpp
+++ b/src/binding/transaction_log/transaction_log_file.cpp
@@ -758,9 +758,9 @@ uint32_t TransactionLogFile::findPositionByTimestamp(double timestamp, uint32_t 
 		if (entryLength == 0 ||
 			static_cast<uint64_t>(this->lastIndexedPosition) + TRANSACTION_LOG_ENTRY_HEADER_SIZE + entryLength > writtenExtent) {
 			// A framing break, not an in-flight append: size is bumped only after the bytes
-			// land, so a nonzero header below the written extent is a complete entry. Resume
-			// where framing does, or at the written extent so later appends are still indexed.
+			// land, so a nonzero header below the written extent is a complete entry.
 			uint32_t searchable = std::min(writtenExtent, static_cast<uint32_t>(memoryMap->mapSize));
+			bool searchedWholeExtent = searchable == writtenExtent;
 			if (searchable <= this->resyncSearchedExtent) {
 				// These bytes already failed to yield a resume for this same break; only a larger
 				// map can change the answer, and the search spans the whole corrupt gap under the
@@ -771,13 +771,16 @@ uint32_t TransactionLogFile::findPositionByTimestamp(double timestamp, uint32_t 
 #ifdef ROCKSDB_JS_NATIVE_TESTS
 			++this->resyncSearchCountForTests;
 #endif
-			uint32_t resume = findFramingResumeOffset(mappedFile, searchable, this->lastIndexedPosition + 1);
+			// A chain landing on the end of a short map lands on an arbitrary cut, not on the
+			// end of the data, so only the frame-run signal is trustworthy there.
+			uint32_t resume = findFramingResumeOffset(
+				mappedFile, searchable, this->lastIndexedPosition + 1, searchedWholeExtent);
 			if (resume != 0) {
 				this->lastIndexedPosition = resume;
 				this->resyncSearchedExtent = 0;
 				continue;
 			}
-			if (searchable < writtenExtent) {
+			if (!searchedWholeExtent) {
 				// The map stops short of the written extent, so "nothing resumes" only rules out
 				// the bytes we could read. Parking at the written extent would strand the rest
 				// permanently — a later, larger map resumes from lastIndexedPosition and would

--- a/src/binding/transaction_log/transaction_log_file.cpp
+++ b/src/binding/transaction_log/transaction_log_file.cpp
@@ -718,11 +718,6 @@ uint32_t TransactionLogFile::findPositionByTimestamp(double timestamp, uint32_t 
 		if (this->lastIndexedPosition >= writtenExtent) {
 			break;
 		}
-		if (static_cast<uint64_t>(this->lastIndexedPosition) + TRANSACTION_LOG_ENTRY_HEADER_SIZE > memoryMap->mapSize) {
-			stoppedAtUnindexedTail = true;
-			break;
-		}
-		double entryTimestamp = readDoubleBE(mappedFile + this->lastIndexedPosition);
 		// The header's own timestamp slot is not an entry, so a legitimate value of exactly
 		// zero there (e.g. an unset/epoch file timestamp) must not be mistaken for the
 		// zero-padding end-of-data marker below — that heuristic only applies once we're
@@ -731,10 +726,15 @@ uint32_t TransactionLogFile::findPositionByTimestamp(double timestamp, uint32_t 
 		// back into the header itself.
 		if (TRANSACTION_LOG_FILE_TIMESTAMP_POSITION == this->lastIndexedPosition) {
 			// specifically record the log file timestamp as the first entry with a position of zero
-			positionByTimestampIndex.insert({entryTimestamp, 0});
+			positionByTimestampIndex.insert({readDoubleBE(mappedFile + this->lastIndexedPosition), 0});
 			this->lastIndexedPosition = TRANSACTION_LOG_FILE_HEADER_SIZE; // move to the first transaction entry
 			continue;
 		}
+		if (static_cast<uint64_t>(this->lastIndexedPosition) + TRANSACTION_LOG_ENTRY_HEADER_SIZE > memoryMap->mapSize) {
+			stoppedAtUnindexedTail = true;
+			break;
+		}
+		double entryTimestamp = readDoubleBE(mappedFile + this->lastIndexedPosition);
 		if (entryTimestamp == 0) {
 			// A zero timestamp marks the end of the written data. Only correct this->size down to the
 			// true written extent when no entries have been appended since (re)open — i.e. during

--- a/src/binding/transaction_log/transaction_log_file.cpp
+++ b/src/binding/transaction_log/transaction_log_file.cpp
@@ -756,12 +756,9 @@ uint32_t TransactionLogFile::findPositionByTimestamp(double timestamp, uint32_t 
 		uint32_t entryLength = readUint32BE(mappedFile + this->lastIndexedPosition + 8);
 		if (entryLength == 0 ||
 			static_cast<uint64_t>(this->lastIndexedPosition) + TRANSACTION_LOG_ENTRY_HEADER_SIZE + entryLength > writtenExtent) {
-			// A framing break. It cannot be an in-flight append: size is bumped only after the
-			// bytes are written, so a non-zero header inside the written extent is a complete
-			// entry. Striding through the declared length would carry the walk past every
-			// later entry and freeze the index there, so resume where framing does (the same
-			// rule readers use for CorruptFrameError.resyncPosition) or, for a torn tail, at
-			// the written extent so later appends still get indexed.
+			// A framing break, not an in-flight append: size is bumped only after the bytes
+			// land, so a nonzero header below the written extent is a complete entry. Resume
+			// where framing does, or at the written extent so later appends are still indexed.
 			uint32_t searchable = std::min(writtenExtent, static_cast<uint32_t>(memoryMap->mapSize));
 			uint32_t resume = findFramingResumeOffset(mappedFile, searchable, this->lastIndexedPosition + 1);
 			this->lastIndexedPosition = resume != 0 ? resume : writtenExtent;

--- a/src/binding/transaction_log/transaction_log_file.h
+++ b/src/binding/transaction_log/transaction_log_file.h
@@ -547,6 +547,13 @@ struct TransactionLogFile final {
 	 * can be exercised on POSIX. INT64_MIN disables the override. Test-only.
 	 */
 	static std::atomic<int64_t> forcedBytesLandedForTests;
+
+	/**
+	 * Counts the byte-wise resync searches the index walk has run, so a test can prove the
+	 * failed-extent memo (resyncSearchedExtent) elides a repeat search rather than only
+	 * returning the same position. Guarded by indexMutex like the memo itself. Test-only.
+	 */
+	uint32_t resyncSearchCountForTests = 0;
 #endif
 
 private:

--- a/src/binding/transaction_log/transaction_log_file.h
+++ b/src/binding/transaction_log/transaction_log_file.h
@@ -245,8 +245,9 @@ struct TransactionLogFile final {
 	 * search spans the whole corrupt gap and runs under the store's dataSetsMutex, so repeating
 	 * it on every seek would stall writers and readers alike; a search is only worth redoing once
 	 * the mapped region has grown past what it already covered. Zero whenever lastIndexedPosition
-	 * is not parked at an unresolved break — every other assignment to lastIndexedPosition
-	 * (including resetTimestampIndex()) clears it, so the two can never disagree.
+	 * is not parked at an unresolved break: both paths that leave a break clear it, as does
+	 * resetTimestampIndex(), and the paths that advance through a well-framed entry cannot run
+	 * while parked (the walk re-detects the break before reaching them).
 	 */
 	uint32_t resyncSearchedExtent = 0;
 	std::mutex indexMutex;

--- a/src/binding/transaction_log/transaction_log_file.h
+++ b/src/binding/transaction_log/transaction_log_file.h
@@ -239,6 +239,16 @@ struct TransactionLogFile final {
 
 	std::map<double, uint32_t> positionByTimestampIndex;
 	uint32_t lastIndexedPosition = TRANSACTION_LOG_FILE_TIMESTAMP_POSITION;
+	/**
+	 * How far findPositionByTimestamp() has already searched, without success, for the point
+	 * where framing resumes after the break now sitting at lastIndexedPosition. The byte-wise
+	 * search spans the whole corrupt gap and runs under the store's dataSetsMutex, so repeating
+	 * it on every seek would stall writers and readers alike; a search is only worth redoing once
+	 * the mapped region has grown past what it already covered. Zero whenever lastIndexedPosition
+	 * is not parked at an unresolved break — every other assignment to lastIndexedPosition
+	 * (including resetTimestampIndex()) clears it, so the two can never disagree.
+	 */
+	uint32_t resyncSearchedExtent = 0;
 	std::mutex indexMutex;
 
 	/**

--- a/src/binding/transaction_log/transaction_log_recovery.cpp
+++ b/src/binding/transaction_log/transaction_log_recovery.cpp
@@ -186,7 +186,6 @@ RecoveryScan scanTransactionLogForRecovery(
 	uint32_t tailEntries = 0;
 	double tailTimestamp = 0;
 	bool tailUniformTimestamp = true;
-	// The classification pins to the first break while the walk continues past it.
 	uint32_t firstBreak = 0;
 	auto scan = [&](RecoveryScan::Kind kind, uint32_t validEnd) {
 		if (firstBreak != 0) {

--- a/src/binding/transaction_log/transaction_log_recovery.cpp
+++ b/src/binding/transaction_log/transaction_log_recovery.cpp
@@ -36,6 +36,35 @@ struct ScanReader {
 		}
 	}
 
+	// End of the nonzero bytes: where a pre-extended file's zero padding starts. A
+	// frame chain landing exactly here is as conclusive as one landing on EOF,
+	// which padding never lets it reach. Computed on first use, reading backwards.
+	uint32_t nonzeroEnd() {
+		if (nonzeroEndKnown) {
+			return nonzeroEndValue;
+		}
+		std::vector<char> tail(RESYNC_WINDOW);
+		uint32_t end = fileSize;
+		while (end > 0) {
+			uint32_t len = std::min(RESYNC_WINDOW, end);
+			readExact(end - len, tail.data(), len);
+			for (uint32_t i = len; i > 0; --i) {
+				if (tail[i - 1] != 0) {
+					nonzeroEndValue = end - len + i;
+					nonzeroEndKnown = true;
+					return nonzeroEndValue;
+				}
+			}
+			end -= len;
+		}
+		nonzeroEndValue = 0;
+		nonzeroEndKnown = true;
+		return 0;
+	}
+
+	bool nonzeroEndKnown = false;
+	uint32_t nonzeroEndValue = 0;
+
 	// Sequential headers within 64 KiB of the current window refill from the
 	// next header. A larger gap is a payload skip: read exactly 13 bytes so
 	// that payload is not pulled in.
@@ -80,7 +109,8 @@ bool headerLooksLikeFrame(const char* header, uint32_t pos, uint32_t fileSize) {
 
 // Returns the first offset in [from, fileSize) where valid log data resumes:
 // either a run of at least RESYNC_MIN_FRAMES well-formed frames, or any run that
-// lands exactly on EOF. Returns 0 when nothing resumes. Sequential candidate
+// lands exactly on the written extent (EOF, or the start of a pre-extended
+// file's zero padding). Returns 0 when nothing resumes. Sequential candidate
 // offsets are served from a 64 KiB window; chain hops (HEADER+length) read a
 // 13-byte header so a large payload is not pulled in. A failed read throws — it
 // must not look like "no resume".
@@ -89,6 +119,10 @@ uint32_t findFramingResumeOffset(ScanReader& source, uint32_t from) {
 	uint32_t windowStart = 0;
 	uint32_t windowLen = 0;
 	char headerBuf[TRANSACTION_LOG_ENTRY_HEADER_SIZE];
+
+	auto reachesWrittenExtent = [&](uint32_t pos) -> bool {
+		return pos == source.fileSize || pos == source.nonzeroEnd();
+	};
 
 	auto loadHeader = [&](uint32_t pos, const char*& out) -> bool {
 		if (static_cast<uint64_t>(pos) + TRANSACTION_LOG_ENTRY_HEADER_SIZE > source.fileSize) {
@@ -120,12 +154,12 @@ uint32_t findFramingResumeOffset(ScanReader& source, uint32_t from) {
 
 		uint32_t pos = start + TRANSACTION_LOG_ENTRY_HEADER_SIZE + readUint32BE(header + 8);
 		int frames = 1;
-		if (frames >= RESYNC_MIN_FRAMES || pos == source.fileSize) {
+		if (frames >= RESYNC_MIN_FRAMES || reachesWrittenExtent(pos)) {
 			return start;
 		}
 		while (loadHeader(pos, header) && headerLooksLikeFrame(header, pos, source.fileSize)) {
 			pos += TRANSACTION_LOG_ENTRY_HEADER_SIZE + readUint32BE(header + 8);
-			if (++frames >= RESYNC_MIN_FRAMES || pos == source.fileSize) {
+			if (++frames >= RESYNC_MIN_FRAMES || reachesWrittenExtent(pos)) {
 				return start;
 			}
 		}
@@ -152,8 +186,7 @@ RecoveryScan scanTransactionLogForRecovery(
 	uint32_t tailEntries = 0;
 	double tailTimestamp = 0;
 	bool tailUniformTimestamp = true;
-	// Offset of the first framing break that intact frames follow; 0 until one is
-	// found. Fixes the classification while the walk continues past it.
+	// The classification pins to the first break while the walk continues past it.
 	uint32_t firstBreak = 0;
 	auto scan = [&](RecoveryScan::Kind kind, uint32_t validEnd) {
 		if (firstBreak != 0) {

--- a/src/binding/transaction_log/transaction_log_recovery.cpp
+++ b/src/binding/transaction_log/transaction_log_recovery.cpp
@@ -114,14 +114,14 @@ bool headerLooksLikeFrame(const char* header, uint32_t pos, uint32_t fileSize) {
 // offsets are served from a 64 KiB window; chain hops (HEADER+length) read a
 // 13-byte header so a large payload is not pulled in. A failed read throws — it
 // must not look like "no resume".
-uint32_t findFramingResumeOffset(ScanReader& source, uint32_t from) {
+uint32_t findFramingResumeOffset(ScanReader& source, uint32_t from, bool endIsWrittenExtent) {
 	std::vector<char> window(RESYNC_WINDOW);
 	uint32_t windowStart = 0;
 	uint32_t windowLen = 0;
 	char headerBuf[TRANSACTION_LOG_ENTRY_HEADER_SIZE];
 
 	auto reachesWrittenExtent = [&](uint32_t pos) -> bool {
-		return pos == source.fileSize || pos == source.nonzeroEnd();
+		return endIsWrittenExtent && (pos == source.fileSize || pos == source.nonzeroEnd());
 	};
 
 	auto loadHeader = [&](uint32_t pos, const char*& out) -> bool {
@@ -170,13 +170,14 @@ uint32_t findFramingResumeOffset(ScanReader& source, uint32_t from) {
 } // namespace
 
 uint32_t findFramingResumeOffset(
-	uint32_t fileSize, TransactionLogReadFn read, void* context, uint32_t from
+	uint32_t fileSize, TransactionLogReadFn read, void* context, uint32_t from,
+	bool endIsWrittenExtent
 ) {
 	if (from == 0 || from >= fileSize) {
 		return 0;
 	}
 	ScanReader source{ read, context, fileSize, {}, 0, 0 };
-	return findFramingResumeOffset(source, from);
+	return findFramingResumeOffset(source, from, endIsWrittenExtent);
 }
 
 RecoveryScan scanTransactionLogForRecovery(
@@ -222,7 +223,7 @@ RecoveryScan scanTransactionLogForRecovery(
 			// Intact frames after the break are mid-file corruption; truncating would
 			// discard them, and the committed watermark must still reach them, so the
 			// walk resumes where framing does. A torn tail has nothing valid behind it.
-			uint32_t resume = findFramingResumeOffset(source, pos + 1);
+			uint32_t resume = findFramingResumeOffset(source, pos + 1, /*endIsWrittenExtent=*/true);
 			if (resume == 0) {
 				return scan(RecoveryScan::Kind::TruncateTail, pos);
 			}
@@ -262,8 +263,11 @@ RecoveryScan scanTransactionLogForRecovery(const char* data, uint32_t fileSize) 
 	return scanTransactionLogForRecovery(fileSize, readFromBuffer, const_cast<char*>(data));
 }
 
-uint32_t findFramingResumeOffset(const char* data, uint32_t fileSize, uint32_t from) {
-	return findFramingResumeOffset(fileSize, readFromBuffer, const_cast<char*>(data), from);
+uint32_t findFramingResumeOffset(
+	const char* data, uint32_t fileSize, uint32_t from, bool endIsWrittenExtent
+) {
+	return findFramingResumeOffset(
+		fileSize, readFromBuffer, const_cast<char*>(data), from, endIsWrittenExtent);
 }
 
 RecoveryScan scanTransactionLogForRecovery(TransactionLogFile& file) {

--- a/src/binding/transaction_log/transaction_log_recovery.cpp
+++ b/src/binding/transaction_log/transaction_log_recovery.cpp
@@ -18,7 +18,7 @@ namespace {
 constexpr int RESYNC_MIN_FRAMES = 8;
 
 // Sequential window for nearby success-path headers and for the corruption-only
-// byte search in validFramingResumes. Heap-allocated: 64 KiB on the stack is
+// byte search in findFramingResumeOffset. Heap-allocated: 64 KiB on the stack is
 // hostile to musl/small-stack threads.
 constexpr uint32_t RESYNC_WINDOW = 65536;
 
@@ -78,12 +78,13 @@ bool headerLooksLikeFrame(const char* header, uint32_t pos, uint32_t fileSize) {
 	return static_cast<uint64_t>(pos) + TRANSACTION_LOG_ENTRY_HEADER_SIZE + length <= fileSize;
 }
 
-// Returns true if valid log data resumes at some offset in [from, fileSize):
+// Returns the first offset in [from, fileSize) where valid log data resumes:
 // either a run of at least RESYNC_MIN_FRAMES well-formed frames, or any run that
-// lands exactly on EOF. Sequential candidate offsets are served from a 64 KiB
-// window; chain hops (HEADER+length) read a 13-byte header so a large payload is
-// not pulled in. A failed read throws — it must not look like "no resume".
-bool validFramingResumes(ScanReader& source, uint32_t from) {
+// lands exactly on EOF. Returns 0 when nothing resumes. Sequential candidate
+// offsets are served from a 64 KiB window; chain hops (HEADER+length) read a
+// 13-byte header so a large payload is not pulled in. A failed read throws — it
+// must not look like "no resume".
+uint32_t findFramingResumeOffset(ScanReader& source, uint32_t from) {
 	std::vector<char> window(RESYNC_WINDOW);
 	uint32_t windowStart = 0;
 	uint32_t windowLen = 0;
@@ -120,19 +121,29 @@ bool validFramingResumes(ScanReader& source, uint32_t from) {
 		uint32_t pos = start + TRANSACTION_LOG_ENTRY_HEADER_SIZE + readUint32BE(header + 8);
 		int frames = 1;
 		if (frames >= RESYNC_MIN_FRAMES || pos == source.fileSize) {
-			return true;
+			return start;
 		}
 		while (loadHeader(pos, header) && headerLooksLikeFrame(header, pos, source.fileSize)) {
 			pos += TRANSACTION_LOG_ENTRY_HEADER_SIZE + readUint32BE(header + 8);
 			if (++frames >= RESYNC_MIN_FRAMES || pos == source.fileSize) {
-				return true;
+				return start;
 			}
 		}
 	}
-	return false;
+	return 0;
 }
 
 } // namespace
+
+uint32_t findFramingResumeOffset(
+	uint32_t fileSize, TransactionLogReadFn read, void* context, uint32_t from
+) {
+	if (from == 0 || from >= fileSize) {
+		return 0;
+	}
+	ScanReader source{ read, context, fileSize, {}, 0, 0 };
+	return findFramingResumeOffset(source, from);
+}
 
 RecoveryScan scanTransactionLogForRecovery(
 	uint32_t fileSize, TransactionLogReadFn read, void* context
@@ -141,7 +152,14 @@ RecoveryScan scanTransactionLogForRecovery(
 	uint32_t tailEntries = 0;
 	double tailTimestamp = 0;
 	bool tailUniformTimestamp = true;
+	// Offset of the first framing break that intact frames follow; 0 until one is
+	// found. Fixes the classification while the walk continues past it.
+	uint32_t firstBreak = 0;
 	auto scan = [&](RecoveryScan::Kind kind, uint32_t validEnd) {
+		if (firstBreak != 0) {
+			kind = RecoveryScan::Kind::MidFileCorruption;
+			validEnd = firstBreak;
+		}
 		return RecoveryScan{ kind, validEnd, lastCompleteEnd, tailEntries,
 			tailEntries > 0 && tailUniformTimestamp };
 	};
@@ -170,11 +188,19 @@ RecoveryScan scanTransactionLogForRecovery(
 		if (length == 0 ||
 			static_cast<uint64_t>(pos) + TRANSACTION_LOG_ENTRY_HEADER_SIZE + length > fileSize) {
 			// Intact frames after the break are mid-file corruption; truncating would
-			// discard them. A torn tail has nothing valid behind it.
-			if (validFramingResumes(source, pos + 1)) {
-				return scan(RecoveryScan::Kind::MidFileCorruption, pos);
+			// discard them, and the committed watermark must still reach them, so the
+			// walk resumes where framing does. A torn tail has nothing valid behind it.
+			uint32_t resume = findFramingResumeOffset(source, pos + 1);
+			if (resume == 0) {
+				return scan(RecoveryScan::Kind::TruncateTail, pos);
 			}
-			return scan(RecoveryScan::Kind::TruncateTail, pos);
+			if (firstBreak == 0) {
+				firstBreak = pos;
+			}
+			pos = resume;
+			tailEntries = 0;
+			tailUniformTimestamp = true;
+			continue;
 		}
 		bool closesTransaction = (readUint8(header + 12) & TRANSACTION_LOG_ENTRY_LAST_FLAG) != 0;
 		if (tailEntries++ == 0) {
@@ -202,6 +228,10 @@ bool readFromBuffer(void* context, uint32_t offset, void* dest, uint32_t n) {
 
 RecoveryScan scanTransactionLogForRecovery(const char* data, uint32_t fileSize) {
 	return scanTransactionLogForRecovery(fileSize, readFromBuffer, const_cast<char*>(data));
+}
+
+uint32_t findFramingResumeOffset(const char* data, uint32_t fileSize, uint32_t from) {
+	return findFramingResumeOffset(fileSize, readFromBuffer, const_cast<char*>(data), from);
 }
 
 RecoveryScan scanTransactionLogForRecovery(TransactionLogFile& file) {

--- a/src/binding/transaction_log/transaction_log_recovery.h
+++ b/src/binding/transaction_log/transaction_log_recovery.h
@@ -40,7 +40,8 @@ struct RecoveryScan final {
 	/**
 	 * Offset just past the last entry carrying `TRANSACTION_LOG_ENTRY_LAST_FLAG`
 	 * — i.e. the end of the last COMPLETE transaction in this file — or 0 if the
-	 * file contains no complete transaction. Always <= `validEnd`.
+	 * file contains no complete transaction. <= `validEnd` for `Clean` and
+	 * `TruncateTail`.
 	 *
 	 * A batch's entries are written together but only its final entry carries the
 	 * flag, so a crash mid-batch can leave whole, well-framed entries that are
@@ -48,9 +49,20 @@ struct RecoveryScan final {
 	 * are intact); this is the stricter bound for anything that must not observe a
 	 * partial transaction, notably the committed-read watermark and the open-time
 	 * discard of an interrupted batch.
+	 *
+	 * For `MidFileCorruption` the scan resumes where framing does and keeps
+	 * advancing this past every break, so it can exceed `validEnd`: the entries
+	 * after a break stay reachable through the committed-read watermark, and readers
+	 * report the break itself as a CorruptFrameError with the resync offset. A
+	 * flagged entry after a break closes whatever group precedes it, including a
+	 * group the break tore; that group is reported through the error, not excluded.
 	 */
 	uint32_t lastCompleteTransactionEnd;
-	/** Number of entries between `lastCompleteTransactionEnd` and the end of the entries. */
+	/**
+	 * Number of entries between `lastCompleteTransactionEnd` (or the last framing
+	 * break, whichever is later) and the end of the entries. Unused for
+	 * `MidFileCorruption`.
+	 */
 	uint32_t unclosedTailEntries;
 	/**
 	 * True when that trailing run exists and every entry in it carries the same
@@ -100,6 +112,19 @@ RecoveryScan scanTransactionLogForRecovery(const char* data, uint32_t fileSize);
  * instead (the mutex is not recursive). Throws DBException on I/O failure.
  */
 RecoveryScan scanTransactionLogForRecovery(TransactionLogFile& file);
+
+/**
+ * Finds where valid framing resumes at or after `from`, using the same rule as
+ * the recovery scan: the first offset that starts a run of well-formed frames
+ * which is either RESYNC_MIN_FRAMES long or lands exactly on `fileSize`. Returns
+ * 0 when nothing resumes (0 is never a valid entry offset). Throws DBException on
+ * a failed read.
+ */
+uint32_t findFramingResumeOffset(
+	uint32_t fileSize, TransactionLogReadFn read, void* context, uint32_t from);
+
+/** In-memory adapter over findFramingResumeOffset(fileSize, read, context, from). */
+uint32_t findFramingResumeOffset(const char* data, uint32_t fileSize, uint32_t from);
 
 /**
  * Counts the well-formed v1 entry frames in an in-memory transaction log image.

--- a/src/binding/transaction_log/transaction_log_recovery.h
+++ b/src/binding/transaction_log/transaction_log_recovery.h
@@ -120,12 +120,21 @@ RecoveryScan scanTransactionLogForRecovery(TransactionLogFile& file);
  * (`fileSize`, or the start of a pre-extended file's zero padding). Returns
  * 0 when nothing resumes (0 is never a valid entry offset). Throws DBException on
  * a failed read.
+ *
+ * `endIsWrittenExtent` is false when `fileSize` is only as far as the caller can
+ * read (a memory map short of the written extent), where the region's end is an
+ * arbitrary cut rather than the end of the data. The landing rule is then dropped
+ * — a chain ending on a cut proves nothing, and accepting one lets a garbage chain
+ * inside the corrupt gap pass as the resume — leaving RESYNC_MIN_FRAMES as the
+ * only signal.
  */
 uint32_t findFramingResumeOffset(
-	uint32_t fileSize, TransactionLogReadFn read, void* context, uint32_t from);
+	uint32_t fileSize, TransactionLogReadFn read, void* context, uint32_t from,
+	bool endIsWrittenExtent = true);
 
 /** In-memory adapter over findFramingResumeOffset(fileSize, read, context, from). */
-uint32_t findFramingResumeOffset(const char* data, uint32_t fileSize, uint32_t from);
+uint32_t findFramingResumeOffset(
+	const char* data, uint32_t fileSize, uint32_t from, bool endIsWrittenExtent = true);
 
 /**
  * Counts the well-formed v1 entry frames in an in-memory transaction log image.

--- a/src/binding/transaction_log/transaction_log_recovery.h
+++ b/src/binding/transaction_log/transaction_log_recovery.h
@@ -116,7 +116,8 @@ RecoveryScan scanTransactionLogForRecovery(TransactionLogFile& file);
 /**
  * Finds where valid framing resumes at or after `from`, using the same rule as
  * the recovery scan: the first offset that starts a run of well-formed frames
- * which is either RESYNC_MIN_FRAMES long or lands exactly on `fileSize`. Returns
+ * which is either RESYNC_MIN_FRAMES long or lands exactly on the written extent
+ * (`fileSize`, or the start of a pre-extended file's zero padding). Returns
  * 0 when nothing resumes (0 is never a valid entry offset). Throws DBException on
  * a failed read.
  */

--- a/src/transaction-log-reader.ts
+++ b/src/transaction-log-reader.ts
@@ -91,8 +91,8 @@ function frameFits(dataView: DataView, pos: number, dataEnd: number): boolean {
  * terminator, let a chain "end" anywhere in megabytes of padding. Against the written extent the
  * end is a single offset, so a chain landing on it is ~1/2^32 to be coincidence.
  *
- * The JS counterpart of `validFramingResumes()` in `transaction_log_recovery.cpp`, which answers
- * the same question at open time but keeps only the yes/no, discarding the offset.
+ * The JS counterpart of `findFramingResumeOffset()` in `transaction_log_recovery.cpp`, which the
+ * open-time scan and the timestamp index use to keep walking past the same break.
  */
 function findResyncPosition(dataView: DataView, from: number, dataEnd: number): number | undefined {
 	const lastStart = dataEnd - TRANSACTION_LOG_ENTRY_HEADER_SIZE;

--- a/test/native/transaction_log_recovery_test.cc
+++ b/test/native/transaction_log_recovery_test.cc
@@ -741,6 +741,33 @@ TEST(TransactionLogTimestampIndex, SeeksPastMultipleBreaks) {
 	EXPECT_EQ(file.findPositionByTimestamp(52.0, img.size(), /*isCurrent=*/true), 0xFFFFFFFFu);
 }
 
+// A map shorter than the written extent (one batch larger than maxFileSize, or a
+// lowered maxFileSize) can cover the break without covering the run behind it.
+// "Nothing resumes" then rules out only the bytes that were searchable, so the
+// walk must stay at the break: parking at the written extent would leave those
+// entries permanently unindexed, since a later, larger map resumes from
+// lastIndexedPosition and never looks below it.
+TEST(TransactionLogTimestampIndex, ShortMapDoesNotSkipTheUnsearchedPostBreakTail) {
+	LogImage img;
+	img.entry(16, /*flags=*/1, /*timestamp=*/10.0);
+	uint32_t breakOffset = img.size();
+	img.entryRaw(/*declaredLength=*/100000, /*actualDataLen=*/8, /*flags=*/1, /*timestamp=*/11.0);
+	std::vector<uint32_t> offsets;
+	for (int i = 0; i < 12; ++i) {
+		offsets.push_back(img.size());
+		img.entry(16, /*flags=*/1, /*timestamp=*/20.0 + i);
+	}
+	OpenedLogFile opened(img);
+	TransactionLogFile& file = opened.get();
+	// Cut the map mid-entry, too few frames past the break to qualify as a resume.
+	uint32_t shortMap = offsets[2] + 5;
+	EXPECT_EQ(file.findPositionByTimestamp(20.0, shortMap, /*isCurrent=*/true), breakOffset);
+	// Once the map reaches the written extent the run is found, indexed and seekable.
+	EXPECT_EQ(file.findPositionByTimestamp(20.0, img.size(), /*isCurrent=*/true), offsets[0]);
+	EXPECT_EQ(file.findPositionByTimestamp(31.0, img.size(), /*isCurrent=*/true), offsets[11]);
+	EXPECT_EQ(file.findPositionByTimestamp(32.0, img.size(), /*isCurrent=*/true), 0xFFFFFFFFu);
+}
+
 TEST(TransactionLogTimestampIndex, TornTailLeavesEarlierEntriesSeekable) {
 	LogImage img;
 	img.entry(16, /*flags=*/1, /*timestamp=*/10.0);

--- a/test/native/transaction_log_recovery_test.cc
+++ b/test/native/transaction_log_recovery_test.cc
@@ -672,6 +672,21 @@ TEST(TransactionLogResumeOffset, ZeroWhenNothingResumes) {
 	EXPECT_EQ(findFramingResumeOffset(img.data(), img.size(), 0), 0u);
 }
 
+// A region that ends where the caller's map ends, not where the data ends, cannot
+// offer the "chain lands on the written extent" signal: the cut is arbitrary.
+TEST(TransactionLogResumeOffset, ACutIsNotTheWrittenExtent) {
+	LogImage img;
+	img.entry(10);
+	uint32_t breakOffset = img.size();
+	img.entryRaw(/*declaredLength=*/100000, /*actualDataLen=*/8);
+	uint32_t resumeOffset = img.size();
+	img.entry(16).entry(16); // too short for RESYNC_MIN_FRAMES: only the landing rule can accept it
+	EXPECT_EQ(findFramingResumeOffset(img.data(), img.size(), breakOffset + 1), resumeOffset);
+	EXPECT_EQ(
+		findFramingResumeOffset(img.data(), img.size(), breakOffset + 1, /*endIsWrittenExtent=*/false),
+		0u);
+}
+
 TEST(TransactionLogResumeOffset, IoFailureThrows) {
 	LogImage img;
 	img.entry(10);
@@ -768,8 +783,6 @@ TEST(TransactionLogTimestampIndex, ShortMapDoesNotSkipTheUnsearchedPostBreakTail
 	uint32_t shortMap = offsets[2] + 5;
 	EXPECT_EQ(file.findPositionByTimestamp(20.0, shortMap, /*isCurrent=*/true), breakOffset);
 	EXPECT_EQ(file.resyncSearchCountForTests, 1u);
-	// A repeat seek against the same map answers from the recorded searched extent
-	// instead of re-scanning the corrupt gap under the store lock.
 	EXPECT_EQ(file.findPositionByTimestamp(25.0, shortMap, /*isCurrent=*/true), breakOffset);
 	EXPECT_EQ(file.resyncSearchCountForTests, 1u);
 	// Once the map reaches the written extent the run is found, indexed and seekable.
@@ -777,6 +790,29 @@ TEST(TransactionLogTimestampIndex, ShortMapDoesNotSkipTheUnsearchedPostBreakTail
 	EXPECT_EQ(file.resyncSearchCountForTests, 2u);
 	EXPECT_EQ(file.findPositionByTimestamp(31.0, img.size(), /*isCurrent=*/true), offsets[11]);
 	EXPECT_EQ(file.findPositionByTimestamp(32.0, img.size(), /*isCurrent=*/true), 0xFFFFFFFFu);
+}
+
+// The index walk searches only the mapped region, so a chain ending on that map's
+// last byte has reached a cut and not the end of the data. Accepting one would let a
+// garbage chain inside the corrupt gap resume the walk, and its bogus timestamp would
+// cap this running-maxima index against every real entry behind it.
+TEST(TransactionLogTimestampIndex, ShortMapCutIsNotTreatedAsTheWrittenExtent) {
+	LogImage img;
+	img.entry(16, /*flags=*/1, /*timestamp=*/10.0);
+	uint32_t breakOffset = img.size();
+	img.entryRaw(/*declaredLength=*/100000, /*actualDataLen=*/8, /*flags=*/1, /*timestamp=*/11.0);
+	std::vector<uint32_t> offsets;
+	for (int i = 0; i < 12; ++i) {
+		offsets.push_back(img.size());
+		img.entry(16, /*flags=*/1, /*timestamp=*/20.0 + i);
+	}
+	OpenedLogFile opened(img);
+	TransactionLogFile& file = opened.get();
+	file.downgradeMapToFrozen();
+	file.resetTimestampIndex();
+	// Cut the map exactly on a frame boundary, two frames past the break.
+	EXPECT_EQ(file.findPositionByTimestamp(20.0, offsets[2], /*isCurrent=*/true), breakOffset);
+	EXPECT_EQ(file.findPositionByTimestamp(20.0, img.size(), /*isCurrent=*/true), offsets[0]);
 }
 
 TEST(TransactionLogTimestampIndex, TornTailLeavesEarlierEntriesSeekable) {

--- a/test/native/transaction_log_recovery_test.cc
+++ b/test/native/transaction_log_recovery_test.cc
@@ -762,6 +762,8 @@ TEST(TransactionLogTimestampIndex, ShortMapDoesNotSkipTheUnsearchedPostBreakTail
 	// Cut the map mid-entry, too few frames past the break to qualify as a resume.
 	uint32_t shortMap = offsets[2] + 5;
 	EXPECT_EQ(file.findPositionByTimestamp(20.0, shortMap, /*isCurrent=*/true), breakOffset);
+	// A repeat seek against the same map answers from the recorded searched extent.
+	EXPECT_EQ(file.findPositionByTimestamp(25.0, shortMap, /*isCurrent=*/true), breakOffset);
 	// Once the map reaches the written extent the run is found, indexed and seekable.
 	EXPECT_EQ(file.findPositionByTimestamp(20.0, img.size(), /*isCurrent=*/true), offsets[0]);
 	EXPECT_EQ(file.findPositionByTimestamp(31.0, img.size(), /*isCurrent=*/true), offsets[11]);

--- a/test/native/transaction_log_recovery_test.cc
+++ b/test/native/transaction_log_recovery_test.cc
@@ -21,6 +21,7 @@
 
 using rocksdb_js::countTransactionLogEntries;
 using rocksdb_js::DBException;
+using rocksdb_js::findFramingResumeOffset;
 using rocksdb_js::RecoveryScan;
 using rocksdb_js::scanTransactionLogForRecovery;
 using rocksdb_js::TransactionLogFile;
@@ -181,6 +182,125 @@ TEST(TransactionLogRecovery, BrokenFrameThenFewEntriesReachingEofIsNotTruncated)
 	auto scan = scanTransactionLogForRecovery(img.data(), img.size());
 	EXPECT_EQ(scan.kind, RecoveryScan::Kind::MidFileCorruption);
 	EXPECT_EQ(scan.validEnd, breakOffset);
+}
+
+// A mid-file break must not amputate the committed watermark: the scan resumes
+// where framing does and keeps advancing lastCompleteTransactionEnd, while the
+// classification stays pinned to the FIRST break.
+
+TEST(TransactionLogRecovery, WatermarkAdvancesPastAMidFileBreak) {
+	LogImage img;
+	img.entry(10).entry(20);
+	uint32_t breakOffset = img.size();
+	img.entryRaw(/*declaredLength=*/100000, /*actualDataLen=*/8);
+	for (int i = 0; i < 12; ++i) {
+		img.entry(16);
+	}
+	auto scan = scanTransactionLogForRecovery(img.data(), img.size());
+	EXPECT_EQ(scan.kind, RecoveryScan::Kind::MidFileCorruption);
+	EXPECT_EQ(scan.validEnd, breakOffset);
+	EXPECT_EQ(scan.lastCompleteTransactionEnd, img.size());
+	EXPECT_EQ(scan.unclosedTailEntries, 0u);
+}
+
+TEST(TransactionLogRecovery, WatermarkAdvancesPastAShortRunReachingEof) {
+	LogImage img;
+	img.entry(10).entry(20);
+	uint32_t breakOffset = img.size();
+	img.entryRaw(/*declaredLength=*/100000, /*actualDataLen=*/8);
+	img.entry(16).entry(16).entry(16);
+	auto scan = scanTransactionLogForRecovery(img.data(), img.size());
+	EXPECT_EQ(scan.kind, RecoveryScan::Kind::MidFileCorruption);
+	EXPECT_EQ(scan.validEnd, breakOffset);
+	EXPECT_EQ(scan.lastCompleteTransactionEnd, img.size());
+}
+
+TEST(TransactionLogRecovery, WatermarkAdvancesPastMultipleBreaks) {
+	LogImage img;
+	img.entry(10);
+	uint32_t firstBreak = img.size();
+	img.entryRaw(/*declaredLength=*/0, /*actualDataLen=*/0);
+	for (int i = 0; i < 12; ++i) {
+		img.entry(16);
+	}
+	img.entryRaw(/*declaredLength=*/100000, /*actualDataLen=*/8);
+	for (int i = 0; i < 12; ++i) {
+		img.entry(16);
+	}
+	auto scan = scanTransactionLogForRecovery(img.data(), img.size());
+	EXPECT_EQ(scan.kind, RecoveryScan::Kind::MidFileCorruption);
+	EXPECT_EQ(scan.validEnd, firstBreak);
+	EXPECT_EQ(scan.lastCompleteTransactionEnd, img.size());
+}
+
+TEST(TransactionLogRecovery, FlaggedEntryAfterABreakClosesTheTornGroup) {
+	// The break tore a multi-entry transaction. Its later entries are still on
+	// disk, and the first flagged entry after the break advances the watermark
+	// over all of them: readers see the tear through CorruptFrameError, not
+	// through a watermark that hides everything behind it.
+	LogImage img;
+	img.entry(10, /*flags=*/1, /*timestamp=*/2.0);
+	img.entry(20, /*flags=*/0, /*timestamp=*/3.0);
+	uint32_t breakOffset = img.size();
+	img.entryRaw(/*declaredLength=*/100000, /*actualDataLen=*/8, /*flags=*/0, /*timestamp=*/3.0);
+	for (int i = 0; i < 11; ++i) {
+		img.entry(16, /*flags=*/0, /*timestamp=*/3.0);
+	}
+	img.entry(16, /*flags=*/1, /*timestamp=*/3.0);
+	auto scan = scanTransactionLogForRecovery(img.data(), img.size());
+	EXPECT_EQ(scan.kind, RecoveryScan::Kind::MidFileCorruption);
+	EXPECT_EQ(scan.validEnd, breakOffset);
+	EXPECT_EQ(scan.lastCompleteTransactionEnd, img.size());
+}
+
+TEST(TransactionLogRecovery, TornTailAfterAMidFileBreakStaysMidFileCorruption) {
+	// A file with a mid-file break is never truncated, even when a torn tail
+	// follows the resumed run: the watermark stops at the run's last boundary.
+	LogImage img;
+	img.entry(10);
+	uint32_t breakOffset = img.size();
+	img.entryRaw(/*declaredLength=*/100000, /*actualDataLen=*/8);
+	for (int i = 0; i < 12; ++i) {
+		img.entry(16);
+	}
+	uint32_t runEnd = img.size();
+	img.entryRaw(/*declaredLength=*/5000, /*actualDataLen=*/12);
+	auto scan = scanTransactionLogForRecovery(img.data(), img.size());
+	EXPECT_EQ(scan.kind, RecoveryScan::Kind::MidFileCorruption);
+	EXPECT_EQ(scan.validEnd, breakOffset);
+	EXPECT_EQ(scan.lastCompleteTransactionEnd, runEnd);
+}
+
+TEST(TransactionLogRecovery, ZeroPaddingAfterAMidFileBreakStaysMidFileCorruption) {
+	LogImage img;
+	img.entry(10);
+	uint32_t breakOffset = img.size();
+	img.entryRaw(/*declaredLength=*/100000, /*actualDataLen=*/8);
+	for (int i = 0; i < 12; ++i) {
+		img.entry(16);
+	}
+	uint32_t runEnd = img.size();
+	img.zeros(64);
+	auto scan = scanTransactionLogForRecovery(img.data(), img.size());
+	EXPECT_EQ(scan.kind, RecoveryScan::Kind::MidFileCorruption);
+	EXPECT_EQ(scan.validEnd, breakOffset);
+	EXPECT_EQ(scan.lastCompleteTransactionEnd, runEnd);
+}
+
+TEST(TransactionLogRecovery, UnflaggedRunAfterAMidFileBreakDoesNotAdvanceTheWatermark) {
+	LogImage img;
+	img.entry(10);
+	uint32_t breakOffset = img.size();
+	img.entryRaw(/*declaredLength=*/100000, /*actualDataLen=*/8);
+	for (int i = 0; i < 12; ++i) {
+		img.entry(16, /*flags=*/1);
+	}
+	uint32_t lastClosed = img.size();
+	img.entry(16, /*flags=*/0).entry(16, /*flags=*/0);
+	auto scan = scanTransactionLogForRecovery(img.data(), img.size());
+	EXPECT_EQ(scan.kind, RecoveryScan::Kind::MidFileCorruption);
+	EXPECT_EQ(scan.validEnd, breakOffset);
+	EXPECT_EQ(scan.lastCompleteTransactionEnd, lastClosed);
 }
 
 TEST(TransactionLogRecovery, ZeroLengthFrameAtTailTruncates) {
@@ -505,6 +625,97 @@ TEST(TransactionLogRecoveryFile, MatchesBufferScanOnARealFile) {
 	EXPECT_EQ(fromFile.lastCompleteTransactionEnd, fromBuffer.lastCompleteTransactionEnd);
 	EXPECT_EQ(fromFile.unclosedTailEntries, fromBuffer.unclosedTailEntries);
 	EXPECT_EQ(fromFile.unclosedTailIsOneTransaction, fromBuffer.unclosedTailIsOneTransaction);
+}
+
+TEST(TransactionLogResumeOffset, FindsTheFirstFrameAfterABreak) {
+	LogImage img;
+	img.entry(10).entry(20);
+	uint32_t breakOffset = img.size();
+	img.entryRaw(/*declaredLength=*/100000, /*actualDataLen=*/8);
+	uint32_t resumeOffset = img.size();
+	for (int i = 0; i < 12; ++i) {
+		img.entry(16);
+	}
+	EXPECT_EQ(findFramingResumeOffset(img.data(), img.size(), breakOffset + 1), resumeOffset);
+	CountingRead counted{ img.data(), img.size() };
+	EXPECT_EQ(findFramingResumeOffset(img.size(), countingRead, &counted, breakOffset + 1), resumeOffset);
+}
+
+TEST(TransactionLogResumeOffset, ZeroWhenNothingResumes) {
+	LogImage img;
+	img.entry(10).entry(20);
+	uint32_t tornStart = img.size();
+	img.entryRaw(/*declaredLength=*/5000, /*actualDataLen=*/12);
+	EXPECT_EQ(findFramingResumeOffset(img.data(), img.size(), tornStart + 1), 0u);
+	EXPECT_EQ(findFramingResumeOffset(img.data(), img.size(), img.size()), 0u);
+	EXPECT_EQ(findFramingResumeOffset(img.data(), img.size(), 0), 0u);
+}
+
+TEST(TransactionLogResumeOffset, IoFailureThrows) {
+	LogImage img;
+	img.entry(10);
+	uint32_t breakOffset = img.size();
+	img.entryRaw(/*declaredLength=*/100000, /*actualDataLen=*/8);
+	for (int i = 0; i < 12; ++i) {
+		img.entry(16);
+	}
+	FailingRead failing{ img.data(), img.size(), /*succeedCount=*/0 };
+	EXPECT_THROW(findFramingResumeOffset(img.size(), failingRead, &failing, breakOffset + 1), DBException);
+}
+
+// The timestamp index walks the same framing. Striding through a broken frame's
+// declared length used to carry it past the written extent, freezing the index
+// so every seek at or after the break reported "past this file".
+
+TEST(TransactionLogTimestampIndex, SeeksPastAMidFileBreak) {
+	LogImage img;
+	img.entry(16, /*flags=*/1, /*timestamp=*/10.0);
+	uint32_t breakOffset = img.size();
+	img.entryRaw(/*declaredLength=*/100000, /*actualDataLen=*/8, /*flags=*/1, /*timestamp=*/11.0);
+	uint32_t resumeOffset = img.size();
+	std::vector<uint32_t> offsets;
+	for (int i = 0; i < 12; ++i) {
+		offsets.push_back(img.size());
+		img.entry(16, /*flags=*/1, /*timestamp=*/20.0 + i);
+	}
+	OpenedLogFile opened(img);
+	TransactionLogFile& file = opened.get();
+	EXPECT_EQ(file.findPositionByTimestamp(10.0, img.size(), /*isCurrent=*/true), TRANSACTION_LOG_FILE_HEADER_SIZE);
+	EXPECT_EQ(file.findPositionByTimestamp(11.0, img.size(), /*isCurrent=*/true), resumeOffset);
+	EXPECT_EQ(file.findPositionByTimestamp(20.0, img.size(), /*isCurrent=*/true), offsets[0]);
+	EXPECT_EQ(file.findPositionByTimestamp(25.5, img.size(), /*isCurrent=*/true), offsets[6]);
+	EXPECT_EQ(file.findPositionByTimestamp(31.0, img.size(), /*isCurrent=*/true), offsets[11]);
+	EXPECT_EQ(file.findPositionByTimestamp(32.0, img.size(), /*isCurrent=*/true), 0xFFFFFFFFu);
+	EXPECT_EQ(breakOffset + TRANSACTION_LOG_ENTRY_HEADER_SIZE + 8u, resumeOffset);
+}
+
+TEST(TransactionLogTimestampIndex, SeeksPastMultipleBreaks) {
+	LogImage img;
+	img.entry(16, /*flags=*/1, /*timestamp=*/10.0);
+	img.entryRaw(/*declaredLength=*/0, /*actualDataLen=*/0, /*flags=*/1, /*timestamp=*/11.0);
+	for (int i = 0; i < 12; ++i) {
+		img.entry(16, /*flags=*/1, /*timestamp=*/20.0 + i);
+	}
+	img.entryRaw(/*declaredLength=*/100000, /*actualDataLen=*/8, /*flags=*/1, /*timestamp=*/40.0);
+	uint32_t lastRun = img.size();
+	img.entry(16, /*flags=*/1, /*timestamp=*/50.0).entry(16, /*flags=*/1, /*timestamp=*/51.0);
+	OpenedLogFile opened(img);
+	TransactionLogFile& file = opened.get();
+	EXPECT_EQ(file.findPositionByTimestamp(50.0, img.size(), /*isCurrent=*/true), lastRun);
+	EXPECT_EQ(file.findPositionByTimestamp(51.0, img.size(), /*isCurrent=*/true), lastRun + 13u + 16u);
+	EXPECT_EQ(file.findPositionByTimestamp(52.0, img.size(), /*isCurrent=*/true), 0xFFFFFFFFu);
+}
+
+TEST(TransactionLogTimestampIndex, TornTailLeavesEarlierEntriesSeekable) {
+	LogImage img;
+	img.entry(16, /*flags=*/1, /*timestamp=*/10.0);
+	uint32_t second = img.size();
+	img.entry(16, /*flags=*/1, /*timestamp=*/11.0);
+	img.entryRaw(/*declaredLength=*/5000, /*actualDataLen=*/12, /*flags=*/1, /*timestamp=*/12.0);
+	OpenedLogFile opened(img);
+	TransactionLogFile& file = opened.get();
+	EXPECT_EQ(file.findPositionByTimestamp(11.0, img.size(), /*isCurrent=*/true), second);
+	EXPECT_EQ(file.findPositionByTimestamp(12.0, img.size(), /*isCurrent=*/true), 0xFFFFFFFFu);
 }
 
 TEST(TransactionLogRecoveryFile, MatchesBufferScanOnMidFileCorruption) {

--- a/test/native/transaction_log_recovery_test.cc
+++ b/test/native/transaction_log_recovery_test.cc
@@ -762,10 +762,14 @@ TEST(TransactionLogTimestampIndex, ShortMapDoesNotSkipTheUnsearchedPostBreakTail
 	// Cut the map mid-entry, too few frames past the break to qualify as a resume.
 	uint32_t shortMap = offsets[2] + 5;
 	EXPECT_EQ(file.findPositionByTimestamp(20.0, shortMap, /*isCurrent=*/true), breakOffset);
-	// A repeat seek against the same map answers from the recorded searched extent.
+	EXPECT_EQ(file.resyncSearchCountForTests, 1u);
+	// A repeat seek against the same map answers from the recorded searched extent
+	// instead of re-scanning the corrupt gap under the store lock.
 	EXPECT_EQ(file.findPositionByTimestamp(25.0, shortMap, /*isCurrent=*/true), breakOffset);
+	EXPECT_EQ(file.resyncSearchCountForTests, 1u);
 	// Once the map reaches the written extent the run is found, indexed and seekable.
 	EXPECT_EQ(file.findPositionByTimestamp(20.0, img.size(), /*isCurrent=*/true), offsets[0]);
+	EXPECT_EQ(file.resyncSearchCountForTests, 2u);
 	EXPECT_EQ(file.findPositionByTimestamp(31.0, img.size(), /*isCurrent=*/true), offsets[11]);
 	EXPECT_EQ(file.findPositionByTimestamp(32.0, img.size(), /*isCurrent=*/true), 0xFFFFFFFFu);
 }

--- a/test/native/transaction_log_recovery_test.cc
+++ b/test/native/transaction_log_recovery_test.cc
@@ -759,6 +759,11 @@ TEST(TransactionLogTimestampIndex, ShortMapDoesNotSkipTheUnsearchedPostBreakTail
 	}
 	OpenedLogFile opened(img);
 	TransactionLogFile& file = opened.get();
+	// Windows indexes the whole file against a full-extent map during openFile(), so drop
+	// that mapping and index to reach the partial-map case identically on both platforms.
+	file.downgradeMapToFrozen();
+	file.resetTimestampIndex();
+	file.resyncSearchCountForTests = 0;
 	// Cut the map mid-entry, too few frames past the break to qualify as a resume.
 	uint32_t shortMap = offsets[2] + 5;
 	EXPECT_EQ(file.findPositionByTimestamp(20.0, shortMap, /*isCurrent=*/true), breakOffset);

--- a/test/native/transaction_log_recovery_test.cc
+++ b/test/native/transaction_log_recovery_test.cc
@@ -184,10 +184,6 @@ TEST(TransactionLogRecovery, BrokenFrameThenFewEntriesReachingEofIsNotTruncated)
 	EXPECT_EQ(scan.validEnd, breakOffset);
 }
 
-// A mid-file break must not amputate the committed watermark: the scan resumes
-// where framing does and keeps advancing lastCompleteTransactionEnd, while the
-// classification stays pinned to the FIRST break.
-
 TEST(TransactionLogRecovery, WatermarkAdvancesPastAMidFileBreak) {
 	LogImage img;
 	img.entry(10).entry(20);
@@ -213,6 +209,34 @@ TEST(TransactionLogRecovery, WatermarkAdvancesPastAShortRunReachingEof) {
 	EXPECT_EQ(scan.kind, RecoveryScan::Kind::MidFileCorruption);
 	EXPECT_EQ(scan.validEnd, breakOffset);
 	EXPECT_EQ(scan.lastCompleteTransactionEnd, img.size());
+}
+
+// A pre-extended (Windows) segment ends in zero padding, so a short run after a
+// break never lands on EOF; landing on the end of the nonzero bytes must count
+// the same, or recovery truncates the run's committed entries.
+TEST(TransactionLogRecovery, ShortRunReachingThePaddingIsNotTruncated) {
+	LogImage img;
+	img.entry(10).entry(20);
+	uint32_t breakOffset = img.size();
+	img.entryRaw(/*declaredLength=*/100000, /*actualDataLen=*/8);
+	img.entry(16).entry(16).entry(16);
+	uint32_t runEnd = img.size();
+	img.zeros(4096);
+	auto scan = scanTransactionLogForRecovery(img.data(), img.size());
+	EXPECT_EQ(scan.kind, RecoveryScan::Kind::MidFileCorruption);
+	EXPECT_EQ(scan.validEnd, breakOffset);
+	EXPECT_EQ(scan.lastCompleteTransactionEnd, runEnd);
+}
+
+TEST(TransactionLogRecovery, TornTailBeforeThePaddingIsStillTruncated) {
+	LogImage img;
+	img.entry(10).entry(20);
+	uint32_t breakOffset = img.size();
+	img.entryRaw(/*declaredLength=*/100000, /*actualDataLen=*/8);
+	img.zeros(4096);
+	auto scan = scanTransactionLogForRecovery(img.data(), img.size());
+	EXPECT_EQ(scan.kind, RecoveryScan::Kind::TruncateTail);
+	EXPECT_EQ(scan.validEnd, breakOffset);
 }
 
 TEST(TransactionLogRecovery, WatermarkAdvancesPastMultipleBreaks) {
@@ -663,9 +687,7 @@ TEST(TransactionLogResumeOffset, IoFailureThrows) {
 	EXPECT_THROW(findFramingResumeOffset(img.size(), failingRead, &failing, breakOffset + 1), DBException);
 }
 
-// The timestamp index walks the same framing. Striding through a broken frame's
-// declared length used to carry it past the written extent, freezing the index
-// so every seek at or after the break reported "past this file".
+// The timestamp index walks the same framing and must resume past a break too.
 
 TEST(TransactionLogTimestampIndex, SeeksPastAMidFileBreak) {
 	LogImage img;
@@ -687,6 +709,22 @@ TEST(TransactionLogTimestampIndex, SeeksPastAMidFileBreak) {
 	EXPECT_EQ(file.findPositionByTimestamp(31.0, img.size(), /*isCurrent=*/true), offsets[11]);
 	EXPECT_EQ(file.findPositionByTimestamp(32.0, img.size(), /*isCurrent=*/true), 0xFFFFFFFFu);
 	EXPECT_EQ(breakOffset + TRANSACTION_LOG_ENTRY_HEADER_SIZE + 8u, resumeOffset);
+}
+
+TEST(TransactionLogTimestampIndex, ShortRunBeforeThePaddingIsIndexedAndEndsTheFile) {
+	LogImage img;
+	img.entry(16, /*flags=*/1, /*timestamp=*/10.0);
+	img.entryRaw(/*declaredLength=*/100000, /*actualDataLen=*/8, /*flags=*/1, /*timestamp=*/11.0);
+	uint32_t resumeOffset = img.size();
+	img.entry(16, /*flags=*/1, /*timestamp=*/20.0).entry(16, /*flags=*/1, /*timestamp=*/21.0);
+	uint32_t runEnd = img.size();
+	img.zeros(4096);
+	OpenedLogFile opened(img);
+	TransactionLogFile& file = opened.get();
+	EXPECT_EQ(file.findPositionByTimestamp(11.0, img.size(), /*isCurrent=*/true), resumeOffset);
+	EXPECT_EQ(file.findPositionByTimestamp(21.0, img.size(), /*isCurrent=*/true), resumeOffset + TRANSACTION_LOG_ENTRY_HEADER_SIZE + 16u);
+	EXPECT_EQ(file.findPositionByTimestamp(22.0, img.size(), /*isCurrent=*/true), 0xFFFFFFFFu);
+	EXPECT_EQ(file.size.load(), runEnd);
 }
 
 TEST(TransactionLogTimestampIndex, SeeksPastMultipleBreaks) {
@@ -718,9 +756,8 @@ TEST(TransactionLogTimestampIndex, TornTailLeavesEarlierEntriesSeekable) {
 	EXPECT_EQ(file.findPositionByTimestamp(12.0, img.size(), /*isCurrent=*/true), 0xFFFFFFFFu);
 }
 
-// A header-only file has no entry to bound-check against the map: the header's
-// own timestamp slot must still be indexed rather than reported as a tail the
-// map could not reach (which would hand a reader offset 5, mid-header).
+// A header-only file has no entry to bound-check against the map; its own
+// timestamp slot must still be indexed (an unindexed tail would read as offset 5).
 TEST(TransactionLogTimestampIndex, HeaderOnlyFileIsNotAnUnindexedTail) {
 	LogImage img;
 	OpenedLogFile opened(img);

--- a/test/native/transaction_log_recovery_test.cc
+++ b/test/native/transaction_log_recovery_test.cc
@@ -212,8 +212,7 @@ TEST(TransactionLogRecovery, WatermarkAdvancesPastAShortRunReachingEof) {
 }
 
 // A pre-extended (Windows) segment ends in zero padding, so a short run after a
-// break never lands on EOF; landing on the end of the nonzero bytes must count
-// the same, or recovery truncates the run's committed entries.
+// break never lands on EOF.
 TEST(TransactionLogRecovery, ShortRunReachingThePaddingIsNotTruncated) {
 	LogImage img;
 	img.entry(10).entry(20);
@@ -258,10 +257,8 @@ TEST(TransactionLogRecovery, WatermarkAdvancesPastMultipleBreaks) {
 }
 
 TEST(TransactionLogRecovery, FlaggedEntryAfterABreakClosesTheTornGroup) {
-	// The break tore a multi-entry transaction. Its later entries are still on
-	// disk, and the first flagged entry after the break advances the watermark
-	// over all of them: readers see the tear through CorruptFrameError, not
-	// through a watermark that hides everything behind it.
+	// Readers see the tear through CorruptFrameError, not through a watermark
+	// that hides everything behind it.
 	LogImage img;
 	img.entry(10, /*flags=*/1, /*timestamp=*/2.0);
 	img.entry(20, /*flags=*/0, /*timestamp=*/3.0);

--- a/test/native/transaction_log_recovery_test.cc
+++ b/test/native/transaction_log_recovery_test.cc
@@ -718,6 +718,32 @@ TEST(TransactionLogTimestampIndex, TornTailLeavesEarlierEntriesSeekable) {
 	EXPECT_EQ(file.findPositionByTimestamp(12.0, img.size(), /*isCurrent=*/true), 0xFFFFFFFFu);
 }
 
+// A header-only file has no entry to bound-check against the map: the header's
+// own timestamp slot must still be indexed rather than reported as a tail the
+// map could not reach (which would hand a reader offset 5, mid-header).
+TEST(TransactionLogTimestampIndex, HeaderOnlyFileIsNotAnUnindexedTail) {
+	LogImage img;
+	OpenedLogFile opened(img);
+	TransactionLogFile& file = opened.get();
+	EXPECT_EQ(file.findPositionByTimestamp(0.5, img.size(), /*isCurrent=*/true), 0u);
+	EXPECT_EQ(file.findPositionByTimestamp(1.0, img.size(), /*isCurrent=*/true), 0u);
+	EXPECT_EQ(file.findPositionByTimestamp(1.5, img.size(), /*isCurrent=*/true), 0xFFFFFFFFu);
+}
+
+// A partial header below the written extent (fewer than 13 bytes) is a torn
+// tail the map may not fully cover; the walk must stop short of it instead of
+// reading past the mapping.
+TEST(TransactionLogTimestampIndex, PartialTrailingHeaderStopsTheWalk) {
+	LogImage img;
+	img.entry(16, /*flags=*/1, /*timestamp=*/10.0);
+	uint32_t tail = img.size();
+	img.raw({ '\x40', '\x24', '\x00', '\x00', '\x00' });
+	OpenedLogFile opened(img);
+	TransactionLogFile& file = opened.get();
+	EXPECT_EQ(file.findPositionByTimestamp(10.0, img.size(), /*isCurrent=*/true), TRANSACTION_LOG_FILE_HEADER_SIZE);
+	EXPECT_EQ(file.findPositionByTimestamp(11.0, img.size(), /*isCurrent=*/true), tail);
+}
+
 TEST(TransactionLogRecoveryFile, MatchesBufferScanOnMidFileCorruption) {
 	LogImage img;
 	img.entry(10).entry(20);

--- a/test/transaction-log.test.ts
+++ b/test/transaction-log.test.ts
@@ -2072,13 +2072,8 @@ describe('Transaction Log', () => {
 			}));
 
 		// A mid-file break (a frame whose declared length overruns the file, with intact entries
-		// behind it) is left in place by recovery. Two engine walks stride through framing and
-		// used to stop dead at that break: the open-time scan, whose lastCompleteTransactionEnd
-		// seeds the committed watermark on an unflushed reopen (so committed reads ended at the
-		// break with no error at all), and the timestamp index, which followed the broken
-		// frame's declared length past the written extent and froze there (so every seek at or
-		// after the break, and every entry appended after reopen, reported as past the file).
-		// Both now resume where framing does, the same rule query() uses for resyncPosition.
+		// behind it) is left in place by recovery; the committed watermark and the timestamp
+		// index must resume past it by the same rule query() uses for resyncPosition.
 		describe('mid-file break on reopen', () => {
 			const ENTRY_DATA = 24;
 			const FRAME = TRANSACTION_LOG_ENTRY_HEADER_SIZE + ENTRY_DATA;
@@ -2148,7 +2143,6 @@ describe('Transaction Log', () => {
 						expect(afterBreak.errors).toEqual([]);
 						expect(Array.from(reopened.query({ start: timestamps[59] })).length).toBe(1);
 
-						// an append after reopen is indexed and readable
 						await database.transaction(async (txn) => {
 							reopened.addEntry(Buffer.from('r60'.padEnd(ENTRY_DATA, 'x')), txn.id);
 						});
@@ -2189,6 +2183,39 @@ describe('Transaction Log', () => {
 						const tail = drainPastCorruption(reopened.query({ start: timestamps[50] }));
 						expect(tail.entries.length).toBe(10);
 						expect(tail.errors).toEqual([]);
+					} finally {
+						database.close();
+					}
+				}));
+
+			// A pre-extended segment (Windows; here, a file padded on disk) ends in zeros rather
+			// than at EOF, and a run shorter than the resync minimum must still count as resumed.
+			it('keeps a short run before the zero padding instead of truncating it', () =>
+				dbRunner(async ({ db, dbPath }) => {
+					let database = db;
+					try {
+						const timestamps = await writeEntries(database, 60);
+						database.close();
+						const logPath = logPathFor(dbPath, 'foo');
+						const writtenSize = statSync(logPath).size;
+						await tearFrames(logPath, 57);
+						await writeFile(logPath, Buffer.concat([readFileSync(logPath), Buffer.alloc(1 << 20)]));
+
+						database = RocksDatabase.open(dbPath);
+						const reopened = database.useLog('foo');
+						for (const readUncommitted of [false, true]) {
+							const { entries, errors } = drainPastCorruption(
+								reopened.query({ start: 0, readUncommitted })
+							);
+							expect(entries.map(dataOf).slice(56)).toEqual(['r56', 'r58', 'r59']);
+							expect(errors.map((error) => error.position)).toEqual([frameOffset(57)]);
+						}
+						// the index walk found the end of data behind the padding
+						expect(reopened.getLogFileSize(1)).toBe(writtenSize);
+						expect(Array.from(reopened.query({ start: timestamps[58] })).map(dataOf)).toEqual([
+							'r58',
+							'r59',
+						]);
 					} finally {
 						database.close();
 					}

--- a/test/transaction-log.test.ts
+++ b/test/transaction-log.test.ts
@@ -2188,8 +2188,7 @@ describe('Transaction Log', () => {
 					}
 				}));
 
-			// A pre-extended segment (Windows; here, a file padded on disk) ends in zeros rather
-			// than at EOF, and a run shorter than the resync minimum must still count as resumed.
+			// A pre-extended (Windows) segment ends in zero padding rather than at EOF.
 			it('keeps a short run before the zero padding instead of truncating it', () =>
 				dbRunner(async ({ db, dbPath }) => {
 					let database = db;
@@ -2197,7 +2196,6 @@ describe('Transaction Log', () => {
 						const timestamps = await writeEntries(database, 60);
 						database.close();
 						const logPath = logPathFor(dbPath, 'foo');
-						const writtenSize = statSync(logPath).size;
 						await tearFrames(logPath, 57);
 						await writeFile(logPath, Buffer.concat([readFileSync(logPath), Buffer.alloc(1 << 20)]));
 
@@ -2210,8 +2208,7 @@ describe('Transaction Log', () => {
 							expect(entries.map(dataOf).slice(56)).toEqual(['r56', 'r58', 'r59']);
 							expect(errors.map((error) => error.position)).toEqual([frameOffset(57)]);
 						}
-						// the index walk found the end of data behind the padding
-						expect(reopened.getLogFileSize(1)).toBe(writtenSize);
+						expect(reopened.getLogFileSize(1)).toBe(frameOffset(60));
 						expect(Array.from(reopened.query({ start: timestamps[58] })).map(dataOf)).toEqual([
 							'r58',
 							'r59',

--- a/test/transaction-log.test.ts
+++ b/test/transaction-log.test.ts
@@ -2079,6 +2079,8 @@ describe('Transaction Log', () => {
 			const FRAME = TRANSACTION_LOG_ENTRY_HEADER_SIZE + ENTRY_DATA;
 			const frameOffset = (index: number) => TRANSACTION_LOG_FILE_HEADER_SIZE + index * FRAME;
 
+			// No read here: a query would map the file, and the map outlives close() while its entries are
+			// reachable, which on Windows makes the truncating rewrite in tearFrames fail (ERROR_USER_MAPPED_FILE).
 			async function writeEntries(database: RocksDatabase, count: number) {
 				const log = database.useLog('foo');
 				for (let i = 0; i < count; i++) {
@@ -2086,7 +2088,11 @@ describe('Transaction Log', () => {
 						log.addEntry(Buffer.from(`r${i}`.padEnd(ENTRY_DATA, 'x')), txn.id);
 					});
 				}
-				return Array.from(log.query({ start: 0 })).map((entry) => entry.timestamp as number);
+			}
+
+			function headerTimestamps(logPath: string, count: number) {
+				const image = readFileSync(logPath);
+				return Array.from({ length: count }, (_, index) => image.readDoubleBE(frameOffset(index)));
 			}
 
 			// Overruns the declared length of frame `index` past both the file and the pre-extended
@@ -2105,9 +2111,10 @@ describe('Transaction Log', () => {
 				dbRunner(async ({ db, dbPath }) => {
 					let database = db;
 					try {
-						const timestamps = await writeEntries(database, 60);
+						await writeEntries(database, 60);
 						database.close();
 						const logPath = logPathFor(dbPath, 'foo');
+						const timestamps = headerTimestamps(logPath, 60);
 						const fullSize = statSync(logPath).size;
 						await tearFrames(logPath, 39);
 
@@ -2163,8 +2170,9 @@ describe('Transaction Log', () => {
 				dbRunner(async ({ db, dbPath }) => {
 					let database = db;
 					try {
-						const timestamps = await writeEntries(database, 60);
+						await writeEntries(database, 60);
 						database.close();
+						const timestamps = headerTimestamps(logPathFor(dbPath, 'foo'), 60);
 						await tearFrames(logPathFor(dbPath, 'foo'), 20, 40);
 
 						database = RocksDatabase.open(dbPath);
@@ -2193,9 +2201,10 @@ describe('Transaction Log', () => {
 				dbRunner(async ({ db, dbPath }) => {
 					let database = db;
 					try {
-						const timestamps = await writeEntries(database, 60);
+						await writeEntries(database, 60);
 						database.close();
 						const logPath = logPathFor(dbPath, 'foo');
+						const timestamps = headerTimestamps(logPath, 60);
 						await tearFrames(logPath, 57);
 						await writeFile(logPath, Buffer.concat([readFileSync(logPath), Buffer.alloc(1 << 20)]));
 

--- a/test/transaction-log.test.ts
+++ b/test/transaction-log.test.ts
@@ -2070,6 +2070,168 @@ describe('Transaction Log', () => {
 					database.close();
 				}
 			}));
+
+		// A mid-file break (a frame whose declared length overruns the file, with intact entries
+		// behind it) is left in place by recovery. Two engine walks stride through framing and
+		// used to stop dead at that break: the open-time scan, whose lastCompleteTransactionEnd
+		// seeds the committed watermark on an unflushed reopen (so committed reads ended at the
+		// break with no error at all), and the timestamp index, which followed the broken
+		// frame's declared length past the written extent and froze there (so every seek at or
+		// after the break, and every entry appended after reopen, reported as past the file).
+		// Both now resume where framing does, the same rule query() uses for resyncPosition.
+		describe('mid-file break on reopen', () => {
+			const ENTRY_DATA = 24;
+			const FRAME = TRANSACTION_LOG_ENTRY_HEADER_SIZE + ENTRY_DATA;
+			const frameOffset = (index: number) => TRANSACTION_LOG_FILE_HEADER_SIZE + index * FRAME;
+
+			async function writeEntries(database: RocksDatabase, count: number) {
+				const log = database.useLog('foo');
+				for (let i = 0; i < count; i++) {
+					await database.transaction(async (txn) => {
+						log.addEntry(Buffer.from(`r${i}`.padEnd(ENTRY_DATA, 'x')), txn.id);
+					});
+				}
+				return Array.from(log.query({ start: 0 })).map((entry) => entry.timestamp as number);
+			}
+
+			// Overruns the declared length of frame `index` past both the file and the pre-extended
+			// map an uncommitted read is bounded by; its bytes stay, so framing resumes at the next frame.
+			function tearFrames(logPath: string, ...indexes: number[]) {
+				const image = readFileSync(logPath);
+				for (const index of indexes) {
+					image.writeUInt32BE(0x7fffffff, frameOffset(index) + 8);
+				}
+				return writeFile(logPath, image);
+			}
+
+			const dataOf = (entry: any) => Buffer.from(entry.data).toString().replace(/x+$/, '');
+
+			it('keeps the entries after the break readable and seekable', () =>
+				dbRunner(async ({ db, dbPath }) => {
+					let database = db;
+					try {
+						const timestamps = await writeEntries(database, 60);
+						database.close();
+						const logPath = logPathFor(dbPath, 'foo');
+						const fullSize = statSync(logPath).size;
+						await tearFrames(logPath, 39);
+
+						database = RocksDatabase.open(dbPath);
+						const reopened = database.useLog('foo');
+						expect(reopened.getLogFileSize(1)).toBe(fullSize);
+
+						for (const readUncommitted of [false, true]) {
+							const { entries, errors } = drainPastCorruption(
+								reopened.query({ start: 0, readUncommitted })
+							);
+							expect(entries.length).toBe(59);
+							expect(dataOf(entries[38])).toBe('r38');
+							expect(dataOf(entries[39])).toBe('r40');
+							expect(dataOf(entries[58])).toBe('r59');
+							expect(errors.length).toBe(1);
+							expect(errors[0]).toBeInstanceOf(CorruptFrameError);
+							expect(errors[0].position).toBe(frameOffset(39));
+							expect(errors[0].resyncPosition).toBe(frameOffset(40));
+						}
+
+						// seeks at and after the break land on the next entry, not "past this file";
+						// the torn frame itself is not indexed, so a seek to its timestamp starts past it
+						const fromBreak = drainPastCorruption(reopened.query({ start: timestamps[39] }));
+						expect(fromBreak.entries.map(dataOf)).toEqual(
+							Array.from({ length: 20 }, (_, i) => `r${40 + i}`)
+						);
+						expect(fromBreak.errors).toEqual([]);
+						const afterBreak = drainPastCorruption(reopened.query({ start: timestamps[45] }));
+						expect(afterBreak.entries.map(dataOf)).toEqual(
+							Array.from({ length: 15 }, (_, i) => `r${45 + i}`)
+						);
+						expect(afterBreak.errors).toEqual([]);
+						expect(Array.from(reopened.query({ start: timestamps[59] })).length).toBe(1);
+
+						// an append after reopen is indexed and readable
+						await database.transaction(async (txn) => {
+							reopened.addEntry(Buffer.from('r60'.padEnd(ENTRY_DATA, 'x')), txn.id);
+						});
+						const appended = Array.from(
+							reopened.query({ start: timestamps[59], exclusiveStart: true })
+						);
+						expect(appended.map(dataOf)).toEqual(['r60']);
+						const all = drainPastCorruption(reopened.query({ start: 0 }));
+						expect(all.entries.length).toBe(60);
+						expect(dataOf(all.entries[59])).toBe('r60');
+						expect(all.errors.length).toBe(1);
+					} finally {
+						database.close();
+					}
+				}));
+
+			it('reports each of several breaks and reads past all of them', () =>
+				dbRunner(async ({ db, dbPath }) => {
+					let database = db;
+					try {
+						const timestamps = await writeEntries(database, 60);
+						database.close();
+						await tearFrames(logPathFor(dbPath, 'foo'), 20, 40);
+
+						database = RocksDatabase.open(dbPath);
+						const reopened = database.useLog('foo');
+						const { entries, errors } = drainPastCorruption(reopened.query({ start: 0 }));
+						expect(entries.length).toBe(58);
+						expect(dataOf(entries[57])).toBe('r59');
+						expect(errors.map((error) => error.position)).toEqual([
+							frameOffset(20),
+							frameOffset(40),
+						]);
+						expect(errors.map((error) => error.resyncPosition)).toEqual([
+							frameOffset(21),
+							frameOffset(41),
+						]);
+						const tail = drainPastCorruption(reopened.query({ start: timestamps[50] }));
+						expect(tail.entries.length).toBe(10);
+						expect(tail.errors).toEqual([]);
+					} finally {
+						database.close();
+					}
+				}));
+
+			it('leaves the file intact when a torn tail follows the break', () =>
+				dbRunner(async ({ db, dbPath }) => {
+					let database = db;
+					try {
+						await writeEntries(database, 60);
+						database.close();
+						const logPath = logPathFor(dbPath, 'foo');
+						await tearFrames(logPath, 39);
+						await writeFile(
+							logPath,
+							Buffer.concat([readFileSync(logPath), tornEntry(0x7fffffff, 16)])
+						);
+						const fullSize = statSync(logPath).size;
+
+						database = RocksDatabase.open(dbPath);
+						const reopened = database.useLog('foo');
+						expect(statSync(logPath).size).toBe(fullSize);
+						// the committed watermark stops at the run's last closed transaction
+						const committed = drainPastCorruption(reopened.query({ start: 0 }));
+						expect(committed.entries.length).toBe(59);
+						expect(dataOf(committed.entries[58])).toBe('r59');
+						expect(committed.errors.map((error) => error.position)).toEqual([frameOffset(39)]);
+						// an uncommitted read reaches the torn tail and reports it as end-of-log
+						const { entries, errors } = drainPastCorruption(
+							reopened.query({ start: 0, readUncommitted: true })
+						);
+						expect(entries.length).toBe(59);
+						expect(errors.map((error) => error.position)).toEqual([
+							frameOffset(39),
+							frameOffset(60),
+						]);
+						expect(errors[0].resyncPosition).toBe(frameOffset(40));
+						expect(errors[1].resyncPosition).toBeUndefined();
+					} finally {
+						database.close();
+					}
+				}));
+		});
 	});
 
 	describe('purgeLogs', () => {


### PR DESCRIPTION
A transaction log with a mid-file framing break — a torn frame that intact, committed entries follow — is now fully readable after reopen. Two native walks of the framing stopped at the first break even though `query()` has resynced past such breaks since #750: the open-time recovery scan seeded the committed-read watermark (`lastCompleteTransactionEnd`) from the entries *before* the break, so a committed drain of a 60-entry log torn at frame 39 returned 39 entries and no error; and the timestamp index strode through the broken frame's declared length past the written extent and froze, so every seek at or after the break reported "past this file". Both walks now resume at the same offset the JS reader's `findResyncPosition()` uses ([`findFramingResumeOffset()`](https://github.com/HarperFast/rocksdb-js/pull/817/changes?w=1#diff-edc5e16c84874b5fcccc16d99d63a57bc55ef0c45f1d72827edba02fdcd926d2R117), shared by [the scan](https://github.com/HarperFast/rocksdb-js/pull/817/changes?w=1#diff-edc5e16c84874b5fcccc16d99d63a57bc55ef0c45f1d72827edba02fdcd926d2R225) and [the index](https://github.com/HarperFast/rocksdb-js/pull/817/changes?w=1#diff-70d82772a7a297690416ca9fa571592a9b9d2e0e8b91b58a2a1541ebc173ad74R776)), so the watermark covers every complete transaction in the file and the index covers every intact entry. The break is still surfaced as `CorruptFrameError` with `resyncPosition`; a file with a break is never truncated, including when a torn tail follows the break.

The shared resume rule also learned about pre-extended segments: on Windows a segment is zero-padded to its maximum size, and the native walks run before `size` has been corrected to the end of the data, so a chain of fewer than eight frames in front of the padding could never "reach EOF" and classified as a torn tail — recovery would have truncated committed entries. A chain landing exactly on [the end of the nonzero bytes](https://github.com/HarperFast/rocksdb-js/pull/817/changes?w=1#diff-edc5e16c84874b5fcccc16d99d63a57bc55ef0c45f1d72827edba02fdcd926d2R123) now counts the same as one landing on EOF.

Review feedback on this PR found the other half of that accounting in the index walk. It searches the **mapped** region ([`min(size, mapSize)`](https://github.com/HarperFast/rocksdb-js/pull/817/changes?w=1#diff-70d82772a7a297690416ca9fa571592a9b9d2e0e8b91b58a2a1541ebc173ad74R763)), which stops short of the written extent whenever one batch exceeded `transactionLogMaxSize` or the limit was lowered — and an empty search there was treated as "nothing follows the break", parking `lastIndexedPosition` at the extent, past bytes the walk never read. That loss is permanent: a later, larger map resumes from `lastIndexedPosition` and never looks below it. An empty result is now scoped to the bytes that were searchable, so the walk [stays at the break and reports an unindexed tail](https://github.com/HarperFast/rocksdb-js/pull/817/changes?w=1#diff-70d82772a7a297690416ca9fa571592a9b9d2e0e8b91b58a2a1541ebc173ad74R783) — the same treatment the header bound-check above it already gives a tail the map does not cover — and parks at the extent only when the whole extent was searchable and the break is therefore a torn tail. A short search also [gives up the "chain lands on the written extent" signal](https://github.com/HarperFast/rocksdb-js/pull/817/changes?w=1#diff-70d82772a7a297690416ca9fa571592a9b9d2e0e8b91b58a2a1541ebc173ad74R777): the region ends on an arbitrary cut, so a chain landing there proves nothing, and accepting one would let a garbage chain inside the corrupt gap resume the walk — whose bogus timestamp then caps this running-maxima index and hides every real entry behind it.

Fixes #815. This is the engine half of the harper-pro `txnlogTearReplication` red (follower stuck at 39/60 rows); harper core and harper-pro follow with their own PRs on top of the 2.8.1 release.

## For the human reviewer

Framing-Verdict: better-alternative-exists (8fc19599da00) — resolved by ruling: system-level resync (core surfaces the mid-log-break halt, harper-pro forces the bounded base-copy) *plus* fix the engine watermark amputation and seek blindness here, rather than either alone.

1. **The committed watermark now trusts the resync heuristic.** [`lastCompleteTransactionEnd` advances past a break](https://github.com/HarperFast/rocksdb-js/pull/817/changes?w=1#diff-edc5e16c84874b5fcccc16d99d63a57bc55ef0c45f1d72827edba02fdcd926d2R233) to the last flagged entry the scan can reach, which means the committed-read bound accepts a run of frames that `findFramingResumeOffset()` judged to be real log data (≥ 8 well-formed frames, or a chain landing exactly on the written extent). Alternative: keep the watermark pinned before the first break and leave only uncommitted reads able to see past it. Chosen because the JS reader already delivers those frames as entries under the same heuristic, so pinning the watermark buys no additional safety, only the 39/60 amputation. A "no" here reverts to the amputation and pushes the whole recovery onto the base-copy resync in harper-pro. Cheap to reverse (one branch in the scan).
2. **Accepted and filed, not fixed here: the unflagged prefix of the torn transaction is now reachable on committed reads of the current file** (#816). When the break tore the last entry of a batch, the batch's earlier entries are intact frames below the advanced watermark, so a committed read delivers them before throwing at the break — entries the source never committed. Pinning the watermark only for that shape would silently re-amputate it (the sender would park with no error), which is worse under the ruling's invariant than a loud break plus a phantom the forced copy repairs; a proper fix is a hole-aware committed read (per-file torn-group range surfaced to the reader, including lazily for rotated files, where the same leak has existed since #750). That is a new engine surface, out of scope for the red fix. Both the PR review and every pre-push round re-raised it as the top finding; the ruling on this task was to keep #817 scoped and land the hole-aware reader in #816.
3. **The index walk treats a frame whose length overruns `size` as a break, never as an in-flight append.** This rests on `writeEntriesV1` bumping `size` only after `writev` returns and on the POSIX overlay exposing bytes only up to an entry boundary, so a nonzero header below `size` is always a complete entry. If that invariant is ever relaxed (a writer publishing `size` before the bytes land), the walk would skip a live entry's index slot until `resetTimestampIndex()`. Same assumption the base code made implicitly by striding `HEADER + length`; this PR makes it explicit in the comment. Where to look hardest: [the resume branch of `findPositionByTimestamp`](https://github.com/HarperFast/rocksdb-js/pull/817/changes?w=1#diff-70d82772a7a297690416ca9fa571592a9b9d2e0e8b91b58a2a1541ebc173ad74R759) and the [`min(size, mapSize)` bound](https://github.com/HarperFast/rocksdb-js/pull/817/changes?w=1#diff-70d82772a7a297690416ca9fa571592a9b9d2e0e8b91b58a2a1541ebc173ad74R763) on the byte search.
4. **A short map's empty search stops the index at the break; only a full-extent search parks it at the extent.** [The torn-tail branch](https://github.com/HarperFast/rocksdb-js/pull/817/changes?w=1#diff-70d82772a7a297690416ca9fa571592a9b9d2e0e8b91b58a2a1541ebc173ad74R793) still jumps `lastIndexedPosition` to `size` so later appends get indexed and the torn bytes never do — but only when the whole written extent was searchable, which is the only case that proves nothing follows. Staying at the break costs nothing per seek: the extent that failed is [memoized](https://github.com/HarperFast/rocksdb-js/pull/817/changes?w=1#diff-01368d0a7e6260e12be3080a46522d2a748c253d88a35b493f66f8f082b32e5dR251), since only a larger map can change the answer, and [the guard](https://github.com/HarperFast/rocksdb-js/pull/817/changes?w=1#diff-70d82772a7a297690416ca9fa571592a9b9d2e0e8b91b58a2a1541ebc173ad74R764) answers a repeat seek without re-scanning the corrupt gap under the store's `dataSetsMutex`. Every assignment that moves `lastIndexedPosition` off the break — including `resetTimestampIndex()` — clears the memo, so the two cannot disagree; that is the invariant to check hardest. A native-test-only counter (`resyncSearchCountForTests`, `ROCKSDB_JS_NATIVE_TESTS` only) makes the elision assertable rather than assumed. The landing rule is switched off for a short search through [`endIsWrittenExtent`](https://github.com/HarperFast/rocksdb-js/pull/817/changes?w=1#diff-edc5e16c84874b5fcccc16d99d63a57bc55ef0c45f1d72827edba02fdcd926d2R124), which defaults to true so the recovery scan — which reads the real file — is unchanged.
5. **"End of the nonzero bytes" as a second written-extent signal.** [`nonzeroEnd()`](https://github.com/HarperFast/rocksdb-js/pull/817/changes?w=1#diff-edc5e16c84874b5fcccc16d99d63a57bc55ef0c45f1d72827edba02fdcd926d2R42) is computed once per scan, reading the file backwards from its physical size, only when a break has already been found. The residual: a run whose *last payload ends in zero bytes* still misses the signal (its chain lands past the nonzero end) and, if shorter than eight frames and in front of padding, still classifies as torn — Windows-only, and narrower than the base behaviour, which truncated every such run; the rule is recorded in [AGENTS.md invariant 11](https://github.com/HarperFast/rocksdb-js/pull/817/changes?w=1#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9R459). A false positive needs a forged chain landing on that exact offset (one in 2³² per candidate). Alternative: derive the extent from the caller's corrected `size` — but the callers are the ones computing `size`, so the scan has nothing to be handed. Fixing it exactly needs a persisted logical append extent, which is a format change and a follow-up, not part of this red fix; accepting `pos >= nonzeroEnd()` instead would let any forged length landing anywhere in megabytes of padding qualify, which is a much worse trade.
6. **Classification stays pinned to the first break** ([`firstBreak`](https://github.com/HarperFast/rocksdb-js/pull/817/changes?w=1#diff-edc5e16c84874b5fcccc16d99d63a57bc55ef0c45f1d72827edba02fdcd926d2R230)) while the walk continues past it (`MidFileCorruption`, `validEnd` = first break) — unchanged from base, which also stopped classifying at the first break and never truncated after it.

Declined: the resync byte search runs under `fileMutex` with no upper bound other than the file (Codex, round 1). It runs once per file per open, only when a break exists, and spans only the corrupt gap; the adjudicator agreed it is a latency cliff on an already-corrupt file, not a hang. The memo above removes the repeat-seek half of the same concern raised against the index walk (which holds the store's `dataSetsMutex`). The overlay-lag concern from the same round ("a live append mistaken for corruption") does not apply: the shared range ends at an entry boundary and the walk never reads a header at or past `size`, so a lagging overlay reads as zeros — the existing end-of-data branch.

Declined: "the partial-map retry cannot recover through the public reader, because a current file is always mapped at `maxFileSize`" (pre-push round 6-9). The retry is what makes recovery possible at all. While the segment is current, `maxFileSize` is the same bound the *reader* maps under (`TransactionLogStore::getMemoryMap`), so no entry past it was readable in the first place; once the segment rotates or is reopened as non-current it is mapped at its own `size`, the whole extent becomes searchable, and the walk — still parked at the break — resumes and indexes the run. Under the previous behaviour `lastIndexedPosition` had already jumped past those entries, so rotation could never recover them.

## Verification

- Fails-on-base: with `src/` reverted to `origin/main` (tests kept), the new behaviour tests in `TransactionLogRecovery.*` / `TransactionLogTimestampIndex.*` fail and the 3 new JS [`mid-file break on reopen`](https://github.com/HarperFast/rocksdb-js/pull/817/changes?w=1#diff-22a3c4e9b693561b0d3d6534ae81880ea0dec05f14fc12b7bbc837a5748e59e5R2077) tests fail with `expected 39 to be 59`, `expected 20 to be 58`, `expected 39 to be 59` — the same 39/60 shape as the harper-pro red. The `TransactionLogResumeOffset.*` tests do not compile on base (new symbol). The padding rule proven the same way: with `reachesWrittenExtent` reduced to `pos == fileSize`, [`ShortRunReachingThePaddingIsNotTruncated`](https://github.com/HarperFast/rocksdb-js/pull/817/changes?w=1#diff-3113b0b5416781a95ab3ef9fad57195b021e3f38992632b828139c5d6ef24b9aR216) fails (`TruncateTail` instead of `MidFileCorruption`, watermark 69 instead of 177) and `ShortRunBeforeThePaddingIsIndexedAndEndsTheFile` fails (seek reports past-file).
- Fails-on-branch for the new index rule: [`ShortMapDoesNotSkipTheUnsearchedPostBreakTail`](https://github.com/HarperFast/rocksdb-js/pull/817/changes?w=1#diff-3113b0b5416781a95ab3ef9fad57195b021e3f38992632b828139c5d6ef24b9aR750) fails with the previous `lastIndexedPosition = writtenExtent` line restored — the short-map seek and both later full-map seeks report `4294967295` (past-file) instead of the break and the run's offsets — and, with the memo guard disabled, the counter assertions fail `2`/`3` against the expected `1`/`2`. [`ShortMapCutIsNotTreatedAsTheWrittenExtent`](https://github.com/HarperFast/rocksdb-js/pull/817/changes?w=1#diff-3113b0b5416781a95ab3ef9fad57195b021e3f38992632b828139c5d6ef24b9aR799) and [`ACutIsNotTheWrittenExtent`](https://github.com/HarperFast/rocksdb-js/pull/817/changes?w=1#diff-3113b0b5416781a95ab3ef9fad57195b021e3f38992632b828139c5d6ef24b9aR677) both fail with `endIsWrittenExtent` forced true (the index one resumes at the run instead of holding at the break).
- Green: `pnpm test:native` 180/180; `pnpm test` 837 passed, 3 skipped; `pnpm check` clean. Note for anyone re-running the native suite: `pnpm test:native` rebuilds only when the binary is missing or the RocksDB pin changed, so a C++ edit needs `NATIVE_TEST_REBUILD=1` or it silently tests the previous binary.
- Windows CI (first push): the four `mid-file break on reopen` tests failed on every Windows leg with `errno -4094` (`ERROR_USER_MAPPED_FILE`) opening `1.txnlog`. The tests queried the log before closing the database to collect seek timestamps; that query maps the file and the map outlives `close()` while its entries are reachable, so the truncating rewrite that tears the frame is refused on Windows. They now read the timestamps from the frame headers on disk after close, so nothing is mapped when the file is rewritten (`test/transaction-log.test.ts` `headerTimestamps`). The new native test needs the same care from the other direction: Windows indexes the whole file against a full-extent map inside `openFile()`, so it drops that mapping and the index before asserting. Both are proven by the Windows legs on this push.
- End-to-end route: harper-pro `integrationTests/cluster/txnlogTearReplication.test.mjs` against a core pinned to this build, in the harper-pro PR that lands on top (its own PR body carries the 60/60 result).

Complexity: complicated

<sub>Review-Coverage: authored=claude; ran=codex; blocked=gemini(auth); declined=cursor-grok,cursor-composer,domain; rounds=11 @ 7012af701590</sub>

<sub>Human-Review-Need: 4 @ 7012af701590</sub>
