### PR TITLE
Make a WriteBufferManager write stall observable

### DIFF
--- a/.github/workflows/benchmark-asan.yml
+++ b/.github/workflows/benchmark-asan.yml
@@ -36,8 +36,6 @@ jobs:
 
       - name: Install pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-        with:
-          version: latest
 
       - name: Use Node.js 24
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/.github/workflows/benchmark-asan.yml
+++ b/.github/workflows/benchmark-asan.yml
@@ -67,7 +67,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           ROCKSDB_ASAN: '1'
-        run: pnpm rebuild
+        run: pnpm run rebuild
 
       - name: Loop worker benchmarks under ASan
         id: asan

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -47,8 +47,6 @@ jobs:
 
       - name: Install pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-        with:
-          version: latest
 
       - name: Use Node.js 24
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -23,8 +23,6 @@ jobs:
 
       - name: Install pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-        with:
-          version: latest
 
       - name: Use Node.js 24
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -23,8 +23,6 @@ jobs:
 
       - name: Install pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-        with:
-          version: latest
 
       - name: Use Node.js 24
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -60,8 +58,6 @@ jobs:
 
       - name: Install pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-        with:
-          version: latest
 
       - name: Use Node.js ${{ matrix.node }}
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -97,8 +93,6 @@ jobs:
 
       - name: Install pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-        with:
-          version: latest
 
       - name: Use Node.js 24
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -146,8 +140,6 @@ jobs:
 
       - name: Install pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-        with:
-          version: latest
 
       - name: Use Node.js 24
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -188,8 +180,6 @@ jobs:
 
       - name: Install pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-        with:
-          version: latest
 
       - name: Use Node.js 24
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,8 +21,6 @@ jobs:
 
       - name: Install pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-        with:
-          version: latest
 
       - name: Setup node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -151,8 +149,6 @@ jobs:
 
       - name: Install pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-        with:
-          version: latest
 
       - name: Setup node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -206,8 +202,6 @@ jobs:
 
       - name: Install pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-        with:
-          version: latest
 
       - name: Setup node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/.github/workflows/stress.yml
+++ b/.github/workflows/stress.yml
@@ -33,8 +33,6 @@ jobs:
 
       - name: Install pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-        with:
-          version: latest
 
       - name: Use Node.js 24
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -747,14 +747,14 @@ sufficient (env teardown does not honor tsfn acquire counts); see
     Eight hours of wedged production read `0` on every one of them (HarperFast/rocksdb-js#822).
     `WriteBufferManager::IsStallActive()` against `memory_usage()`/`buffer_size()` is the only
     distinguishing signal, surfaced as `writeBufferManager.*` in `db.getStats()`/`getStat()` and
-    `RocksDatabase.getWriteBufferManagerStats()`.
+    `getWriteBufferManagerStats()`.
 
     **The watchdog owns a thread because every other tick in this process is blocked by the
     condition it reports.** `CommitWorker` parks in `db->Write()` (it is one of the wedged threads in
     #822's backtrace); `logWorker` is event-driven off commits the stall prevents;
     `ParkTimeoutRegistry`'s thread is per-descriptor and only exists after a VT conflict; RocksDB's
     stall callbacks never fire; and a JS timer cannot run on a thread parked in `store.putSync()`.
-    So `DBSettings` owns one process-wide thread, started lazily only while a manager exists **with**
+    So `DBStats` owns one process-wide thread, started lazily only while a manager exists **with**
     `allowStall` (`ShouldStall()` short-circuits otherwise, so no stall is reachable and no thread is
     started), sampling one relaxed atomic per second. Plain `std::thread`, not `uv_timer_t`, for
     invariant 12's reason.
@@ -766,7 +766,10 @@ sufficient (env teardown does not honor tsfn acquire counts); see
       `databasesMutex` only inside `CollectWriteBufferManagerInventory`, so there is no cycle — but
       that is why `ensureWriteBufferManagerWatchdog()` must never **join** a retiring thread: it runs
       under `databasesMutex`, and the thread it would join may be waiting for exactly that lock.
-      Joining is `joinWriteBufferManagerWatchdog()`'s job alone.
+      Joining is `DBStats::joinWriteBufferManagerWatchdog()`'s job alone. `DBStats::Init()`
+      materializes the watchdog owner after `DBRegistry`, while its constructor first materializes
+      `DBSettings` and `GlobalEvents`; reverse static destruction therefore joins the watchdog before
+      any dependency it reads is destroyed.
     - **Stop and join are split** (`binding.cpp`, both the `shutdown()` export and the last-env
       cleanup hook): request the stop first, run `DBRegistry::Shutdown()` (the flush path), and join
       _after_. The warn line goes to `stderr`, which can block on a full pipe, and joining first

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -210,6 +210,14 @@ sufficient (env teardown does not honor tsfn acquire counts); see
   ambiguous "disable the bound") falls back to the default like any malformed
   value. There is no opt-out: a deployment that would rather wait than fail a
   legitimately slow holder raises the value instead
+- `ROCKSDB_JS_WBM_STALL_WARN_MS` - How long a `WriteBufferManager` stall must be
+  _continuously_ active (default `5000`) before the stall watchdog writes its one
+  warn line. `0` disables the watchdog entirely (and with it
+  `writeBufferManager.stallActiveMs`); a value below the 1s sample interval clamps
+  up to it; malformed, negative or above 24h falls back to the default. Read once
+  per process via a function-local `static` (the watchdog runs off the JS thread —
+  same `::getenv`-vs-`process.env` caveat as `ROCKSDB_JS_PARK_TIMEOUT_MS`), so it
+  must be set in the environment a process is started with
 - `ROCKSDB_JS_WRITE_STALL_DEBOUNCE_MS` - Rate-limit window (default `1000`) for the
   per-database `'writeStall'` event. The event is rising-edge only (fires when a
   column family enters a stall); during a sustained oscillating stall it re-emits
@@ -730,6 +738,54 @@ sufficient (env teardown does not honor tsfn acquire counts); see
     written remains frozen across retries, though reapplying the same timestamp is idempotent while
     the transaction remains pending. rocksdb-js does not define record value layouts: a producer
     that copies `getTimestamp()` into record bytes must call `setTimestamp()` first.
+
+19. **A WriteBufferManager stall is a second, entirely separate stall mechanism, and nothing in
+    RocksDB reports it**: `DBImpl::WriteBufferManagerStallWrites` parks writers on the manager's own
+    queue (`WBMStallInterface::Block`) without touching the `WriteController`, so `rocksdb.stall.micros`,
+    the `WRITE_STALL` histogram, `OnStallConditionsChanged` — and therefore the `'writeStall'` event
+    and `isWriteStalled()` (invariant 16's neighbours) — all stay at zero for its entire duration.
+    Eight hours of wedged production read `0` on every one of them (HarperFast/rocksdb-js#822).
+    `WriteBufferManager::IsStallActive()` against `memory_usage()`/`buffer_size()` is the only
+    distinguishing signal, surfaced as `writeBufferManager.*` in `db.getStats()`/`getStat()` and
+    `RocksDatabase.getWriteBufferManagerStats()`.
+
+    **The watchdog owns a thread because every other tick in this process is blocked by the
+    condition it reports.** `CommitWorker` parks in `db->Write()` (it is one of the wedged threads in
+    #822's backtrace); `logWorker` is event-driven off commits the stall prevents;
+    `ParkTimeoutRegistry`'s thread is per-descriptor and only exists after a VT conflict; RocksDB's
+    stall callbacks never fire; and a JS timer cannot run on a thread parked in `store.putSync()`.
+    So `DBSettings` owns one process-wide thread, started lazily only while a manager exists **with**
+    `allowStall` (`ShouldStall()` short-circuits otherwise, so no stall is reachable and no thread is
+    started), sampling one relaxed atomic per second. Plain `std::thread`, not `uv_timer_t`, for
+    invariant 12's reason.
+
+    Three constraints on that thread, each of which has a failure mode:
+    - **Lock order is `databasesMutex -> writeBufferManagerMutex -> watchdogMutex`**, because
+      `DBRegistry::OpenDB` holds `databasesMutex` across `DBDescriptor::open`, which calls
+      `getWriteBufferManager()`. The watchdog drops `watchdogMutex` before every sample and takes
+      `databasesMutex` only inside `CollectWriteBufferManagerInventory`, so there is no cycle — but
+      that is why `ensureWriteBufferManagerWatchdog()` must never **join** a retiring thread: it runs
+      under `databasesMutex`, and the thread it would join may be waiting for exactly that lock.
+      Joining is `joinWriteBufferManagerWatchdog()`'s job alone.
+    - **Stop and join are split** (`binding.cpp`, both the `shutdown()` export and the last-env
+      cleanup hook): request the stop first, run `DBRegistry::Shutdown()` (the flush path), and join
+      _after_. The warn line goes to `stderr`, which can block on a full pipe, and joining first
+      would put a logging stall in front of durability.
+    - **The inventory counts only column families that can explain the budget** — descriptors that
+      attached _this_ manager (attachment is decided per open, so a database opened before the
+      manager was configured, or while its size was 0, has not) and are not read-only. The retention
+      value it reports is the **effective** `max_write_buffer_size_to_maintain` read from
+      `db->GetOptions(cf)` at creation, never the requested one: #821's whole finding is that
+      `TransactionDB::Open` rewrites a requested `0` into 256 MiB per CF, so the requested value
+      hides the fact the report exists to expose.
+
+    The report is one line per _episode_ (a stall must be continuously active past the threshold),
+    with deliberately no second rate-limit window on top — a window would suppress the first line of
+    a genuinely new episode, which is the one that matters. The decision FSM is Node-free in
+    `core/wbm_stall_watchdog.h` and GoogleTest-covered; a test that reaches a real stall must run in
+    a child process the parent kills on a deadline, because the stalled writer blocks the JS thread
+    and the runner's own timeout cannot fire (#781 item 2), and because `allowStall` is fixed when
+    the manager singleton is constructed.
 
 ## Debugging native heap corruption
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -779,8 +779,13 @@ sufficient (env teardown does not honor tsfn acquire counts); see
       attached _this_ manager (attachment is decided per open, so a database opened before the
       manager was configured, or while its size was 0, has not). Read-only opens are included because
       WAL recovery can retain charged memtables. A dropped family can remain charged through a live
-      handle after leaving the by-name map, so that descriptor makes the inventory unavailable rather
-      than incomplete. The retention value it reports is the **effective**
+      handle after leaving the by-name map, so `unregisterColumnFamily` moves it to
+      `DBDescriptor::droppedColumns` — a `weak_ptr` plus a copy of its retention target — and the
+      walk keeps counting it until that last handle closes. Only `expired()` is ever called on that
+      reference: `lock()`ing it would make the sampling thread the potential last releaser, running
+      `~ColumnFamilyDescriptor` (and the RocksDB handle it owns) under both inventory locks. Latching
+      the descriptor unavailable instead was the first attempt, and one `dropSync()` then blinded the
+      report for the life of the database. The retention value it reports is the **effective**
       `max_write_buffer_size_to_maintain` read from `db->GetOptions(cf)` at creation, never the
       requested one: #821's whole finding is that `TransactionDB::Open` rewrites a requested `0` into
       256 MiB per CF, so the requested value hides the fact the report exists to expose.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -787,8 +787,7 @@ sufficient (env teardown does not honor tsfn acquire counts); see
     a genuinely new episode, which is the one that matters. The decision FSM is Node-free in
     `core/wbm_stall_watchdog.h` and GoogleTest-covered; a test that reaches a real stall must run in
     a child process the parent kills on a deadline, because the stalled writer blocks the JS thread
-    and the runner's own timeout cannot fire (#781 item 2), and because `allowStall` is fixed when
-    the manager singleton is constructed.
+    and the runner's own timeout cannot fire (#781 item 2).
 
 ## Debugging native heap corruption
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -756,9 +756,10 @@ sufficient (env teardown does not honor tsfn acquire counts); see
     stall callbacks never fire; and a JS timer cannot run on a thread parked in `store.putSync()`.
     So `DBStats` owns one process-wide thread, created lazily the first time a manager exists **with**
     `allowStall` (`ShouldStall()` short-circuits otherwise, so no stall is reachable). Runtime disable
-    parks that thread and re-enable arms it with a fresh episode state; only final teardown joins it.
-    It samples one relaxed atomic per second. Plain `std::thread`, not `uv_timer_t`, for invariant
-    12's reason.
+    parks that thread and re-enable arms it with a fresh episode state; explicit shutdown and final
+    teardown join it. Since `shutdown()` supports reopening databases, the stop latch resets only
+    after the old thread has joined. It samples one relaxed atomic per second. Plain `std::thread`,
+    not `uv_timer_t`, for invariant 12's reason.
 
     Three constraints on that thread, each of which has a failure mode:
     - **Lock order is `databasesMutex -> writeBufferManagerMutex -> watchdogMutex`**, because
@@ -776,11 +777,13 @@ sufficient (env teardown does not honor tsfn acquire counts); see
       would put a logging stall in front of durability.
     - **The inventory counts only column families that can explain the budget** — descriptors that
       attached _this_ manager (attachment is decided per open, so a database opened before the
-      manager was configured, or while its size was 0, has not) and are not read-only. The retention
-      value it reports is the **effective** `max_write_buffer_size_to_maintain` read from
-      `db->GetOptions(cf)` at creation, never the requested one: #821's whole finding is that
-      `TransactionDB::Open` rewrites a requested `0` into 256 MiB per CF, so the requested value
-      hides the fact the report exists to expose.
+      manager was configured, or while its size was 0, has not). Read-only opens are included because
+      WAL recovery can retain charged memtables. A dropped family can remain charged through a live
+      handle after leaving the by-name map, so that descriptor makes the inventory unavailable rather
+      than incomplete. The retention value it reports is the **effective**
+      `max_write_buffer_size_to_maintain` read from `db->GetOptions(cf)` at creation, never the
+      requested one: #821's whole finding is that `TransactionDB::Open` rewrites a requested `0` into
+      256 MiB per CF, so the requested value hides the fact the report exists to expose.
 
     The report is one line per _episode_ (a stall must be continuously active past the threshold),
     with deliberately no second rate-limit window on top — a window would suppress the first line of

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -754,19 +754,19 @@ sufficient (env teardown does not honor tsfn acquire counts); see
     #822's backtrace); `logWorker` is event-driven off commits the stall prevents;
     `ParkTimeoutRegistry`'s thread is per-descriptor and only exists after a VT conflict; RocksDB's
     stall callbacks never fire; and a JS timer cannot run on a thread parked in `store.putSync()`.
-    So `DBStats` owns one process-wide thread, started lazily only while a manager exists **with**
-    `allowStall` (`ShouldStall()` short-circuits otherwise, so no stall is reachable and no thread is
-    started), sampling one relaxed atomic per second. Plain `std::thread`, not `uv_timer_t`, for
-    invariant 12's reason.
+    So `DBStats` owns one process-wide thread, created lazily the first time a manager exists **with**
+    `allowStall` (`ShouldStall()` short-circuits otherwise, so no stall is reachable). Runtime disable
+    parks that thread and re-enable arms it with a fresh episode state; only final teardown joins it.
+    It samples one relaxed atomic per second. Plain `std::thread`, not `uv_timer_t`, for invariant
+    12's reason.
 
     Three constraints on that thread, each of which has a failure mode:
     - **Lock order is `databasesMutex -> writeBufferManagerMutex -> watchdogMutex`**, because
       `DBRegistry::OpenDB` holds `databasesMutex` across `DBDescriptor::open`, which calls
-      `getWriteBufferManager()`. The watchdog drops `watchdogMutex` before every sample and takes
-      `databasesMutex` only inside `CollectWriteBufferManagerInventory`, so there is no cycle — but
-      that is why `ensureWriteBufferManagerWatchdog()` must never **join** a retiring thread: it runs
-      under `databasesMutex`, and the thread it would join may be waiting for exactly that lock.
-      Joining is `DBStats::joinWriteBufferManagerWatchdog()`'s job alone. `DBStats::Init()`
+      `getWriteBufferManager()`. The watchdog drops `watchdogMutex` before every sample and only
+      try-locks the registry and column inventories, so there is no cycle. `ensure` and `disable`
+      only arm or park it because they run under higher-order locks and its stderr write may block;
+      joining is `DBStats::joinWriteBufferManagerWatchdog()`'s final-teardown job alone. `DBStats::Init()`
       materializes the watchdog owner after `DBRegistry`, while its constructor first materializes
       `DBSettings` and `GlobalEvents`; reverse static destruction therefore joins the watchdog before
       any dependency it reads is destroyed.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -758,12 +758,15 @@ sufficient (env teardown does not honor tsfn acquire counts); see
     So `DBStats` owns one process-wide thread, created lazily the first time a manager exists **with**
     `allowStall` (`ShouldStall()` short-circuits otherwise, so no stall is reachable). Runtime disable
     parks that thread and re-enable arms it with a fresh episode state; explicit shutdown and final
-    teardown join it. Since `shutdown()` supports reopening databases, the stop latch resets only
-    after the old thread has joined — and only by the joiner that actually took the thread. Two envs
-    calling `shutdown()` at once both reach the join, and letting the one that found nothing to join
-    clear the latch stranded the other inside `join()` forever: the thread had not observed the stop
-    yet, so it went back to waiting on `stopRequested || armed` with both false. `watchdogRetiring`
-    makes the non-owning joiners wait for the retirement instead
+    teardown join it. Since `shutdown()` supports reopening databases, every `ensure` advances an
+    arm-request generation that `shutdown()` snapshots before closing databases. A rearm-capable
+    joiner returns without retiring when that generation changed, so an older shutdown cannot stop a
+    watchdog belonging to a concurrent reopen. Once a joiner takes a thread, the stop latch resets
+    only after that thread has joined; callers that find no thread return without mutating the stop
+    state. Two envs calling `shutdown()` at once both reach the join, and letting a non-owner clear
+    the latch stranded the owner inside `join()` forever: the thread had not observed the stop yet,
+    so it went back to waiting on `stopRequested || armed` with both false. `watchdogRetiring` makes
+    the non-owning joiners wait for the retirement instead
     (`test/fixtures/fork-wbm-watchdog-shutdown.mts`, which reproduces the hang about one run in three
     without the fix). It samples one relaxed atomic per second. Plain `std::thread`,
     not `uv_timer_t`, for invariant 12's reason.
@@ -778,10 +781,11 @@ sufficient (env teardown does not honor tsfn acquire counts); see
       materializes the watchdog owner after `DBRegistry`, while its constructor first materializes
       `DBSettings` and `GlobalEvents`; reverse static destruction therefore joins the watchdog before
       any dependency it reads is destroyed.
-    - **Stop and join are split** (`binding.cpp`, both the `shutdown()` export and the last-env
-      cleanup hook): request the stop first, run `DBRegistry::Shutdown()` (the flush path), and join
-      _after_. The warn line goes to `stderr`, which can block on a full pipe, and joining first
-      would put a logging stall in front of durability.
+    - **Stop and join both follow the flush** (`binding.cpp`, both the `shutdown()` export and the
+      last-env cleanup hook): snapshot the arm-request generation, run `DBRegistry::Shutdown()`, then
+      stop and join. Keeping the watchdog live through the flush lets it write to `stderr` when
+      shutdown itself is wedged behind a stalled writer; global listeners have already been released.
+      Joining after the flush also keeps a blocking stderr write out of the durability path.
     - **The inventory counts only column families that can explain the budget** — descriptors that
       attached _this_ manager (attachment is decided per open, so a database opened before the
       manager was configured, or while its size was 0, has not). Read-only opens are included because

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -758,7 +758,13 @@ sufficient (env teardown does not honor tsfn acquire counts); see
     `allowStall` (`ShouldStall()` short-circuits otherwise, so no stall is reachable). Runtime disable
     parks that thread and re-enable arms it with a fresh episode state; explicit shutdown and final
     teardown join it. Since `shutdown()` supports reopening databases, the stop latch resets only
-    after the old thread has joined. It samples one relaxed atomic per second. Plain `std::thread`,
+    after the old thread has joined — and only by the joiner that actually took the thread. Two envs
+    calling `shutdown()` at once both reach the join, and letting the one that found nothing to join
+    clear the latch stranded the other inside `join()` forever: the thread had not observed the stop
+    yet, so it went back to waiting on `stopRequested || armed` with both false. `watchdogRetiring`
+    makes the non-owning joiners wait for the retirement instead
+    (`test/fixtures/fork-wbm-watchdog-shutdown.mts`, which reproduces the hang about one run in three
+    without the fix). It samples one relaxed atomic per second. Plain `std::thread`,
     not `uv_timer_t`, for invariant 12's reason.
 
     Three constraints on that thread, each of which has a failure mode:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -731,6 +731,7 @@ sufficient (env teardown does not honor tsfn acquire counts); see
     so a leaked one wedges its workspace permanently. While any key for that physical path is
     closing, `OpenDB` must wait before opening every other key too; otherwise a fresh read-only or
     secondary key can appear after destroy's claim and be deleted and erased without being closed.
+
 19. **A transaction timestamp freezes when native state captures it**: `setTimestamp()` may adopt an
     origin timestamp for replication or replay only while the transaction is pending and before any
     database write or transaction-log entry is staged. The log batch snapshots the timestamp at the
@@ -739,7 +740,7 @@ sufficient (env teardown does not honor tsfn acquire counts); see
     the transaction remains pending. rocksdb-js does not define record value layouts: a producer
     that copies `getTimestamp()` into record bytes must call `setTimestamp()` first.
 
-19. **A WriteBufferManager stall is a second, entirely separate stall mechanism, and nothing in
+20. **A WriteBufferManager stall is a second, entirely separate stall mechanism, and nothing in
     RocksDB reports it**: `DBImpl::WriteBufferManagerStallWrites` parks writers on the manager's own
     queue (`WBMStallInterface::Block`) without touching the `WriteController`, so `rocksdb.stall.micros`,
     the `WRITE_STALL` histogram, `OnStallConditionsChanged` — and therefore the `'writeStall'` event

--- a/README.md
+++ b/README.md
@@ -270,6 +270,9 @@ where the call was made.
 - `watchdogRunning: boolean` Whether the stall watchdog thread is running.
 - `columnFamilies: number` Live column families across every writable database attached to this
   manager.
+- `inventoryAvailable: boolean` `false` when the inventory could not be collected because the
+  database registry was locked — most plausibly by a close waiting out this same stall. The two
+  inventory fields are then empty and everything else is still live; the call never blocks on it.
 - `maxWriteBufferSizeToMaintain: Record<string, number>` Effective per-column-family retained-history
   target (as a decimal string) to how many of those column families carry it. Effective, not
   requested: RocksDB rewrites a requested `0` for a transaction database.

--- a/README.md
+++ b/README.md
@@ -225,7 +225,11 @@ Sets global database settings.
   - `writeBufferManagerAllowStall: boolean` When `true`, writes are stalled once the manager's
     `buffer_size` is exceeded, providing a hard cap on memtable memory. When `false`, memtables are
     allowed to grow past the limit and flushes are simply scheduled more aggressively. Off by
-    default to favor write throughput over hard memory bounding. Defaults to `false`.
+    default to favor write throughput over hard memory bounding. Defaults to `false`. A stall here
+    is invisible to RocksDB's own stall counters and to
+    [`db.isWriteStalled()`](#dbiswritestalled-boolean) — see
+    [`RocksDatabase.getWriteBufferManagerStats()`](#rocksdatabasegetwritebuffermanagerstats-writebuffermanagerstats),
+    which also describes the watchdog that logs a sustained stall.
   - `writeBufferManagerCostToCache: boolean` When `true`, memtable memory is "charged" against the
     shared block cache so the block cache and write buffers draw from a single pool. During write
     bursts the cache shrinks to make room for memtables; once memtables flush, the cache can grow
@@ -243,6 +247,69 @@ RocksDatabase.config({
 	writeBufferManagerCostToCache: false,
 	writeBufferManagerSize: 64 * 1024 * 1024, // 64MB
 });
+```
+
+### `RocksDatabase.getWriteBufferManagerStats(): WriteBufferManagerStats`
+
+Reads the live state of the `WriteBufferManager`.
+
+**Process-wide, not per-database.** The manager is a singleton shared by every database opened in
+this process, `worker_threads` included, so these values describe the whole process regardless of
+where the call was made.
+
+- `enabled: boolean` Whether a manager has been created. Every other value is `0`/`false` when not.
+- `bufferSize: number` The budget in bytes (`writeBufferManagerSize`, read live).
+- `memoryUsage: number` Total memtable memory in bytes charged against the manager.
+- `mutableMemoryUsage: number` The share of `memoryUsage` held by active (mutable) memtables; the
+  rest is memtables awaiting flush plus retained write history.
+- `allowStall: boolean`, `costToCache: boolean` The manager's configuration.
+- `stallActive: boolean` Whether the manager is currently stalling writes.
+- `stallActiveMs: number` How long the current stall has been active; `0` when not stalled.
+  Sampled once a second by the watchdog, so `0` for a stall's first second and whenever
+  `watchdogRunning` is `false`.
+- `watchdogRunning: boolean` Whether the stall watchdog thread is running.
+- `columnFamilies: number` Live column families across every writable database attached to this
+  manager.
+- `maxWriteBufferSizeToMaintain: Record<string, number>` Effective per-column-family retained-history
+  target (as a decimal string) to how many of those column families carry it. Effective, not
+  requested: RocksDB rewrites a requested `0` for a transaction database.
+
+The first five values are also in [`db.getStats()`](#dbgetstatsall-boolean-rocksdbstats) and
+`db.getStat()` under the same `writeBufferManager.` prefix, for scraping; the column-family
+inventory is only here, because collecting it walks the database registry.
+
+`stallActive` is the signal that distinguishes a stalled process from an idle one.
+[`db.isWriteStalled()`](#dbiswritestalled-boolean), the [`'writeStall'` event](#event-writestall)
+and `rocksdb.stall.micros` all track RocksDB's `WriteController`, which a `WriteBufferManager`
+stall never goes through.
+
+#### The stall watchdog
+
+While a manager exists with `writeBufferManagerAllowStall`, one low-frequency thread samples the
+manager once a second. When a stall has been continuously active past
+`ROCKSDB_JS_WBM_STALL_WARN_MS` (default `5000`; `0` disables the watchdog) it writes **one** line
+to `stderr` and emits it as a process-wide `'log.warn'` event — once per stall episode, not per
+blocked writer and not per sample:
+
+```
+[rocksdb-js] WriteBufferManager write stall active for 5.0s - no write can complete until memtable
+memory drops below the budget. budget=661.2MB usage=662.2MB (100.2%) mutable=12.4MB (1.9%)
+allowStall=true costToCache=true columnFamilies=28 maxWriteBufferSizeToMaintain={268435456:28}
+```
+
+It needs its own thread because every other candidate is blocked by the very condition it reports:
+a writer is parked inside RocksDB, RocksDB's stall callbacks are `WriteController`-only, and a JS
+timer cannot fire on a thread parked in a synchronous write. The line goes to `stderr` as well as
+the event so it is not lost when nothing has registered a `'log.warn'` listener; route one and
+ignore `stderr` if you would rather have it in your own log.
+
+```typescript
+RocksDatabase.on('log.warn', (message) => logger.warn(message));
+
+const wbm = RocksDatabase.getWriteBufferManagerStats();
+if (wbm.stallActive) {
+	logger.warn(`writes stalled for ${wbm.stallActiveMs}ms: ${wbm.memoryUsage}/${wbm.bufferSize}`);
+}
 ```
 
 ### `db.isOpen(): boolean`
@@ -1393,8 +1460,11 @@ Column family and ticker stat values are 64-bit unsigned integers and histogram 
 `StatsHistogramData` objects.
 
 The result also always includes a summarized, aggregate set of `txnlog.*` keys covering all of
-the database's transaction logs. These are present regardless of whether statistics are enabled
-and can be fetched individually with `db.getStat('txnlog.…')`. For detailed, per-log statistics —
+the database's transaction logs, and a set of `writeBufferManager.*` keys describing the
+process-wide `WriteBufferManager`
+([`RocksDatabase.getWriteBufferManagerStats()`](#rocksdatabasegetwritebuffermanagerstats-writebuffermanagerstats)
+carries the same values plus its column-family inventory). Both sets are present regardless of
+whether statistics are enabled and can be fetched individually with `db.getStat()`. For detailed, per-log statistics —
 including memory-map usage — use [`log.getStats()`](#loggetstats-transactionlogstats). All stat
 names are documented in [docs/stats.md](docs/stats.md).
 

--- a/README.md
+++ b/README.md
@@ -268,11 +268,13 @@ where the call was made.
   Sampled once a second by the watchdog, so `0` for a stall's first second and whenever
   `watchdogRunning` is `false`.
 - `watchdogRunning: boolean` Whether the stall watchdog thread is running.
-- `columnFamilies: number` Live column families across every database attached to this manager.
+- `columnFamilies: number` Live column families across every database attached to this manager. A
+  dropped column family keeps charging the manager until its last handle closes, so it is counted
+  until then.
 - `inventoryAvailable: boolean` `false` when the inventory could not be collected because the
-  database registry or a column-family inventory was locked, or a dropped column family may still
-  be retained by a live handle. The two inventory fields are then empty and everything else is
-  still live; the call never blocks on database work that may itself be stalled.
+  database registry or a column-family inventory was locked. The two inventory fields are then
+  empty and everything else is still live; the call never blocks on database work that may itself
+  be stalled.
 - `maxWriteBufferSizeToMaintain: Record<string, number>` Effective per-column-family retained-history
   target (as a decimal string) to how many of those column families carry it. Effective, not
   requested: RocksDB rewrites a requested `0` for a transaction database.

--- a/README.md
+++ b/README.md
@@ -257,7 +257,11 @@ Reads the live state of the `WriteBufferManager`.
 this process, `worker_threads` included, so these values describe the whole process regardless of
 where the call was made.
 
-- `enabled: boolean` Whether a manager has been created. Every other value is `0`/`false` when not.
+- `enabled: boolean` Whether a manager has been created. `bufferSize`, `memoryUsage`,
+  `mutableMemoryUsage`, `stallActive`, `stallActiveMs`, `watchdogRunning` and `columnFamilies` are
+  `0`/`false` when not; `allowStall` and `costToCache` still reflect the configured setting (a
+  manager is only created once `writeBufferManagerSize` is also set), and `inventoryAvailable` is
+  `true` (there is nothing to fail to collect).
 - `bufferSize: number` The budget in bytes (`writeBufferManagerSize`, read live).
 - `memoryUsage: number` Total memtable memory in bytes charged against the manager.
 - `mutableMemoryUsage: number` The share of `memoryUsage` held by active (mutable) memtables; the
@@ -279,9 +283,11 @@ where the call was made.
   target (as a decimal string) to how many of those column families carry it. Effective, not
   requested: RocksDB rewrites a requested `0` for a transaction database.
 
-The first five values are also in [`db.getStats()`](#dbgetstatsall-boolean-rocksdbstats) and
-`db.getStat()` under the same `writeBufferManager.` prefix, for scraping; the column-family
-inventory is only here, because collecting it walks the database registry.
+`bufferSize`, `memoryUsage`, `mutableMemoryUsage`, `stallActive` and `stallActiveMs` are also in
+[`db.getStats()`](#dbgetstatsall-boolean-rocksdbstats) and `db.getStat()` under the same
+`writeBufferManager.` prefix, for scraping; `enabled`, `allowStall`, `costToCache`,
+`watchdogRunning`, and the column-family inventory are only here, because collecting them either
+walks the database registry or isn't scrape-shaped.
 
 `stallActive` is the signal that distinguishes a stalled process from an idle one.
 [`db.isWriteStalled()`](#dbiswritestalled-boolean), the [`'writeStall'` event](#event-writestall)

--- a/README.md
+++ b/README.md
@@ -271,8 +271,9 @@ where the call was made.
 - `columnFamilies: number` Live column families across every writable database attached to this
   manager.
 - `inventoryAvailable: boolean` `false` when the inventory could not be collected because the
-  database registry was locked — most plausibly by a close waiting out this same stall. The two
-  inventory fields are then empty and everything else is still live; the call never blocks on it.
+  database registry or a column-family inventory was locked — most plausibly by database work
+  waiting out this same stall. The two inventory fields are then empty and everything else is still
+  live; the call never blocks on it.
 - `maxWriteBufferSizeToMaintain: Record<string, number>` Effective per-column-family retained-history
   target (as a decimal string) to how many of those column families carry it. Effective, not
   requested: RocksDB rewrites a requested `0` for a transaction database.

--- a/README.md
+++ b/README.md
@@ -268,12 +268,11 @@ where the call was made.
   Sampled once a second by the watchdog, so `0` for a stall's first second and whenever
   `watchdogRunning` is `false`.
 - `watchdogRunning: boolean` Whether the stall watchdog thread is running.
-- `columnFamilies: number` Live column families across every writable database attached to this
-  manager.
+- `columnFamilies: number` Live column families across every database attached to this manager.
 - `inventoryAvailable: boolean` `false` when the inventory could not be collected because the
-  database registry or a column-family inventory was locked — most plausibly by database work
-  waiting out this same stall. The two inventory fields are then empty and everything else is still
-  live; the call never blocks on it.
+  database registry or a column-family inventory was locked, or a dropped column family may still
+  be retained by a live handle. The two inventory fields are then empty and everything else is
+  still live; the call never blocks on database work that may itself be stalled.
 - `maxWriteBufferSizeToMaintain: Record<string, number>` Effective per-column-family retained-history
   target (as a decimal string) to how many of those column families carry it. Effective, not
   requested: RocksDB rewrites a requested `0` for a transaction database.

--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ Sets global database settings.
     default to favor write throughput over hard memory bounding. Defaults to `false`. A stall here
     is invisible to RocksDB's own stall counters and to
     [`db.isWriteStalled()`](#dbiswritestalled-boolean) — see
-    [`RocksDatabase.getWriteBufferManagerStats()`](#rocksdatabasegetwritebuffermanagerstats-writebuffermanagerstats),
+    [`getWriteBufferManagerStats()`](#getwritebuffermanagerstats-writebuffermanagerstats),
     which also describes the watchdog that logs a sustained stall.
   - `writeBufferManagerCostToCache: boolean` When `true`, memtable memory is "charged" against the
     shared block cache so the block cache and write buffers draw from a single pool. During write
@@ -249,7 +249,7 @@ RocksDatabase.config({
 });
 ```
 
-### `RocksDatabase.getWriteBufferManagerStats(): WriteBufferManagerStats`
+### `getWriteBufferManagerStats(): WriteBufferManagerStats`
 
 Reads the live state of the `WriteBufferManager`.
 
@@ -309,7 +309,7 @@ ignore `stderr` if you would rather have it in your own log.
 ```typescript
 RocksDatabase.on('log.warn', (message) => logger.warn(message));
 
-const wbm = RocksDatabase.getWriteBufferManagerStats();
+const wbm = getWriteBufferManagerStats();
 if (wbm.stallActive) {
 	logger.warn(`writes stalled for ${wbm.stallActiveMs}ms: ${wbm.memoryUsage}/${wbm.bufferSize}`);
 }
@@ -1465,7 +1465,7 @@ Column family and ticker stat values are 64-bit unsigned integers and histogram 
 The result also always includes a summarized, aggregate set of `txnlog.*` keys covering all of
 the database's transaction logs, and a set of `writeBufferManager.*` keys describing the
 process-wide `WriteBufferManager`
-([`RocksDatabase.getWriteBufferManagerStats()`](#rocksdatabasegetwritebuffermanagerstats-writebuffermanagerstats)
+([`getWriteBufferManagerStats()`](#getwritebuffermanagerstats-writebuffermanagerstats)
 carries the same values plus its column-family inventory). Both sets are present regardless of
 whether statistics are enabled and can be fetched individually with `db.getStat()`. For detailed, per-log statistics —
 including memory-map usage — use [`log.getStats()`](#loggetstats-transactionlogstats). All stat

--- a/binding.gyp
+++ b/binding.gyp
@@ -59,6 +59,7 @@
 				'src/binding/core/platform.cpp',
 				'src/binding/core/file_lock.cpp',
 				'src/binding/core/verification_table.cpp',
+				'src/binding/core/wbm_stall_watchdog.cpp',
 				'src/binding/napi/background_error.cpp',
 				'src/binding/napi/event_emitter.cpp',
 				'src/binding/napi/global_events.cpp',
@@ -237,6 +238,7 @@
 				'src/binding/core/platform.cpp',
 				'src/binding/core/file_lock.cpp',
 				'src/binding/core/verification_table.cpp',
+				'src/binding/core/wbm_stall_watchdog.cpp',
 				'src/binding/database/backup_disk_space.cpp',
 				'src/binding/transaction_log/transaction_log_file.cpp',
 				'src/binding/transaction_log/transaction_log_recovery.cpp',
@@ -261,6 +263,7 @@
 				'test/native/transaction_log_validation_test.cc',
 				'test/native/transaction_log_writev_test.cc',
 				'test/native/verification_table_test.cc',
+				'test/native/wbm_stall_watchdog_test.cc',
 				'test/native/write_stall_debounce_test.cc',
 			],
 			'defines': [

--- a/binding.gyp
+++ b/binding.gyp
@@ -74,6 +74,7 @@
 				'src/binding/database/db_descriptor.cpp',
 				'src/binding/database/db_handle.cpp',
 				'src/binding/database/db_registry.cpp',
+				'src/binding/database/db_stats.cpp',
 				'src/binding/database/db_settings.cpp',
 				'src/binding/iterator/db_iterator.cpp',
 				'src/binding/iterator/db_iterator_handle.cpp',

--- a/docs/stats.md
+++ b/docs/stats.md
@@ -74,6 +74,29 @@ By default, `db.getStats()` returns properties only.
 | `txnlog.transactionsWritten`                | Cumulative number of transactions successfully written to the logs (lifetime total), summed across all logs.                                                                                                                  | ticker |
 | `txnlog.uncommittedTransactions`            | Number of transactions written to a log but not yet committed to RocksDB, summed across all logs.                                                                                                                             | gauge  |
 
+| `writeBufferManager.bufferSize` | The `WriteBufferManager`'s memtable-memory budget in bytes, read live. `0` when no manager is configured. **Process-wide**, not per-database — see below. | gauge |
+| `writeBufferManager.memoryUsage` | Total memtable memory in bytes charged against the manager. **Process-wide.** | gauge |
+| `writeBufferManager.mutableMemoryUsage` | The share of `writeBufferManager.memoryUsage` held by active (mutable) memtables; the rest is awaiting flush or retained write history. **Process-wide.** | gauge |
+| `writeBufferManager.stallActive` | `1` while the manager is stalling writes, else `0`. **Process-wide.** | gauge |
+| `writeBufferManager.stallActiveMs` | How long the current stall has been active, in milliseconds; `0` when not stalled. Sampled once a second by the stall watchdog. **Process-wide.** | gauge |
+
+#### The `writeBufferManager.*` keys are process-wide
+
+The `WriteBufferManager` is a **singleton shared by every database opened in this process**,
+`worker_threads` included. These five keys therefore describe the whole process no matter which
+database's `getStats()` returned them — two databases in one process always report identical
+values, and the numbers do not attribute memory to the database you asked. They appear regardless
+of `enableStats`, like the `txnlog.*` and `commitPipeline.*` keys.
+`RocksDatabase.getWriteBufferManagerStats()` returns the same values plus the manager's
+configuration and its live column-family inventory.
+
+`writeBufferManager.stallActive` is the only signal that distinguishes a `WriteBufferManager`
+stall from an idle database. RocksDB's own stall accounting does not cover it:
+`rocksdb.stall.micros`, `rocksdb.db.write.stall` and the `'writeStall'` event all track the
+`WriteController` (L0 and pending-compaction triggers), while a `WriteBufferManager` stall blocks
+writers on a separate queue and touches none of them. Through an eight-hour production wedge all
+three read `0` (HarperFast/rocksdb-js#822).
+
 ### Basic + Curated Stats
 
 If `enableStats` is `true` when the database was opened, then `db.getStats()`
@@ -432,6 +455,27 @@ which includes all of the stats above plus the following:
 | `rocksdb.write.raw.block.micros`                                   | Distribution of raw block write latencies (microseconds).                                                                                     | histogram |
 | `rocksdb.write.self`                                               | Number of writes processed by the calling thread itself (as the write group leader).                                                          | ticker    |
 | `rocksdb.write.wal`                                                | Number of writes that were written to the WAL.                                                                                                | ticker    |
+
+#### `flush.reason.*` vs `atomic_flush.request.reason.*`
+
+This library always opens databases with RocksDB's `atomic_flush`. That does **not** move
+`WriteBufferManager`-pressure flushes off `rocksdb.flush.reason.write_buffer_manager` and onto
+`rocksdb.atomic_flush.request.reason.write_buffer_manager` — measured on this library, both counters
+move together (HarperFast/rocksdb-js#822).
+
+They count different events, though, and neither magnitude can be derived from the other:
+
+- `rocksdb.atomic_flush.request.reason.<reason>` counts flush **requests** — scheduling decisions.
+- `rocksdb.flush.reason.<reason>` counts the flushes that actually **ran**.
+
+Measured ratios in one process ranged from 1:1 (a single column family) to about 1:2 (two to six
+column families), and requests can outnumber executed flushes when several databases share one
+manager. Treat them as two views of the same pressure, not as a fixed multiple.
+
+Neither counter reports a stall. A `0` on both during a `WriteBufferManager` stall is the expected
+reading, not a broken counter: the flush trigger looks only at _mutable_ memory, so a budget held by
+retained history or by memtables already awaiting flush never requests a flush at all.
+`writeBufferManager.stallActive` is what distinguishes that state from an idle database.
 
 ## Transaction Log Stats
 

--- a/docs/stats.md
+++ b/docs/stats.md
@@ -73,12 +73,11 @@ By default, `db.getStats()` returns properties only.
 | `txnlog.totalSizeBytes`                     | Total on-disk size in bytes of all transaction log files, summed across all logs.                                                                                                                                             | gauge  |
 | `txnlog.transactionsWritten`                | Cumulative number of transactions successfully written to the logs (lifetime total), summed across all logs.                                                                                                                  | ticker |
 | `txnlog.uncommittedTransactions`            | Number of transactions written to a log but not yet committed to RocksDB, summed across all logs.                                                                                                                             | gauge  |
-
-| `writeBufferManager.bufferSize` | The `WriteBufferManager`'s memtable-memory budget in bytes, read live. `0` when no manager is configured. **Process-wide**, not per-database — see below. | gauge |
-| `writeBufferManager.memoryUsage` | Total memtable memory in bytes charged against the manager. **Process-wide.** | gauge |
-| `writeBufferManager.mutableMemoryUsage` | The share of `writeBufferManager.memoryUsage` held by active (mutable) memtables; the rest is awaiting flush or retained write history. **Process-wide.** | gauge |
-| `writeBufferManager.stallActive` | `1` while the manager is stalling writes, else `0`. **Process-wide.** | gauge |
-| `writeBufferManager.stallActiveMs` | How long the current stall has been active, in milliseconds; `0` when not stalled. Sampled once a second by the stall watchdog. **Process-wide.** | gauge |
+| `writeBufferManager.bufferSize`             | The `WriteBufferManager`'s memtable-memory budget in bytes, read live. `0` when no manager is configured. **Process-wide**, not per-database — see below.                                                                     | gauge  |
+| `writeBufferManager.memoryUsage`            | Total memtable memory in bytes charged against the manager. **Process-wide.**                                                                                                                                                 | gauge  |
+| `writeBufferManager.mutableMemoryUsage`     | The share of `writeBufferManager.memoryUsage` held by active (mutable) memtables; the rest is awaiting flush or retained write history. **Process-wide.**                                                                     | gauge  |
+| `writeBufferManager.stallActive`            | `1` while the manager is stalling writes, else `0`. **Process-wide.**                                                                                                                                                         | gauge  |
+| `writeBufferManager.stallActiveMs`          | How long the current stall has been active, in milliseconds; `0` when not stalled. Sampled once a second by the stall watchdog. **Process-wide.**                                                                             | gauge  |
 
 #### The `writeBufferManager.*` keys are process-wide
 

--- a/docs/stats.md
+++ b/docs/stats.md
@@ -86,7 +86,7 @@ The `WriteBufferManager` is a **singleton shared by every database opened in thi
 database's `getStats()` returned them — two databases in one process always report identical
 values, and the numbers do not attribute memory to the database you asked. They appear regardless
 of `enableStats`, like the `txnlog.*` and `commitPipeline.*` keys.
-`RocksDatabase.getWriteBufferManagerStats()` returns the same values plus the manager's
+`getWriteBufferManagerStats()` returns the same values plus the manager's
 configuration and its live column-family inventory.
 
 `writeBufferManager.stallActive` is the only signal that distinguishes a `WriteBufferManager`

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "bench": "cross-env CI=1 node --expose-gc ./node_modules/vitest/vitest.mjs bench --passWithNoTests --outputJson benchmark-results.json",
     "bench:bun": "cross-env CI=1 bun --bun bench",
     "bench:deno": "cross-env CI=1 deno run --allow-all --sloppy-imports ./node_modules/vitest/vitest.mjs bench",
-    "build": "pnpm build:bundle && pnpm rebuild",
+    "build": "pnpm build:bundle && pnpm run rebuild",
     "build:binding": "node-gyp build",
     "build:binding:debug": "node-gyp build --coverage --debug --verbose",
     "build:bundle": "node scripts/clean-dist.mjs && tsdown -c tsdown.config.ts",

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
   "engines": {
     "node": "^22.18.0 || >=24.0.0"
   },
+  "packageManager": "pnpm@11.25.0",
   "gypfile": true,
   "rocksdb": {
     "version": "11.8.1"

--- a/src/binding/binding.cpp
+++ b/src/binding/binding.cpp
@@ -39,8 +39,14 @@ namespace rocksdb_js {
  * Shutdown function to ensure that we write in-memory data from all databases.
  */
 napi_value Shutdown(napi_env env, napi_callback_info info) {
+	// Ask the WriteBufferManager stall watchdog to stop, but join it only after
+	// the databases have been shut down: its warn line goes to stderr, which can
+	// block on a full pipe, and a logging stall must never sit in front of the
+	// flush path.
+	DBSettings::getInstance().requestWriteBufferManagerWatchdogStop();
 	GlobalEvents::Shutdown();
 	DBRegistry::Shutdown();
+	DBSettings::getInstance().joinWriteBufferManagerWatchdog();
 	napi_value result;
 	NAPI_STATUS_THROWS(::napi_get_undefined(env, &result));
 	return result;
@@ -216,9 +222,13 @@ NAPI_MODULE_INIT() {
 		int32_t newRefCount = --moduleRefCount;
 		if (newRefCount == 0) {
 			DEBUG_LOG("Binding::Init Cleaning up last instance, shutting down all databases\n");
+			// Same split as the shutdown() export: request the stall watchdog's
+			// stop up front, join it only after the flush path has run.
+			rocksdb_js::DBSettings::getInstance().requestWriteBufferManagerWatchdogStop();
 			rocksdb_js::GlobalEvents::Shutdown();
 			rocksdb_js::TransactionLogStoreRegistry::Shutdown();
 			rocksdb_js::DBRegistry::Shutdown();
+			rocksdb_js::DBSettings::getInstance().joinWriteBufferManagerWatchdog();
 			DEBUG_LOG("Binding::Init env cleanup done\n");
 		} else if (newRefCount < 0) {
 			DEBUG_LOG("Binding::Init WARNING: Module ref count went negative!\n");

--- a/src/binding/binding.cpp
+++ b/src/binding/binding.cpp
@@ -43,7 +43,9 @@ napi_value Shutdown(napi_env env, napi_callback_info info) {
 	DBStats::getInstance().requestWriteBufferManagerWatchdogStop();
 	GlobalEvents::Shutdown();
 	DBRegistry::Shutdown();
-	DBStats::getInstance().joinWriteBufferManagerWatchdog();
+	// This JS-callable shutdown() documents that databases may reopen
+	// afterward, so replay an ensure() that raced the stop above.
+	DBStats::getInstance().joinWriteBufferManagerWatchdog(true);
 	napi_value result;
 	NAPI_STATUS_THROWS(::napi_get_undefined(env, &result));
 	return result;
@@ -223,7 +225,10 @@ NAPI_MODULE_INIT() {
 			rocksdb_js::GlobalEvents::Shutdown();
 			rocksdb_js::TransactionLogStoreRegistry::Shutdown();
 			rocksdb_js::DBRegistry::Shutdown();
-			rocksdb_js::DBStats::getInstance().joinWriteBufferManagerWatchdog();
+			// Unlike the JS-callable shutdown() above, this path cannot tell
+			// "last env, may reopen" from "process is ending" — never spawn a
+			// replacement thread that this path won't join again.
+			rocksdb_js::DBStats::getInstance().joinWriteBufferManagerWatchdog(false);
 			DEBUG_LOG("Binding::Init env cleanup done\n");
 		} else if (newRefCount < 0) {
 			DEBUG_LOG("Binding::Init WARNING: Module ref count went negative!\n");

--- a/src/binding/binding.cpp
+++ b/src/binding/binding.cpp
@@ -1,6 +1,7 @@
 #include "napi/binding.h"
 #include "database/backup.h"
 #include "database/database.h"
+#include "database/db_stats.h"
 #include "iterator/db_iterator.h"
 #include "iterator/db_iterator_handle.h"
 #include "database/db_registry.h"
@@ -43,10 +44,10 @@ napi_value Shutdown(napi_env env, napi_callback_info info) {
 	// the databases have been shut down: its warn line goes to stderr, which can
 	// block on a full pipe, and a logging stall must never sit in front of the
 	// flush path.
-	DBSettings::getInstance().requestWriteBufferManagerWatchdogStop();
+	DBStats::getInstance().requestWriteBufferManagerWatchdogStop();
 	GlobalEvents::Shutdown();
 	DBRegistry::Shutdown();
-	DBSettings::getInstance().joinWriteBufferManagerWatchdog();
+	DBStats::getInstance().joinWriteBufferManagerWatchdog();
 	napi_value result;
 	NAPI_STATUS_THROWS(::napi_get_undefined(env, &result));
 	return result;
@@ -224,11 +225,11 @@ NAPI_MODULE_INIT() {
 			DEBUG_LOG("Binding::Init Cleaning up last instance, shutting down all databases\n");
 			// Same split as the shutdown() export: request the stall watchdog's
 			// stop up front, join it only after the flush path has run.
-			rocksdb_js::DBSettings::getInstance().requestWriteBufferManagerWatchdogStop();
+			rocksdb_js::DBStats::getInstance().requestWriteBufferManagerWatchdogStop();
 			rocksdb_js::GlobalEvents::Shutdown();
 			rocksdb_js::TransactionLogStoreRegistry::Shutdown();
 			rocksdb_js::DBRegistry::Shutdown();
-			rocksdb_js::DBSettings::getInstance().joinWriteBufferManagerWatchdog();
+			rocksdb_js::DBStats::getInstance().joinWriteBufferManagerWatchdog();
 			DEBUG_LOG("Binding::Init env cleanup done\n");
 		} else if (newRefCount < 0) {
 			DEBUG_LOG("Binding::Init WARNING: Module ref count went negative!\n");
@@ -261,6 +262,7 @@ NAPI_MODULE_INIT() {
 
 	// db settings
 	rocksdb_js::DBSettings::Init(env, exports);
+	rocksdb_js::DBStats::Init(env, exports);
 
 	// global event emitter (addListener / removeListener / listenerCount)
 	rocksdb_js::GlobalEvents::Init(env, exports);

--- a/src/binding/binding.cpp
+++ b/src/binding/binding.cpp
@@ -40,10 +40,8 @@ namespace rocksdb_js {
  * Shutdown function to ensure that we write in-memory data from all databases.
  */
 napi_value Shutdown(napi_env env, napi_callback_info info) {
-	// Ask the WriteBufferManager stall watchdog to stop, but join it only after
-	// the databases have been shut down: its warn line goes to stderr, which can
-	// block on a full pipe, and a logging stall must never sit in front of the
-	// flush path.
+	// Stop before the flush, join after: the warn line's stderr write is unbounded
+	// on a full pipe and must not sit in front of durability.
 	DBStats::getInstance().requestWriteBufferManagerWatchdogStop();
 	GlobalEvents::Shutdown();
 	DBRegistry::Shutdown();

--- a/src/binding/binding.cpp
+++ b/src/binding/binding.cpp
@@ -40,8 +40,6 @@ namespace rocksdb_js {
  * Shutdown function to ensure that we write in-memory data from all databases.
  */
 napi_value Shutdown(napi_env env, napi_callback_info info) {
-	// Stop before the flush, join after: the warn line's stderr write is unbounded
-	// on a full pipe and must not sit in front of durability.
 	DBStats::getInstance().requestWriteBufferManagerWatchdogStop();
 	GlobalEvents::Shutdown();
 	DBRegistry::Shutdown();

--- a/src/binding/binding.cpp
+++ b/src/binding/binding.cpp
@@ -22,7 +22,10 @@
 #include "core/test_seam.h"
 #include "napi/helpers.h"
 #include "napi/async.h"
+#include <algorithm>
 #include <atomic>
+#include <chrono>
+#include <thread>
 
 namespace rocksdb_js {
 
@@ -40,12 +43,14 @@ namespace rocksdb_js {
  * Shutdown function to ensure that we write in-memory data from all databases.
  */
 napi_value Shutdown(napi_env env, napi_callback_info info) {
-	DBStats::getInstance().requestWriteBufferManagerWatchdogStop();
+	auto& stats = DBStats::getInstance();
+	const uint64_t watchdogShutdownGeneration = stats.beginWriteBufferManagerWatchdogShutdown();
 	GlobalEvents::Shutdown();
 	DBRegistry::Shutdown();
-	// This JS-callable shutdown() documents that databases may reopen
-	// afterward, so replay an ensure() that raced the stop above.
-	DBStats::getInstance().joinWriteBufferManagerWatchdog(true);
+	if (const int delayMs = consumeWriteBufferManagerJoinDelayForTesting(); delayMs > 0) {
+		std::this_thread::sleep_for(std::chrono::milliseconds(delayMs));
+	}
+	stats.joinWriteBufferManagerWatchdog(true, watchdogShutdownGeneration);
 	napi_value result;
 	NAPI_STATUS_THROWS(::napi_get_undefined(env, &result));
 	return result;
@@ -64,6 +69,16 @@ napi_value ForceTryAgainForTesting(napi_env env, napi_callback_info info) {
 	napi_value result;
 	NAPI_STATUS_THROWS(::napi_get_undefined(env, &result));
 	return result;
+}
+
+napi_value SetWriteBufferManagerJoinDelayForTesting(napi_env env, napi_callback_info info) {
+	NAPI_METHOD_ARGV(2);
+	int32_t countdown = 0;
+	int32_t delayMs = 0;
+	NAPI_STATUS_THROWS(::napi_get_value_int32(env, argv[0], &countdown));
+	NAPI_STATUS_THROWS(::napi_get_value_int32(env, argv[1], &delayMs));
+	setWriteBufferManagerJoinDelayForTesting(std::max(countdown, 0), std::max(delayMs, 0));
+	NAPI_RETURN_UNDEFINED();
 }
 
 /**
@@ -221,14 +236,12 @@ NAPI_MODULE_INIT() {
 		int32_t newRefCount = --moduleRefCount;
 		if (newRefCount == 0) {
 			DEBUG_LOG("Binding::Init Cleaning up last instance, shutting down all databases\n");
-			rocksdb_js::DBStats::getInstance().requestWriteBufferManagerWatchdogStop();
+			auto& stats = rocksdb_js::DBStats::getInstance();
+			const uint64_t watchdogShutdownGeneration = stats.beginWriteBufferManagerWatchdogShutdown();
 			rocksdb_js::GlobalEvents::Shutdown();
 			rocksdb_js::TransactionLogStoreRegistry::Shutdown();
 			rocksdb_js::DBRegistry::Shutdown();
-			// Unlike the JS-callable shutdown() above, this path cannot tell
-			// "last env, may reopen" from "process is ending" — never spawn a
-			// replacement thread that this path won't join again.
-			rocksdb_js::DBStats::getInstance().joinWriteBufferManagerWatchdog(false);
+			stats.joinWriteBufferManagerWatchdog(false, watchdogShutdownGeneration);
 			DEBUG_LOG("Binding::Init env cleanup done\n");
 		} else if (newRefCount < 0) {
 			DEBUG_LOG("Binding::Init WARNING: Module ref count went negative!\n");
@@ -275,6 +288,22 @@ NAPI_MODULE_INIT() {
 	napi_value forceTryAgainFn;
 	NAPI_STATUS_THROWS(::napi_create_function(env, "forceTryAgainForTesting", NAPI_AUTO_LENGTH, ForceTryAgainForTesting, nullptr, &forceTryAgainFn));
 	NAPI_STATUS_THROWS(::napi_set_named_property(env, exports, "forceTryAgainForTesting", forceTryAgainFn));
+
+	napi_value setWriteBufferManagerJoinDelayFn;
+	NAPI_STATUS_THROWS(::napi_create_function(
+		env,
+		"setWriteBufferManagerJoinDelayForTesting",
+		NAPI_AUTO_LENGTH,
+		SetWriteBufferManagerJoinDelayForTesting,
+		nullptr,
+		&setWriteBufferManagerJoinDelayFn
+	));
+	NAPI_STATUS_THROWS(::napi_set_named_property(
+		env,
+		exports,
+		"setWriteBufferManagerJoinDelayForTesting",
+		setWriteBufferManagerJoinDelayFn
+	));
 
 	// currentThreadId function
 	napi_value currentThreadIdFn;

--- a/src/binding/binding.cpp
+++ b/src/binding/binding.cpp
@@ -223,8 +223,6 @@ NAPI_MODULE_INIT() {
 		int32_t newRefCount = --moduleRefCount;
 		if (newRefCount == 0) {
 			DEBUG_LOG("Binding::Init Cleaning up last instance, shutting down all databases\n");
-			// Same split as the shutdown() export: request the stall watchdog's
-			// stop up front, join it only after the flush path has run.
 			rocksdb_js::DBStats::getInstance().requestWriteBufferManagerWatchdogStop();
 			rocksdb_js::GlobalEvents::Shutdown();
 			rocksdb_js::TransactionLogStoreRegistry::Shutdown();

--- a/src/binding/core/test_seam.h
+++ b/src/binding/core/test_seam.h
@@ -42,4 +42,31 @@ inline bool testForceTryAgain() {
 	return false;
 }
 
+inline std::atomic<int>& writeBufferManagerJoinDelayCountdown() {
+	static std::atomic<int> countdown{0};
+	return countdown;
+}
+
+inline std::atomic<int>& writeBufferManagerJoinDelayMs() {
+	static std::atomic<int> delayMs{0};
+	return delayMs;
+}
+
+inline void setWriteBufferManagerJoinDelayForTesting(int countdown, int delayMs) {
+	writeBufferManagerJoinDelayMs().store(delayMs, std::memory_order_relaxed);
+	writeBufferManagerJoinDelayCountdown().store(countdown, std::memory_order_release);
+}
+
+inline int consumeWriteBufferManagerJoinDelayForTesting() {
+	int remaining = writeBufferManagerJoinDelayCountdown().load(std::memory_order_acquire);
+	while (remaining > 0) {
+		if (writeBufferManagerJoinDelayCountdown().compare_exchange_weak(
+				remaining, remaining - 1, std::memory_order_relaxed
+			)) {
+			return remaining == 1 ? writeBufferManagerJoinDelayMs().load(std::memory_order_relaxed) : 0;
+		}
+	}
+	return 0;
+}
+
 #endif

--- a/src/binding/core/wbm_stall_watchdog.cpp
+++ b/src/binding/core/wbm_stall_watchdog.cpp
@@ -35,7 +35,10 @@ void appendPercentOfBudget(std::ostringstream& out, uint64_t part, uint64_t budg
 
 } // namespace
 
-uint64_t resolveWbmStallWarnMs(const char* raw) {
+uint64_t resolveWbmStallWarnMs(const char* raw, bool* rejected) {
+	if (rejected != nullptr) {
+		*rejected = false;
+	}
 	if (raw == nullptr || *raw == '\0') {
 		return WBM_STALL_WARN_MS_DEFAULT;
 	}
@@ -44,6 +47,9 @@ uint64_t resolveWbmStallWarnMs(const char* raw) {
 	long long parsed = ::strtoll(raw, &end, 10);
 	if (errno != 0 || end == raw || *end != '\0' || parsed < 0 ||
 		static_cast<unsigned long long>(parsed) > WBM_STALL_WARN_MS_MAX) {
+		if (rejected != nullptr) {
+			*rejected = true;
+		}
 		return WBM_STALL_WARN_MS_DEFAULT;
 	}
 	uint64_t value = static_cast<uint64_t>(parsed);
@@ -70,8 +76,12 @@ std::string formatWriteBufferManagerStallReport(const WriteBufferManagerStallRep
 	appendBytes(out, report.mutableMemoryUsage);
 	appendPercentOfBudget(out, report.mutableMemoryUsage, report.bufferSize);
 	out << " allowStall=" << (report.allowStall ? "true" : "false")
-		<< " costToCache=" << (report.costToCache ? "true" : "false")
-		<< " columnFamilies=" << report.columnFamilies << " maxWriteBufferSizeToMaintain={";
+		<< " costToCache=" << (report.costToCache ? "true" : "false");
+	if (!report.inventoryAvailable) {
+		out << " columnFamilies=unavailable maxWriteBufferSizeToMaintain=unavailable";
+		return out.str();
+	}
+	out << " columnFamilies=" << report.columnFamilies << " maxWriteBufferSizeToMaintain={";
 	bool first = true;
 	for (const auto& [target, count] : report.maxWriteBufferSizeToMaintain) {
 		if (!first) {

--- a/src/binding/core/wbm_stall_watchdog.cpp
+++ b/src/binding/core/wbm_stall_watchdog.cpp
@@ -1,0 +1,87 @@
+#include "core/wbm_stall_watchdog.h"
+#include <cerrno>
+#include <cstdlib>
+#include <sstream>
+
+namespace rocksdb_js {
+
+namespace {
+
+void appendBytes(std::ostringstream& out, uint64_t bytes) {
+	static constexpr const char* units[] = { "B", "KB", "MB", "GB", "TB" };
+	double value = static_cast<double>(bytes);
+	size_t unit = 0;
+	while (value >= 1024.0 && unit + 1 < sizeof(units) / sizeof(units[0])) {
+		value /= 1024.0;
+		unit++;
+	}
+	std::ostringstream formatted;
+	formatted.setf(std::ios::fixed);
+	formatted.precision(unit == 0 ? 0 : 1);
+	formatted << value;
+	out << formatted.str() << units[unit];
+}
+
+void appendPercentOfBudget(std::ostringstream& out, uint64_t part, uint64_t budget) {
+	if (budget == 0) {
+		return;
+	}
+	std::ostringstream formatted;
+	formatted.setf(std::ios::fixed);
+	formatted.precision(1);
+	formatted << (static_cast<double>(part) * 100.0 / static_cast<double>(budget));
+	out << " (" << formatted.str() << "%)";
+}
+
+} // namespace
+
+uint64_t resolveWbmStallWarnMs(const char* raw) {
+	if (raw == nullptr || *raw == '\0') {
+		return WBM_STALL_WARN_MS_DEFAULT;
+	}
+	errno = 0;
+	char* end = nullptr;
+	long long parsed = ::strtoll(raw, &end, 10);
+	if (errno != 0 || end == raw || *end != '\0' || parsed < 0 ||
+		static_cast<unsigned long long>(parsed) > WBM_STALL_WARN_MS_MAX) {
+		return WBM_STALL_WARN_MS_DEFAULT;
+	}
+	uint64_t value = static_cast<uint64_t>(parsed);
+	if (value == 0) {
+		return 0;
+	}
+	return value < WBM_STALL_SAMPLE_INTERVAL_MS ? WBM_STALL_SAMPLE_INTERVAL_MS : value;
+}
+
+std::string formatWriteBufferManagerStallReport(const WriteBufferManagerStallReport& report) {
+	std::ostringstream out;
+	std::ostringstream seconds;
+	seconds.setf(std::ios::fixed);
+	seconds.precision(1);
+	seconds << (static_cast<double>(report.stallActiveMs) / 1000.0);
+
+	out << "[rocksdb-js] WriteBufferManager write stall active for " << seconds.str()
+		<< "s - no write can complete until memtable memory drops below the budget. budget=";
+	appendBytes(out, report.bufferSize);
+	out << " usage=";
+	appendBytes(out, report.memoryUsage);
+	appendPercentOfBudget(out, report.memoryUsage, report.bufferSize);
+	out << " mutable=";
+	appendBytes(out, report.mutableMemoryUsage);
+	appendPercentOfBudget(out, report.mutableMemoryUsage, report.bufferSize);
+	out << " allowStall=" << (report.allowStall ? "true" : "false")
+		<< " costToCache=" << (report.costToCache ? "true" : "false")
+		<< " columnFamilies=" << report.columnFamilies << " maxWriteBufferSizeToMaintain={";
+	bool first = true;
+	for (const auto& [target, count] : report.maxWriteBufferSizeToMaintain) {
+		if (!first) {
+			out << ',';
+		}
+		first = false;
+		out << target << ':' << count;
+	}
+	out << '}';
+	return out.str();
+}
+
+} // namespace rocksdb_js

--- a/src/binding/core/wbm_stall_watchdog.h
+++ b/src/binding/core/wbm_stall_watchdog.h
@@ -14,7 +14,6 @@ namespace rocksdb_js {
  */
 constexpr uint64_t WBM_STALL_SAMPLE_INTERVAL_MS = 1000;
 
-/** Default for `ROCKSDB_JS_WBM_STALL_WARN_MS`. */
 constexpr uint64_t WBM_STALL_WARN_MS_DEFAULT = 5000;
 
 /**
@@ -28,9 +27,10 @@ constexpr uint64_t WBM_STALL_WARN_MS_MAX = 24 * 60 * 60 * 1000;
  * Parses `ROCKSDB_JS_WBM_STALL_WARN_MS`. `0` disables the watchdog; anything
  * below one sample interval clamps up to it (a threshold the sampler cannot
  * resolve is a lie); malformed, negative, or out-of-range falls back to the
- * default.
+ * default. Falling back rather than clamping errs toward alarming earlier than
+ * asked, never later — but silently, so `rejected` reports it for a diagnostic.
  */
-uint64_t resolveWbmStallWarnMs(const char* raw);
+uint64_t resolveWbmStallWarnMs(const char* raw, bool* rejected = nullptr);
 
 /**
  * Decision state for the WriteBufferManager stall watchdog. Node-free and
@@ -104,6 +104,13 @@ struct WriteBufferManagerStallReport final {
 	uint64_t columnFamilies = 0;
 	/** Effective `max_write_buffer_size_to_maintain` -> number of column families with it. */
 	std::map<int64_t, uint64_t> maxWriteBufferSizeToMaintain;
+	/**
+	 * False when the registry was locked by a close that is itself wedged on this
+	 * stall, so the two fields above are empty rather than measured. The line is
+	 * still emitted: an alarm that waits for the inventory would go silent in
+	 * exactly the incident it exists for.
+	 */
+	bool inventoryAvailable = true;
 };
 
 std::string formatWriteBufferManagerStallReport(const WriteBufferManagerStallReport& report);

--- a/src/binding/core/wbm_stall_watchdog.h
+++ b/src/binding/core/wbm_stall_watchdog.h
@@ -1,0 +1,113 @@
+#ifndef __CORE_WBM_STALL_WATCHDOG_H__
+#define __CORE_WBM_STALL_WATCHDOG_H__
+
+#include <chrono>
+#include <cstdint>
+#include <map>
+#include <string>
+
+namespace rocksdb_js {
+
+/**
+ * Sampling cadence of the WriteBufferManager stall watchdog, and therefore the
+ * resolution of every duration it reports.
+ */
+constexpr uint64_t WBM_STALL_SAMPLE_INTERVAL_MS = 1000;
+
+/** Default for `ROCKSDB_JS_WBM_STALL_WARN_MS`. */
+constexpr uint64_t WBM_STALL_WARN_MS_DEFAULT = 5000;
+
+/**
+ * Upper bound for `ROCKSDB_JS_WBM_STALL_WARN_MS`. A value past this is treated as
+ * malformed rather than clamped: a threshold longer than a day is never what a
+ * caller meant, and accepting one silently disables the alarm.
+ */
+constexpr uint64_t WBM_STALL_WARN_MS_MAX = 24 * 60 * 60 * 1000;
+
+/**
+ * Parses `ROCKSDB_JS_WBM_STALL_WARN_MS`. `0` disables the watchdog; anything
+ * below one sample interval clamps up to it (a threshold the sampler cannot
+ * resolve is a lie); malformed, negative, or out-of-range falls back to the
+ * default.
+ */
+uint64_t resolveWbmStallWarnMs(const char* raw);
+
+/**
+ * Decision state for the WriteBufferManager stall watchdog. Node-free and
+ * RocksDB-free so it is unit-testable without threads (see
+ * test/native/wbm_stall_watchdog_test.cc).
+ *
+ * A WriteBufferManager stall exposes no edge callback — `IsStallActive()` is all
+ * there is — so this is driven by a poll. It collapses that poll into one report
+ * per episode: a stall must be *continuously* active past the threshold, which is
+ * what bounds a flapping stall. There is deliberately no second rate-limit window
+ * on top; a window would suppress the first report of a genuinely new episode,
+ * which is the one report that matters.
+ *
+ * `markReported()` is separate from `onSample()` so the caller only retires the
+ * episode once the line has actually been written — a failed write leaves the
+ * next sample free to retry.
+ */
+class WbmStallWatchdogState final {
+public:
+	using Clock = std::chrono::steady_clock;
+
+	struct Sample {
+		/** The threshold was crossed and this episode has not been reported yet. */
+		bool reportNow = false;
+		/** How long the current stall has been active; 0 when not stalled. */
+		uint64_t stallActiveMs = 0;
+	};
+
+	Sample onSample(bool stallActive, Clock::time_point now, uint64_t thresholdMs) {
+		Sample sample;
+		if (!stallActive) {
+			this->active = false;
+			this->reported = false;
+			return sample;
+		}
+		if (!this->active) {
+			this->active = true;
+			this->reported = false;
+			this->startedAt = now;
+			return sample;
+		}
+		auto elapsed =
+			std::chrono::duration_cast<std::chrono::milliseconds>(now - this->startedAt).count();
+		sample.stallActiveMs = elapsed < 0 ? 0 : static_cast<uint64_t>(elapsed);
+		sample.reportNow =
+			thresholdMs != 0 && !this->reported && sample.stallActiveMs >= thresholdMs;
+		return sample;
+	}
+
+	void markReported() {
+		this->reported = true;
+	}
+
+private:
+	bool active = false;
+	bool reported = false;
+	Clock::time_point startedAt{};
+};
+
+/**
+ * Everything the warn line carries. Aggregate numbers only — no paths, keys,
+ * values or column-family names.
+ */
+struct WriteBufferManagerStallReport final {
+	uint64_t stallActiveMs = 0;
+	uint64_t bufferSize = 0;
+	uint64_t memoryUsage = 0;
+	uint64_t mutableMemoryUsage = 0;
+	bool allowStall = false;
+	bool costToCache = false;
+	uint64_t columnFamilies = 0;
+	/** Effective `max_write_buffer_size_to_maintain` -> number of column families with it. */
+	std::map<int64_t, uint64_t> maxWriteBufferSizeToMaintain;
+};
+
+std::string formatWriteBufferManagerStallReport(const WriteBufferManagerStallReport& report);
+
+} // namespace rocksdb_js
+
+#endif

--- a/src/binding/core/wbm_stall_watchdog.h
+++ b/src/binding/core/wbm_stall_watchdog.h
@@ -53,9 +53,8 @@ public:
 	using Clock = std::chrono::steady_clock;
 
 	struct Sample {
-		/** The threshold was crossed and this episode has not been reported yet. */
 		bool reportNow = false;
-		/** How long the current stall has been active; 0 when not stalled. */
+		/** 0 when not stalled, and for the first sample of a stall. */
 		uint64_t stallActiveMs = 0;
 	};
 

--- a/src/binding/core/wbm_stall_watchdog.h
+++ b/src/binding/core/wbm_stall_watchdog.h
@@ -34,8 +34,7 @@ uint64_t resolveWbmStallWarnMs(const char* raw, bool* rejected = nullptr);
 
 /**
  * Decision state for the WriteBufferManager stall watchdog. Node-free and
- * RocksDB-free so it is unit-testable without threads (see
- * test/native/wbm_stall_watchdog_test.cc).
+ * RocksDB-free so it can be exercised without threads.
  *
  * A WriteBufferManager stall exposes no edge callback — `IsStallActive()` is all
  * there is — so this is driven by a poll. It collapses that poll into one report

--- a/src/binding/core/wbm_stall_watchdog.h
+++ b/src/binding/core/wbm_stall_watchdog.h
@@ -104,10 +104,9 @@ struct WriteBufferManagerStallReport final {
 	/** Effective `max_write_buffer_size_to_maintain` -> number of column families with it. */
 	std::map<int64_t, uint64_t> maxWriteBufferSizeToMaintain;
 	/**
-	 * False when the registry was locked by a close that is itself wedged on this
-	 * stall, so the two fields above are empty rather than measured. The line is
-	 * still emitted: an alarm that waits for the inventory would go silent in
-	 * exactly the incident it exists for.
+	 * False when registry or column-family inventory locks are busy, so the two
+	 * fields above are empty rather than measured. The alarm must not wait for
+	 * database work that may itself be stalled.
 	 */
 	bool inventoryAvailable = true;
 };

--- a/src/binding/database/backup.cpp
+++ b/src/binding/database/backup.cpp
@@ -57,12 +57,16 @@ struct AsyncBackupState final : BaseAsyncState<std::shared_ptr<DBHandle>> {
 	// Our descriptor ref can be the reason a concurrent close skipped its
 	// registry purge (use_count() > 1), so on release we must retry the purge or
 	// the registry entry — and the open RocksDB — would linger forever.
-	~AsyncBackupState() override {
+	void releaseDescriptor() {
 		if (this->descriptor) {
 			DBKey key = descriptorKey(*this->descriptor);
 			this->descriptor.reset();
 			DBRegistry::PurgeIfUnreferenced(key);
 		}
+	}
+
+	~AsyncBackupState() override {
+		this->releaseDescriptor();
 	}
 };
 
@@ -365,6 +369,10 @@ napi_value Database::Backup(napi_env env, napi_callback_info info) {
 		[](napi_env env, napi_status status, void* data) { // complete
 			auto state = reinterpret_cast<AsyncBackupState*>(data);
 			state->deleteAsyncWork();
+			// Promise settlement is the public completion boundary. Release the
+			// descriptor pin and retry any deferred registry purge first so an
+			// immediate registryStatus() / shutdown() cannot observe stale state.
+			state->releaseDescriptor();
 			if (status != napi_cancelled) {
 				if (state->status.ok()) {
 					napi_value result;

--- a/src/binding/database/db_descriptor.cpp
+++ b/src/binding/database/db_descriptor.cpp
@@ -1652,11 +1652,10 @@ void DBDescriptor::unregisterColumnFamily(const std::string& columnName) {
 	// Retire debounce state so the map stays bounded and a recreated CF of the
 	// same name starts fresh rather than inheriting a stale reported-stalled bit.
 	this->writeStallDebounce.forget(columnName);
-	// Only an attached database reaches the stall inventory, and attachment is
-	// decided once at open, so an unattached one tracks nothing.
+	// Attachment is decided once, at open, so an unattached database never reaches
+	// the stall inventory and tracks nothing.
 	const bool trackForInventory = this->attachedWriteBufferManager != nullptr;
 	if (trackForInventory) {
-		// The only place the list grows, so pruning here bounds it.
 		std::erase_if(this->droppedColumns, [](const DroppedColumnFamily& dropped) {
 			return dropped.descriptor.expired();
 		});

--- a/src/binding/database/db_descriptor.cpp
+++ b/src/binding/database/db_descriptor.cpp
@@ -1652,11 +1652,15 @@ void DBDescriptor::unregisterColumnFamily(const std::string& columnName) {
 	// Retire debounce state so the map stays bounded and a recreated CF of the
 	// same name starts fresh rather than inheriting a stale reported-stalled bit.
 	this->writeStallDebounce.forget(columnName);
-	// Drop families whose last handle has since closed; this is the only place
-	// the list grows, so pruning here bounds it.
-	std::erase_if(this->droppedColumns, [](const DroppedColumnFamily& dropped) {
-		return dropped.descriptor.expired();
-	});
+	// Only an attached database reaches the stall inventory, and attachment is
+	// decided once at open, so an unattached one tracks nothing.
+	const bool trackForInventory = this->attachedWriteBufferManager != nullptr;
+	if (trackForInventory) {
+		// The only place the list grows, so pruning here bounds it.
+		std::erase_if(this->droppedColumns, [](const DroppedColumnFamily& dropped) {
+			return dropped.descriptor.expired();
+		});
+	}
 	auto it = this->columns.find(columnName);
 	if (it == this->columns.end()) {
 		DEBUG_LOG("%p DBDescriptor::unregisterColumnFamily column \"%s\" not found\n",
@@ -1667,12 +1671,7 @@ void DBDescriptor::unregisterColumnFamily(const std::string& columnName) {
 	const int64_t maxWriteBufferSizeToMaintain =
 		it->second ? it->second->maxWriteBufferSizeToMaintain : 0;
 	this->columns.erase(it);
-	// A dropped family keeps charging the WriteBufferManager until its last
-	// handle closes, so keep counting it in the stall inventory until then —
-	// dropping it here would understate the memory a stall report has to
-	// explain, and latching the inventory unavailable would erase that report
-	// for the life of the database.
-	if (!dropped.expired()) {
+	if (trackForInventory && !dropped.expired()) {
 		this->droppedColumns.push_back({ std::move(dropped), maxWriteBufferSizeToMaintain });
 	}
 	DEBUG_LOG("%p DBDescriptor::unregisterColumnFamily unregistered column \"%s\"\n",

--- a/src/binding/database/db_descriptor.cpp
+++ b/src/binding/database/db_descriptor.cpp
@@ -535,8 +535,8 @@ void DBDescriptor::finishClose() {
 	{
 		std::lock_guard<std::mutex> columnsLock(this->columnsMutex);
 		this->columns.clear();
-		// The entry stays in the registry until the purge tail finishes, so stop
-		// reporting this database's dropped families the moment its live ones go.
+		// The registry entry outlives this, so drop both or the inventory keeps
+		// reporting families of a closed database.
 		this->droppedColumns.clear();
 	}
 

--- a/src/binding/database/db_descriptor.cpp
+++ b/src/binding/database/db_descriptor.cpp
@@ -1646,6 +1646,7 @@ uint32_t DBDescriptor::transactionGetNextId() {
  */
 void DBDescriptor::unregisterColumnFamily(const std::string& columnName) {
 	std::lock_guard<std::mutex> lock(this->columnsMutex);
+	this->writeBufferManagerInventoryComplete = false;
 	// Retire debounce state so the map stays bounded and a recreated CF of the
 	// same name starts fresh rather than inheriting a stale reported-stalled bit.
 	this->writeStallDebounce.forget(columnName);

--- a/src/binding/database/db_descriptor.cpp
+++ b/src/binding/database/db_descriptor.cpp
@@ -535,6 +535,9 @@ void DBDescriptor::finishClose() {
 	{
 		std::lock_guard<std::mutex> columnsLock(this->columnsMutex);
 		this->columns.clear();
+		// The entry stays in the registry until the purge tail finishes, so stop
+		// reporting this database's dropped families the moment its live ones go.
+		this->droppedColumns.clear();
 	}
 
 	this->events.releaseAll();
@@ -1646,17 +1649,34 @@ uint32_t DBDescriptor::transactionGetNextId() {
  */
 void DBDescriptor::unregisterColumnFamily(const std::string& columnName) {
 	std::lock_guard<std::mutex> lock(this->columnsMutex);
-	this->writeBufferManagerInventoryComplete = false;
 	// Retire debounce state so the map stays bounded and a recreated CF of the
 	// same name starts fresh rather than inheriting a stale reported-stalled bit.
 	this->writeStallDebounce.forget(columnName);
-	if (this->columns.erase(columnName)) {
-		DEBUG_LOG("%p DBDescriptor::unregisterColumnFamily unregistered column \"%s\"\n",
-			this, columnName.c_str());
-	} else {
+	// Drop families whose last handle has since closed; this is the only place
+	// the list grows, so pruning here bounds it.
+	std::erase_if(this->droppedColumns, [](const DroppedColumnFamily& dropped) {
+		return dropped.descriptor.expired();
+	});
+	auto it = this->columns.find(columnName);
+	if (it == this->columns.end()) {
 		DEBUG_LOG("%p DBDescriptor::unregisterColumnFamily column \"%s\" not found\n",
 			this, columnName.c_str());
+		return;
 	}
+	std::weak_ptr<ColumnFamilyDescriptor> dropped = it->second;
+	const int64_t maxWriteBufferSizeToMaintain =
+		it->second ? it->second->maxWriteBufferSizeToMaintain : 0;
+	this->columns.erase(it);
+	// A dropped family keeps charging the WriteBufferManager until its last
+	// handle closes, so keep counting it in the stall inventory until then —
+	// dropping it here would understate the memory a stall report has to
+	// explain, and latching the inventory unavailable would erase that report
+	// for the life of the database.
+	if (!dropped.expired()) {
+		this->droppedColumns.push_back({ std::move(dropped), maxWriteBufferSizeToMaintain });
+	}
+	DEBUG_LOG("%p DBDescriptor::unregisterColumnFamily unregistered column \"%s\"\n",
+		this, columnName.c_str());
 }
 
 /**

--- a/src/binding/database/db_descriptor.cpp
+++ b/src/binding/database/db_descriptor.cpp
@@ -372,6 +372,7 @@ DBDescriptor::DBDescriptor(
 	const DBOptions& options,
 	const rocksdb::ColumnFamilyOptions& cfOptions,
 	std::shared_ptr<rocksdb::DB> db,
+	rocksdb::WriteBufferManager* attachedWriteBufferManager,
 	std::unordered_map<std::string, std::shared_ptr<ColumnFamilyDescriptor>>&& columns,
 	std::shared_ptr<rocksdb::Statistics> statistics
 ):
@@ -383,6 +384,7 @@ DBDescriptor::DBDescriptor(
 	secondaryPath(options.secondaryPath),
 	cfOptions(cfOptions),
 	db(db),
+	attachedWriteBufferManager(attachedWriteBufferManager),
 	columns(std::move(columns)),
 	statistics(statistics)
 {
@@ -1252,8 +1254,10 @@ std::shared_ptr<DBDescriptor> DBDescriptor::open(
 	// memory is bounded across all DBs in this process. With cost_to_cache,
 	// active memtables share the block cache pool — the cache shrinks during
 	// write bursts and reclaims room as memtables flush.
+	rocksdb::WriteBufferManager* attachedWriteBufferManager = nullptr;
 	if (auto wbm = settings.getWriteBufferManager()) {
 		dbOptions.write_buffer_manager = wbm;
+		attachedWriteBufferManager = wbm.get();
 	}
 	dbOptions.IncreaseParallelism(options.parallelismThreads);
 	// Bound how many table files RocksDB holds open: with the RocksDB default
@@ -1501,7 +1505,9 @@ std::shared_ptr<DBDescriptor> DBDescriptor::open(
 	bool columnExists = false;
 	for (size_t n = 0; n < cfHandles.size(); ++n) {
 		auto column = std::shared_ptr<rocksdb::ColumnFamilyHandle>(cfHandles[n]);
-		auto columnDescriptor = std::make_shared<ColumnFamilyDescriptor>(column);
+		auto columnDescriptor = std::make_shared<ColumnFamilyDescriptor>(
+			column, db->GetOptions(column.get()).max_write_buffer_size_to_maintain
+		);
 		columns[cfDescriptors[n].name] = columnDescriptor;
 		if (cfDescriptors[n].name == options.name) {
 			columnExists = true;
@@ -1521,12 +1527,14 @@ std::shared_ptr<DBDescriptor> DBDescriptor::open(
 			applyCompression(cfo, *options.compression, options.compressionLevel);
 		}
 		auto column = rocksdb_js::createRocksDBColumnFamily(db, options.name, cfo);
-		auto columnDescriptor = std::make_shared<ColumnFamilyDescriptor>(column);
+		auto columnDescriptor = std::make_shared<ColumnFamilyDescriptor>(
+			column, db->GetOptions(column.get()).max_write_buffer_size_to_maintain
+		);
 		columns[options.name] = columnDescriptor;
 	}
 
 	DEBUG_LOG("DBDescriptor::open Creating DBDescriptor for \"%s\"\n", path.c_str());
-	auto descriptor = std::shared_ptr<DBDescriptor>(new DBDescriptor(path, identityPath, options, cfOptions, db, std::move(columns), dbOptions.statistics));
+	auto descriptor = std::shared_ptr<DBDescriptor>(new DBDescriptor(path, identityPath, options, cfOptions, db, attachedWriteBufferManager, std::move(columns), dbOptions.statistics));
 	descriptor->secondaryLockToken = secondaryLock.token;
 	secondaryLock.token = 0;
 

--- a/src/binding/database/db_descriptor.h
+++ b/src/binding/database/db_descriptor.h
@@ -273,6 +273,14 @@ struct DBDescriptor final : public std::enable_shared_from_this<DBDescriptor> {
 	std::shared_ptr<rocksdb::DB> db;
 
 	/**
+	 * The process-wide `WriteBufferManager` this database attached at open, or
+	 * null. Recorded because attachment is decided per open: a database opened
+	 * before the manager was configured, or after its size was reset to 0, does
+	 * not draw on the budget and must not appear in a stall report explaining it.
+	 */
+	rocksdb::WriteBufferManager* const attachedWriteBufferManager;
+
+	/**
 	 * Map of column family name to column family handle.
 	 */
 	std::unordered_map<std::string, std::shared_ptr<ColumnFamilyDescriptor>> columns;
@@ -501,6 +509,7 @@ private:
 		const DBOptions& options,
 		const rocksdb::ColumnFamilyOptions& cfOptions,
 		std::shared_ptr<rocksdb::DB> db,
+		rocksdb::WriteBufferManager* attachedWriteBufferManager,
 		std::unordered_map<std::string, std::shared_ptr<ColumnFamilyDescriptor>>&& columns,
 		std::shared_ptr<rocksdb::Statistics> statistics
 	);
@@ -832,7 +841,19 @@ struct ColumnFamilyDescriptor final {
 	 */
 	std::mutex userSharedBuffersMutex;
 
-	ColumnFamilyDescriptor(std::shared_ptr<rocksdb::ColumnFamilyHandle> column) : column(column) {}
+	/**
+	 * The column family's *effective* `max_write_buffer_size_to_maintain`, read
+	 * from RocksDB at creation. Effective, not requested: `TransactionDB::Open`
+	 * rewrites a requested `0` into a derived (large) value, so the requested one
+	 * hides the very condition the stall report exists to expose
+	 * (HarperFast/rocksdb-js#821).
+	 */
+	const int64_t maxWriteBufferSizeToMaintain;
+
+	ColumnFamilyDescriptor(
+		std::shared_ptr<rocksdb::ColumnFamilyHandle> column,
+		int64_t maxWriteBufferSizeToMaintain
+	) : column(column), maxWriteBufferSizeToMaintain(maxWriteBufferSizeToMaintain) {}
 
 	~ColumnFamilyDescriptor() {
 		DEBUG_LOG("%p ColumnFamilyDescriptor::~ColumnFamilyDescriptor destroying column family descriptor\n", this);

--- a/src/binding/database/db_descriptor.h
+++ b/src/binding/database/db_descriptor.h
@@ -284,8 +284,27 @@ struct DBDescriptor final : public std::enable_shared_from_this<DBDescriptor> {
 	 * Map of column family name to column family handle.
 	 */
 	std::unordered_map<std::string, std::shared_ptr<ColumnFamilyDescriptor>> columns;
-	// A dropped family can remain charged through a live handle after leaving `columns`.
-	bool writeBufferManagerInventoryComplete = true;
+
+	/**
+	 * A dropped column family whose memtables a live handle may still be
+	 * charging to the WriteBufferManager after it left `columns`.
+	 *
+	 * The retention target is copied out rather than read back through the
+	 * reference, so the stall inventory can count these without calling
+	 * `weak_ptr::lock()`: releasing that temporary could be the last reference,
+	 * destroying the RocksDB column-family handle on the sampling thread while
+	 * both `databasesMutex` and `columnsMutex` are held.
+	 */
+	struct DroppedColumnFamily final {
+		std::weak_ptr<ColumnFamilyDescriptor> descriptor;
+		int64_t maxWriteBufferSizeToMaintain = 0;
+	};
+
+	/**
+	 * Guarded by `columnsMutex`. Pruned of expired entries on every drop, so it
+	 * holds at most the families that were still live at the previous drop.
+	 */
+	std::vector<DroppedColumnFamily> droppedColumns;
 
 	/**
 	 * Mutex to protect the columns map. Column families can be unregistered on

--- a/src/binding/database/db_descriptor.h
+++ b/src/binding/database/db_descriptor.h
@@ -284,6 +284,8 @@ struct DBDescriptor final : public std::enable_shared_from_this<DBDescriptor> {
 	 * Map of column family name to column family handle.
 	 */
 	std::unordered_map<std::string, std::shared_ptr<ColumnFamilyDescriptor>> columns;
+	// A dropped family can remain charged through a live handle after leaving `columns`.
+	bool writeBufferManagerInventoryComplete = true;
 
 	/**
 	 * Mutex to protect the columns map. Column families can be unregistered on

--- a/src/binding/database/db_handle.cpp
+++ b/src/binding/database/db_handle.cpp
@@ -14,6 +14,59 @@ namespace {
 constexpr const char* COMMIT_PIPELINE_LOG_QUEUE_DEPTH_KEY = "commitPipeline.logQueueDepth";
 constexpr const char* COMMIT_PIPELINE_COMMIT_QUEUE_DEPTH_KEY = "commitPipeline.commitQueueDepth";
 
+// Process-wide WriteBufferManager gauges. These describe the singleton manager
+// shared by every database in the process, not this database (see docs/stats.md).
+constexpr const char* WBM_BUFFER_SIZE_KEY = "writeBufferManager.bufferSize";
+constexpr const char* WBM_MEMORY_USAGE_KEY = "writeBufferManager.memoryUsage";
+constexpr const char* WBM_MUTABLE_MEMORY_USAGE_KEY = "writeBufferManager.mutableMemoryUsage";
+constexpr const char* WBM_STALL_ACTIVE_KEY = "writeBufferManager.stallActive";
+constexpr const char* WBM_STALL_ACTIVE_MS_KEY = "writeBufferManager.stallActiveMs";
+
+bool lookupWriteBufferManagerStat(
+	const std::string& statName,
+	const WriteBufferManagerStats& stats,
+	double& value
+) {
+	if (statName == WBM_BUFFER_SIZE_KEY) {
+		value = static_cast<double>(stats.bufferSize);
+	} else if (statName == WBM_MEMORY_USAGE_KEY) {
+		value = static_cast<double>(stats.memoryUsage);
+	} else if (statName == WBM_MUTABLE_MEMORY_USAGE_KEY) {
+		value = static_cast<double>(stats.mutableMemoryUsage);
+	} else if (statName == WBM_STALL_ACTIVE_KEY) {
+		value = stats.stallActive ? 1 : 0;
+	} else if (statName == WBM_STALL_ACTIVE_MS_KEY) {
+		value = static_cast<double>(stats.stallActiveMs);
+	} else {
+		return false;
+	}
+	return true;
+}
+
+void setWriteBufferManagerStatsOnObject(
+	napi_env env,
+	napi_value result,
+	const WriteBufferManagerStats& stats
+) {
+	static constexpr const char* keys[] = {
+		WBM_BUFFER_SIZE_KEY,
+		WBM_MEMORY_USAGE_KEY,
+		WBM_MUTABLE_MEMORY_USAGE_KEY,
+		WBM_STALL_ACTIVE_KEY,
+		WBM_STALL_ACTIVE_MS_KEY,
+	};
+	for (const char* key : keys) {
+		double value = 0;
+		if (!lookupWriteBufferManagerStat(key, stats, value)) {
+			continue;
+		}
+		napi_value jsValue;
+		if (::napi_create_double(env, value, &jsValue) == napi_ok) {
+			::napi_set_named_property(env, result, key, jsValue);
+		}
+	}
+}
+
 bool lookupTxnlogSummaryStat(
 	const std::string& statName,
 	const TransactionLogStoreStats& total,
@@ -188,6 +241,22 @@ napi_value DBHandle::getStat(napi_env env, const std::string& statName) {
 		return jsValue;
 	}
 
+	// process-wide WriteBufferManager gauges: computed here, so an unknown key in
+	// this namespace returns undefined rather than falling through to the RocksDB
+	// statistics path, which throws when statistics are disabled.
+	if (statName.rfind("writeBufferManager.", 0) == 0) {
+		WriteBufferManagerStats wbmStats =
+			DBSettings::getInstance().getWriteBufferManagerStats(false);
+		double value = 0;
+		napi_value jsValue;
+		if (lookupWriteBufferManagerStat(statName, wbmStats, value)) {
+			NAPI_STATUS_THROWS(::napi_create_double(env, value, &jsValue));
+		} else {
+			NAPI_STATUS_THROWS(::napi_get_undefined(env, &jsValue));
+		}
+		return jsValue;
+	}
+
 	// transaction log summary stats are computed here (not RocksDB tickers or
 	// column-family properties), so resolve them before anything else.
 	if (statName.rfind("txnlog.", 0) == 0) {
@@ -294,6 +363,14 @@ napi_value DBHandle::getStats(napi_env env, bool all) {
 		this->collectTransactionLogSummary(total, logCount);
 		setTxnlogSummaryStatsOnObject(env, result, total, logCount);
 	}
+
+	// process-wide WriteBufferManager gauges. Like the txnlog summary above, these
+	// are independent of the RocksDB statistics gate. The column-family inventory
+	// is deliberately left out: it walks the registry, and this is a scrape path
+	// (RocksDatabase.getWriteBufferManagerStats() carries it).
+	setWriteBufferManagerStatsOnObject(
+		env, result, DBSettings::getInstance().getWriteBufferManagerStats(false)
+	);
 
 	// commit-pipeline queue depths
 	{

--- a/src/binding/database/db_handle.cpp
+++ b/src/binding/database/db_handle.cpp
@@ -189,7 +189,6 @@ napi_value DBHandle::getStat(napi_env env, const std::string& statName) {
 		return jsValue;
 	}
 
-	// Unknown writeBufferManager.* keys must not fall through to RocksDB statistics.
 	if (statName.rfind("writeBufferManager.", 0) == 0) {
 		double value = 0;
 		napi_value jsValue;
@@ -308,7 +307,6 @@ napi_value DBHandle::getStats(napi_env env, bool all) {
 		setTxnlogSummaryStatsOnObject(env, result, total, logCount);
 	}
 
-	// Omit the column-family inventory from this scrape path because it walks the registry.
 	DBStats::getInstance().setWriteBufferManagerStatsOnObject(env, result);
 
 	// commit-pipeline queue depths

--- a/src/binding/database/db_handle.cpp
+++ b/src/binding/database/db_handle.cpp
@@ -189,9 +189,7 @@ napi_value DBHandle::getStat(napi_env env, const std::string& statName) {
 		return jsValue;
 	}
 
-	// process-wide WriteBufferManager gauges: computed here, so an unknown key in
-	// this namespace returns undefined rather than falling through to the RocksDB
-	// statistics path, which throws when statistics are disabled.
+	// Unknown writeBufferManager.* keys must not fall through to RocksDB statistics.
 	if (statName.rfind("writeBufferManager.", 0) == 0) {
 		double value = 0;
 		napi_value jsValue;
@@ -310,10 +308,7 @@ napi_value DBHandle::getStats(napi_env env, bool all) {
 		setTxnlogSummaryStatsOnObject(env, result, total, logCount);
 	}
 
-	// process-wide WriteBufferManager gauges. Like the txnlog summary above, these
-	// are independent of the RocksDB statistics gate. The column-family inventory
-	// is deliberately left out: it walks the registry, and this is a scrape path
-	// (getWriteBufferManagerStats() carries it).
+	// Omit the column-family inventory from this scrape path because it walks the registry.
 	DBStats::getInstance().setWriteBufferManagerStatsOnObject(env, result);
 
 	// commit-pipeline queue depths

--- a/src/binding/database/db_handle.cpp
+++ b/src/binding/database/db_handle.cpp
@@ -2,6 +2,7 @@
 #include "database/db_handle.h"
 #include "database/db_descriptor.h"
 #include "database/db_registry.h"
+#include "database/db_stats.h"
 #include "database/db_settings.h"
 #include "transaction_log/transaction_log_store_registry.h"
 #include "core/verification_table.h"
@@ -13,59 +14,6 @@ namespace {
 // Commit-pipeline queue-depth gauges (see docs/stats.md).
 constexpr const char* COMMIT_PIPELINE_LOG_QUEUE_DEPTH_KEY = "commitPipeline.logQueueDepth";
 constexpr const char* COMMIT_PIPELINE_COMMIT_QUEUE_DEPTH_KEY = "commitPipeline.commitQueueDepth";
-
-// Process-wide WriteBufferManager gauges. These describe the singleton manager
-// shared by every database in the process, not this database (see docs/stats.md).
-constexpr const char* WBM_BUFFER_SIZE_KEY = "writeBufferManager.bufferSize";
-constexpr const char* WBM_MEMORY_USAGE_KEY = "writeBufferManager.memoryUsage";
-constexpr const char* WBM_MUTABLE_MEMORY_USAGE_KEY = "writeBufferManager.mutableMemoryUsage";
-constexpr const char* WBM_STALL_ACTIVE_KEY = "writeBufferManager.stallActive";
-constexpr const char* WBM_STALL_ACTIVE_MS_KEY = "writeBufferManager.stallActiveMs";
-
-bool lookupWriteBufferManagerStat(
-	const std::string& statName,
-	const WriteBufferManagerStats& stats,
-	double& value
-) {
-	if (statName == WBM_BUFFER_SIZE_KEY) {
-		value = static_cast<double>(stats.bufferSize);
-	} else if (statName == WBM_MEMORY_USAGE_KEY) {
-		value = static_cast<double>(stats.memoryUsage);
-	} else if (statName == WBM_MUTABLE_MEMORY_USAGE_KEY) {
-		value = static_cast<double>(stats.mutableMemoryUsage);
-	} else if (statName == WBM_STALL_ACTIVE_KEY) {
-		value = stats.stallActive ? 1 : 0;
-	} else if (statName == WBM_STALL_ACTIVE_MS_KEY) {
-		value = static_cast<double>(stats.stallActiveMs);
-	} else {
-		return false;
-	}
-	return true;
-}
-
-void setWriteBufferManagerStatsOnObject(
-	napi_env env,
-	napi_value result,
-	const WriteBufferManagerStats& stats
-) {
-	static constexpr const char* keys[] = {
-		WBM_BUFFER_SIZE_KEY,
-		WBM_MEMORY_USAGE_KEY,
-		WBM_MUTABLE_MEMORY_USAGE_KEY,
-		WBM_STALL_ACTIVE_KEY,
-		WBM_STALL_ACTIVE_MS_KEY,
-	};
-	for (const char* key : keys) {
-		double value = 0;
-		if (!lookupWriteBufferManagerStat(key, stats, value)) {
-			continue;
-		}
-		napi_value jsValue;
-		if (::napi_create_double(env, value, &jsValue) == napi_ok) {
-			::napi_set_named_property(env, result, key, jsValue);
-		}
-	}
-}
 
 bool lookupTxnlogSummaryStat(
 	const std::string& statName,
@@ -245,11 +193,9 @@ napi_value DBHandle::getStat(napi_env env, const std::string& statName) {
 	// this namespace returns undefined rather than falling through to the RocksDB
 	// statistics path, which throws when statistics are disabled.
 	if (statName.rfind("writeBufferManager.", 0) == 0) {
-		WriteBufferManagerStats wbmStats =
-			DBSettings::getInstance().getWriteBufferManagerStats(false);
 		double value = 0;
 		napi_value jsValue;
-		if (lookupWriteBufferManagerStat(statName, wbmStats, value)) {
+		if (DBStats::getInstance().getWriteBufferManagerStat(statName, value)) {
 			NAPI_STATUS_THROWS(::napi_create_double(env, value, &jsValue));
 		} else {
 			NAPI_STATUS_THROWS(::napi_get_undefined(env, &jsValue));
@@ -367,10 +313,8 @@ napi_value DBHandle::getStats(napi_env env, bool all) {
 	// process-wide WriteBufferManager gauges. Like the txnlog summary above, these
 	// are independent of the RocksDB statistics gate. The column-family inventory
 	// is deliberately left out: it walks the registry, and this is a scrape path
-	// (RocksDatabase.getWriteBufferManagerStats() carries it).
-	setWriteBufferManagerStatsOnObject(
-		env, result, DBSettings::getInstance().getWriteBufferManagerStats(false)
-	);
+	// (getWriteBufferManagerStats() carries it).
+	DBStats::getInstance().setWriteBufferManagerStatsOnObject(env, result);
 
 	// commit-pipeline queue depths
 	{

--- a/src/binding/database/db_registry.cpp
+++ b/src/binding/database/db_registry.cpp
@@ -294,15 +294,18 @@ void DBRegistry::DestroyDB(const std::string& path) {
 	DEBUG_LOG("%p DBRegistry::DestroyDB Successfully destroyed database at \"%s\"\n", instance.get(), identityPath.c_str());
 }
 
-void DBRegistry::CollectWriteBufferManagerInventory(
+bool DBRegistry::CollectWriteBufferManagerInventory(
 	const rocksdb::WriteBufferManager* wbm,
 	uint64_t& columnFamilies,
 	std::map<int64_t, uint64_t>& maxWriteBufferSizeToMaintain
 ) {
 	if (!instance || wbm == nullptr) {
-		return;
+		return false;
 	}
-	std::lock_guard<std::mutex> lock(instance->databasesMutex);
+	std::unique_lock<std::mutex> lock(instance->databasesMutex, std::try_to_lock);
+	if (!lock.owns_lock()) {
+		return false;
+	}
 	for (const auto& [key, entry] : instance->databases) {
 		const auto& descriptor = entry.descriptor;
 		if (!descriptor || descriptor->readOnly || descriptor->attachedWriteBufferManager != wbm) {
@@ -317,6 +320,7 @@ void DBRegistry::CollectWriteBufferManagerInventory(
 			maxWriteBufferSizeToMaintain[columnDescriptor->maxWriteBufferSizeToMaintain]++;
 		}
 	}
+	return true;
 }
 
 /**

--- a/src/binding/database/db_registry.cpp
+++ b/src/binding/database/db_registry.cpp
@@ -326,10 +326,7 @@ bool DBRegistry::CollectWriteBufferManagerInventory(
 			collectedColumnFamilies++;
 			collectedMaxWriteBufferSizeToMaintain[columnDescriptor->maxWriteBufferSizeToMaintain]++;
 		}
-		// A dropped family still charges the manager while a handle holds it, so
-		// it is counted from the target cached at drop. Never `lock()` the weak
-		// reference: releasing that temporary could destroy the RocksDB
-		// column-family handle here, under both inventory locks.
+		// `expired()` only, never `lock()` — see `DBDescriptor::DroppedColumnFamily`.
 		for (const auto& dropped : descriptor->droppedColumns) {
 			if (dropped.descriptor.expired()) {
 				continue;

--- a/src/binding/database/db_registry.cpp
+++ b/src/binding/database/db_registry.cpp
@@ -319,15 +319,23 @@ bool DBRegistry::CollectWriteBufferManagerInventory(
 		if (!columnsLock.owns_lock()) {
 			return false;
 		}
-		if (!descriptor->writeBufferManagerInventoryComplete) {
-			return false;
-		}
 		for (const auto& [name, columnDescriptor] : descriptor->columns) {
 			if (!columnDescriptor) {
 				continue;
 			}
 			collectedColumnFamilies++;
 			collectedMaxWriteBufferSizeToMaintain[columnDescriptor->maxWriteBufferSizeToMaintain]++;
+		}
+		// A dropped family still charges the manager while a handle holds it, so
+		// it is counted from the target cached at drop. Never `lock()` the weak
+		// reference: releasing that temporary could destroy the RocksDB
+		// column-family handle here, under both inventory locks.
+		for (const auto& dropped : descriptor->droppedColumns) {
+			if (dropped.descriptor.expired()) {
+				continue;
+			}
+			collectedColumnFamilies++;
+			collectedMaxWriteBufferSizeToMaintain[dropped.maxWriteBufferSizeToMaintain]++;
 		}
 	}
 	columnFamilies = collectedColumnFamilies;

--- a/src/binding/database/db_registry.cpp
+++ b/src/binding/database/db_registry.cpp
@@ -294,6 +294,31 @@ void DBRegistry::DestroyDB(const std::string& path) {
 	DEBUG_LOG("%p DBRegistry::DestroyDB Successfully destroyed database at \"%s\"\n", instance.get(), identityPath.c_str());
 }
 
+void DBRegistry::CollectWriteBufferManagerInventory(
+	const rocksdb::WriteBufferManager* wbm,
+	uint64_t& columnFamilies,
+	std::map<int64_t, uint64_t>& maxWriteBufferSizeToMaintain
+) {
+	if (!instance || wbm == nullptr) {
+		return;
+	}
+	std::lock_guard<std::mutex> lock(instance->databasesMutex);
+	for (const auto& [key, entry] : instance->databases) {
+		const auto& descriptor = entry.descriptor;
+		if (!descriptor || descriptor->readOnly || descriptor->attachedWriteBufferManager != wbm) {
+			continue;
+		}
+		std::lock_guard<std::mutex> columnsLock(descriptor->columnsMutex);
+		for (const auto& [name, columnDescriptor] : descriptor->columns) {
+			if (!columnDescriptor) {
+				continue;
+			}
+			columnFamilies++;
+			maxWriteBufferSizeToMaintain[columnDescriptor->maxWriteBufferSizeToMaintain]++;
+		}
+	}
+}
+
 /**
  * Initialize the singleton instance of the registry.
  */
@@ -502,7 +527,10 @@ std::unique_ptr<DBHandleParams> DBRegistry::OpenDB(const std::string& path, cons
 			auto column = rocksdb_js::createRocksDBColumnFamily(
 				entry.descriptor->db, name, cfOptions
 			);
-			auto columnDescriptor = std::make_shared<ColumnFamilyDescriptor>(column);
+			auto columnDescriptor = std::make_shared<ColumnFamilyDescriptor>(
+				column,
+				entry.descriptor->db->GetOptions(column.get()).max_write_buffer_size_to_maintain
+			);
 			columns[name] = columnDescriptor;
 			entry.descriptor->columns[name] = columnDescriptor;
 		} else if (options.compressionExplicit && options.compression) {

--- a/src/binding/database/db_registry.cpp
+++ b/src/binding/database/db_registry.cpp
@@ -312,11 +312,14 @@ bool DBRegistry::CollectWriteBufferManagerInventory(
 	std::map<int64_t, uint64_t> collectedMaxWriteBufferSizeToMaintain;
 	for (const auto& [key, entry] : instance->databases) {
 		const auto& descriptor = entry.descriptor;
-		if (!descriptor || descriptor->readOnly || descriptor->attachedWriteBufferManager != wbm) {
+		if (!descriptor || descriptor->attachedWriteBufferManager != wbm) {
 			continue;
 		}
 		std::unique_lock<std::mutex> columnsLock(descriptor->columnsMutex, std::try_to_lock);
 		if (!columnsLock.owns_lock()) {
+			return false;
+		}
+		if (!descriptor->writeBufferManagerInventoryComplete) {
 			return false;
 		}
 		for (const auto& [name, columnDescriptor] : descriptor->columns) {

--- a/src/binding/database/db_registry.cpp
+++ b/src/binding/database/db_registry.cpp
@@ -299,6 +299,8 @@ bool DBRegistry::CollectWriteBufferManagerInventory(
 	uint64_t& columnFamilies,
 	std::map<int64_t, uint64_t>& maxWriteBufferSizeToMaintain
 ) {
+	columnFamilies = 0;
+	maxWriteBufferSizeToMaintain.clear();
 	if (!instance || wbm == nullptr) {
 		return false;
 	}
@@ -306,20 +308,27 @@ bool DBRegistry::CollectWriteBufferManagerInventory(
 	if (!lock.owns_lock()) {
 		return false;
 	}
+	uint64_t collectedColumnFamilies = 0;
+	std::map<int64_t, uint64_t> collectedMaxWriteBufferSizeToMaintain;
 	for (const auto& [key, entry] : instance->databases) {
 		const auto& descriptor = entry.descriptor;
 		if (!descriptor || descriptor->readOnly || descriptor->attachedWriteBufferManager != wbm) {
 			continue;
 		}
-		std::lock_guard<std::mutex> columnsLock(descriptor->columnsMutex);
+		std::unique_lock<std::mutex> columnsLock(descriptor->columnsMutex, std::try_to_lock);
+		if (!columnsLock.owns_lock()) {
+			return false;
+		}
 		for (const auto& [name, columnDescriptor] : descriptor->columns) {
 			if (!columnDescriptor) {
 				continue;
 			}
-			columnFamilies++;
-			maxWriteBufferSizeToMaintain[columnDescriptor->maxWriteBufferSizeToMaintain]++;
+			collectedColumnFamilies++;
+			collectedMaxWriteBufferSizeToMaintain[columnDescriptor->maxWriteBufferSizeToMaintain]++;
 		}
 	}
+	columnFamilies = collectedColumnFamilies;
+	maxWriteBufferSizeToMaintain = std::move(collectedMaxWriteBufferSizeToMaintain);
 	return true;
 }
 

--- a/src/binding/database/db_registry.h
+++ b/src/binding/database/db_registry.h
@@ -2,6 +2,7 @@
 #define __DB_REGISTRY_H__
 
 #include <condition_variable>
+#include <map>
 #include <memory>
 #include <mutex>
 #include <unordered_map>
@@ -111,6 +112,27 @@ private:
 
 public:
 	static void CloseDB(const std::shared_ptr<DBHandle> handle);
+
+	/**
+	 * Counts the live column families that draw on `wbm`, grouped by their
+	 * effective `max_write_buffer_size_to_maintain` — the inventory the stall
+	 * report needs to explain a full budget.
+	 *
+	 * Only descriptors that attached this exact manager and are writable are
+	 * counted: a database opened before the manager was configured, or read-only,
+	 * cannot account for its memory, and including it would report a retention
+	 * distribution that is not the one holding the budget.
+	 *
+	 * Reads only cached integers under `databasesMutex` -> `columnsMutex` (the
+	 * order `OpenDB` already establishes) and copies no `shared_ptr` out, so it
+	 * cannot inflate a descriptor's use count and make a racing close skip its
+	 * purge. Safe to call from a non-JS thread.
+	 */
+	static void CollectWriteBufferManagerInventory(
+		const rocksdb::WriteBufferManager* wbm,
+		uint64_t& columnFamilies,
+		std::map<int64_t, uint64_t>& maxWriteBufferSizeToMaintain
+	);
 #ifdef DEBUG
 	static void DebugLogDescriptorRefs();
 #endif

--- a/src/binding/database/db_registry.h
+++ b/src/binding/database/db_registry.h
@@ -118,9 +118,9 @@ public:
 	 * effective `max_write_buffer_size_to_maintain` — the inventory the stall
 	 * report needs to explain a full budget.
 	 *
-	 * Only descriptors that attached this exact manager are counted. If a dropped
-	 * column family may still be retained by a live handle, the inventory is
-	 * reported unavailable rather than omitting a possible budget owner.
+	 * Only descriptors that attached this exact manager are counted. A dropped
+	 * column family still charging the manager through a live handle is counted
+	 * too, and stops being counted once that last handle closes.
 	 *
 	 * Reads only cached integers under `databasesMutex` -> `columnsMutex` (the
 	 * order `OpenDB` already establishes) and copies no `shared_ptr` out, so it

--- a/src/binding/database/db_registry.h
+++ b/src/binding/database/db_registry.h
@@ -128,11 +128,10 @@ public:
 	 * cannot inflate a descriptor's use count and make a racing close skip its
 	 * purge. Safe to call from a non-JS thread.
 	 *
-	 * `databasesMutex` is acquired with `try_lock`, returning false rather than
-	 * waiting: `PurgeAll` holds it across `descriptor->close()`, whose flush waits
-	 * out a write stall (AGENTS.md note 16), so blocking here would silence the
-	 * stall alarm and hang `getWriteBufferManagerStats()` during exactly the
-	 * incident both exist to report.
+	 * Both mutex levels are acquired with `try_lock`, returning false rather than
+	 * waiting: registry teardown or column-family creation can hold them across
+	 * RocksDB work that waits out a write stall, so blocking here would silence
+	 * the stall alarm during exactly the incident it exists to report.
 	 */
 	static bool CollectWriteBufferManagerInventory(
 		const rocksdb::WriteBufferManager* wbm,

--- a/src/binding/database/db_registry.h
+++ b/src/binding/database/db_registry.h
@@ -127,8 +127,14 @@ public:
 	 * order `OpenDB` already establishes) and copies no `shared_ptr` out, so it
 	 * cannot inflate a descriptor's use count and make a racing close skip its
 	 * purge. Safe to call from a non-JS thread.
+	 *
+	 * `databasesMutex` is acquired with `try_lock`, returning false rather than
+	 * waiting: `PurgeAll` holds it across `descriptor->close()`, whose flush waits
+	 * out a write stall (AGENTS.md note 16), so blocking here would silence the
+	 * stall alarm and hang `getWriteBufferManagerStats()` during exactly the
+	 * incident both exist to report.
 	 */
-	static void CollectWriteBufferManagerInventory(
+	static bool CollectWriteBufferManagerInventory(
 		const rocksdb::WriteBufferManager* wbm,
 		uint64_t& columnFamilies,
 		std::map<int64_t, uint64_t>& maxWriteBufferSizeToMaintain

--- a/src/binding/database/db_registry.h
+++ b/src/binding/database/db_registry.h
@@ -118,10 +118,9 @@ public:
 	 * effective `max_write_buffer_size_to_maintain` — the inventory the stall
 	 * report needs to explain a full budget.
 	 *
-	 * Only descriptors that attached this exact manager and are writable are
-	 * counted: a database opened before the manager was configured, or read-only,
-	 * cannot account for its memory, and including it would report a retention
-	 * distribution that is not the one holding the budget.
+	 * Only descriptors that attached this exact manager are counted. If a dropped
+	 * column family may still be retained by a live handle, the inventory is
+	 * reported unavailable rather than omitting a possible budget owner.
 	 *
 	 * Reads only cached integers under `databasesMutex` -> `columnsMutex` (the
 	 * order `OpenDB` already establishes) and copies no `shared_ptr` out, so it

--- a/src/binding/database/db_settings.cpp
+++ b/src/binding/database/db_settings.cpp
@@ -24,7 +24,19 @@ uint64_t generateSeed() {
 // there is not safe against a concurrent process.env write on any JS thread
 // (same reasoning as ROCKSDB_JS_PARK_TIMEOUT_MS).
 uint64_t writeBufferManagerStallWarnMs() {
-	static const uint64_t value = resolveWbmStallWarnMs(::getenv("ROCKSDB_JS_WBM_STALL_WARN_MS"));
+	static const uint64_t value = [] {
+		const char* raw = ::getenv("ROCKSDB_JS_WBM_STALL_WARN_MS");
+		bool rejected = false;
+		uint64_t resolved = resolveWbmStallWarnMs(raw, &rejected);
+		if (rejected) {
+			::fprintf(stderr,
+				"[rocksdb-js] ignoring ROCKSDB_JS_WBM_STALL_WARN_MS=\"%s\" (not an integer in "
+				"[0, %llu] ms); using %llu\n",
+				raw, static_cast<unsigned long long>(WBM_STALL_WARN_MS_MAX),
+				static_cast<unsigned long long>(resolved));
+		}
+		return resolved;
+	}();
 	return value;
 }
 
@@ -152,8 +164,10 @@ void DBSettings::ensureWriteBufferManagerWatchdog() {
 		return;
 	}
 	this->watchdogStopRequested = false;
+	const uint64_t generation = ++this->watchdogGeneration;
 	try {
-		this->watchdogThread = std::thread([this]() { this->runWriteBufferManagerWatchdog(); });
+		this->watchdogThread =
+			std::thread([this, generation]() { this->runWriteBufferManagerWatchdog(generation); });
 		this->watchdogStarted = true;
 	} catch (...) {
 		this->watchdogStarted = false;
@@ -185,15 +199,18 @@ void DBSettings::joinWriteBufferManagerWatchdog() {
 	}
 }
 
-void DBSettings::runWriteBufferManagerWatchdog() {
+void DBSettings::runWriteBufferManagerWatchdog(uint64_t generation) {
 	setThreadName("rocksdb-wbm-watchdog");
 	this->writeBufferManagerWatchdogRunning.store(true, std::memory_order_relaxed);
 	const uint64_t thresholdMs = writeBufferManagerStallWarnMs();
 	WbmStallWatchdogState state;
 	std::unique_lock<std::mutex> lock(this->watchdogMutex);
-	while (!this->watchdogStopRequested) {
+	auto retired = [&] {
+		return this->watchdogStopRequested || this->watchdogGeneration != generation;
+	};
+	while (!retired()) {
 		this->watchdogCv.wait_for(lock, std::chrono::milliseconds(WBM_STALL_SAMPLE_INTERVAL_MS));
-		if (this->watchdogStopRequested) {
+		if (retired()) {
 			break;
 		}
 		lock.unlock();
@@ -205,8 +222,10 @@ void DBSettings::runWriteBufferManagerWatchdog() {
 		}
 		lock.lock();
 	}
-	this->writeBufferManagerStallActiveMs.store(0, std::memory_order_relaxed);
-	this->writeBufferManagerWatchdogRunning.store(false, std::memory_order_relaxed);
+	if (this->watchdogGeneration == generation) {
+		this->writeBufferManagerStallActiveMs.store(0, std::memory_order_relaxed);
+		this->writeBufferManagerWatchdogRunning.store(false, std::memory_order_relaxed);
+	}
 }
 
 void DBSettings::sampleWriteBufferManagerStall(WbmStallWatchdogState& state, uint64_t thresholdMs) {
@@ -229,19 +248,23 @@ void DBSettings::sampleWriteBufferManagerStall(WbmStallWatchdogState& state, uin
 	report.mutableMemoryUsage = wbm->mutable_memtable_memory_usage();
 	report.allowStall = this->writeBufferManagerAllowStall.load(std::memory_order_relaxed);
 	report.costToCache = this->writeBufferManagerCostToCache.load(std::memory_order_relaxed);
-	DBRegistry::CollectWriteBufferManagerInventory(
+	report.inventoryAvailable = DBRegistry::CollectWriteBufferManagerInventory(
 		wbm, report.columnFamilies, report.maxWriteBufferSizeToMaintain
 	);
 
-	// Formatting and delivery happen after every registry lock is released.
 	std::string line = formatWriteBufferManagerStallReport(report);
-	// stderr is the channel that does not depend on an application having
-	// registered a listener; the event below is the one an application can route.
-	if (::fprintf(stderr, "%s\n", line.c_str()) >= 0) {
+	// stderr does not depend on an application having registered a listener; the
+	// event is the one an application can route. The episode is retired once
+	// either has carried it — gating on stderr alone would re-report every second
+	// for the whole stall when fd 2 is closed but a listener is attached.
+	const bool wroteToStderr = ::fprintf(stderr, "%s\n", line.c_str()) >= 0;
+	if (wroteToStderr) {
 		::fflush(stderr);
+	}
+	const bool emitted = emitGlobalEvent("log.warn", ListenerData::fromStrings({ line }));
+	if (wroteToStderr || emitted) {
 		state.markReported();
 	}
-	emitGlobalEvent("log.warn", ListenerData::fromStrings({ line }));
 }
 
 WriteBufferManagerStats DBSettings::getWriteBufferManagerStats(bool includeColumnFamilies) {
@@ -261,11 +284,15 @@ WriteBufferManagerStats DBSettings::getWriteBufferManagerStats(bool includeColum
 	stats.stallActive = wbm->IsStallActive();
 	stats.stallActiveMs = this->writeBufferManagerStallActiveMs.load(std::memory_order_relaxed);
 	if (includeColumnFamilies) {
-		DBRegistry::CollectWriteBufferManagerInventory(
+		stats.inventoryAvailable = DBRegistry::CollectWriteBufferManagerInventory(
 			wbm, stats.columnFamilies, stats.maxWriteBufferSizeToMaintain
 		);
 	}
 	return stats;
+}
+
+DBSettings::~DBSettings() {
+	this->joinWriteBufferManagerWatchdog();
 }
 
 /**
@@ -430,6 +457,7 @@ napi_value DBSettings::GetWriteBufferManagerStats(napi_env env, napi_callback_in
 	NAPI_STATUS_THROWS(setBoolProperty(env, result, "costToCache", stats.costToCache));
 	NAPI_STATUS_THROWS(setBoolProperty(env, result, "stallActive", stats.stallActive));
 	NAPI_STATUS_THROWS(setBoolProperty(env, result, "watchdogRunning", stats.watchdogRunning));
+	NAPI_STATUS_THROWS(setBoolProperty(env, result, "inventoryAvailable", stats.inventoryAvailable));
 
 	napi_value targets;
 	NAPI_STATUS_THROWS(::napi_create_object(env, &targets));

--- a/src/binding/database/db_settings.cpp
+++ b/src/binding/database/db_settings.cpp
@@ -1,7 +1,10 @@
 #include "database/db_settings.h"
+#include <cstdio>
 #include <random>
 #include "napi/macros.h"
 #include "core/platform.h"
+#include "database/db_registry.h"
+#include "napi/global_events.h"
 #include "napi/helpers.h"
 #include "napi/async.h"
 #include "rocksdb/advanced_cache.h"
@@ -15,6 +18,32 @@ uint64_t generateSeed() {
 	uint64_t hi = static_cast<uint64_t>(rd());
 	uint64_t lo = static_cast<uint64_t>(rd());
 	return (hi << 32) | lo;
+}
+
+// Resolved once per process: the watchdog runs on its own thread, and ::getenv
+// there is not safe against a concurrent process.env write on any JS thread
+// (same reasoning as ROCKSDB_JS_PARK_TIMEOUT_MS).
+uint64_t writeBufferManagerStallWarnMs() {
+	static const uint64_t value = resolveWbmStallWarnMs(::getenv("ROCKSDB_JS_WBM_STALL_WARN_MS"));
+	return value;
+}
+
+napi_status setNumberProperty(napi_env env, napi_value target, const char* key, uint64_t value) {
+	napi_value jsValue;
+	napi_status status = ::napi_create_double(env, static_cast<double>(value), &jsValue);
+	if (status != napi_ok) {
+		return status;
+	}
+	return ::napi_set_named_property(env, target, key, jsValue);
+}
+
+napi_status setBoolProperty(napi_env env, napi_value target, const char* key, bool value) {
+	napi_value jsValue;
+	napi_status status = ::napi_get_boolean(env, value, &jsValue);
+	if (status != napi_ok) {
+		return status;
+	}
+	return ::napi_set_named_property(env, target, key, jsValue);
 }
 
 } // namespace
@@ -92,8 +121,151 @@ std::shared_ptr<rocksdb::WriteBufferManager> DBSettings::getWriteBufferManager()
 			cache,
 			writeBufferManagerAllowStall.load(std::memory_order_relaxed)
 		);
+		writeBufferManagerPtr.store(writeBufferManager.get(), std::memory_order_release);
+	}
+	if (writeBufferManagerAllowStall.load(std::memory_order_relaxed)) {
+		this->ensureWriteBufferManagerWatchdog();
 	}
 	return writeBufferManager;
+}
+
+/**
+ * Starts the stall watchdog if it is not already running. Only a stalling manager
+ * can stall (`WriteBufferManager::ShouldStall` short-circuits on `allow_stall`),
+ * so nothing is started otherwise.
+ *
+ * Thread creation is allowed to fail without taking the caller down with it: this
+ * is an observability feature, and turning thread exhaustion into a failed
+ * `config()` or database open would be strictly worse than losing the warn line.
+ * The failure is visible as `watchdogRunning: false`.
+ */
+void DBSettings::ensureWriteBufferManagerWatchdog() {
+	if (writeBufferManagerStallWarnMs() == 0) {
+		return;
+	}
+	std::lock_guard<std::mutex> lock(this->watchdogMutex);
+	// A stop that has been requested but not yet joined is left to its joiner:
+	// this path runs under databasesMutex (DBRegistry::OpenDB holds it across
+	// DBDescriptor::open), and the watchdog takes databasesMutex to collect its
+	// inventory, so joining here could deadlock against a sample in flight.
+	if (this->watchdogStarted) {
+		return;
+	}
+	this->watchdogStopRequested = false;
+	try {
+		this->watchdogThread = std::thread([this]() { this->runWriteBufferManagerWatchdog(); });
+		this->watchdogStarted = true;
+	} catch (...) {
+		this->watchdogStarted = false;
+		this->writeBufferManagerWatchdogRunning.store(false, std::memory_order_relaxed);
+	}
+}
+
+void DBSettings::requestWriteBufferManagerWatchdogStop() {
+	{
+		std::lock_guard<std::mutex> lock(this->watchdogMutex);
+		this->watchdogStopRequested = true;
+	}
+	this->watchdogCv.notify_all();
+}
+
+void DBSettings::joinWriteBufferManagerWatchdog() {
+	std::thread toJoin;
+	{
+		std::lock_guard<std::mutex> lock(this->watchdogMutex);
+		this->watchdogStopRequested = true;
+		if (this->watchdogStarted) {
+			toJoin = std::move(this->watchdogThread);
+			this->watchdogStarted = false;
+		}
+	}
+	this->watchdogCv.notify_all();
+	if (toJoin.joinable()) {
+		toJoin.join();
+	}
+}
+
+void DBSettings::runWriteBufferManagerWatchdog() {
+	setThreadName("rocksdb-wbm-watchdog");
+	this->writeBufferManagerWatchdogRunning.store(true, std::memory_order_relaxed);
+	const uint64_t thresholdMs = writeBufferManagerStallWarnMs();
+	WbmStallWatchdogState state;
+	std::unique_lock<std::mutex> lock(this->watchdogMutex);
+	while (!this->watchdogStopRequested) {
+		this->watchdogCv.wait_for(lock, std::chrono::milliseconds(WBM_STALL_SAMPLE_INTERVAL_MS));
+		if (this->watchdogStopRequested) {
+			break;
+		}
+		lock.unlock();
+		try {
+			this->sampleWriteBufferManagerStall(state, thresholdMs);
+		} catch (...) {
+			// A report that could not be built (allocation, formatting) must not
+			// take the thread down: the next sample retries.
+		}
+		lock.lock();
+	}
+	this->writeBufferManagerStallActiveMs.store(0, std::memory_order_relaxed);
+	this->writeBufferManagerWatchdogRunning.store(false, std::memory_order_relaxed);
+}
+
+void DBSettings::sampleWriteBufferManagerStall(WbmStallWatchdogState& state, uint64_t thresholdMs) {
+	rocksdb::WriteBufferManager* wbm = this->getWriteBufferManagerRaw();
+	if (wbm == nullptr) {
+		return;
+	}
+	WbmStallWatchdogState::Sample sample = state.onSample(
+		wbm->IsStallActive(), WbmStallWatchdogState::Clock::now(), thresholdMs
+	);
+	this->writeBufferManagerStallActiveMs.store(sample.stallActiveMs, std::memory_order_relaxed);
+	if (!sample.reportNow) {
+		return;
+	}
+
+	WriteBufferManagerStallReport report;
+	report.stallActiveMs = sample.stallActiveMs;
+	report.bufferSize = wbm->buffer_size();
+	report.memoryUsage = wbm->memory_usage();
+	report.mutableMemoryUsage = wbm->mutable_memtable_memory_usage();
+	report.allowStall = this->writeBufferManagerAllowStall.load(std::memory_order_relaxed);
+	report.costToCache = this->writeBufferManagerCostToCache.load(std::memory_order_relaxed);
+	DBRegistry::CollectWriteBufferManagerInventory(
+		wbm, report.columnFamilies, report.maxWriteBufferSizeToMaintain
+	);
+
+	// Formatting and delivery happen after every registry lock is released.
+	std::string line = formatWriteBufferManagerStallReport(report);
+	// stderr is the channel that does not depend on an application having
+	// registered a listener; the event below is the one an application can route.
+	if (::fprintf(stderr, "%s\n", line.c_str()) >= 0) {
+		::fflush(stderr);
+		state.markReported();
+	}
+	emitGlobalEvent("log.warn", ListenerData::fromStrings({ line }));
+}
+
+WriteBufferManagerStats DBSettings::getWriteBufferManagerStats(bool includeColumnFamilies) {
+	WriteBufferManagerStats stats;
+	stats.allowStall = this->writeBufferManagerAllowStall.load(std::memory_order_relaxed);
+	stats.costToCache = this->writeBufferManagerCostToCache.load(std::memory_order_relaxed);
+	stats.watchdogRunning = this->writeBufferManagerWatchdogRunning.load(std::memory_order_relaxed);
+
+	rocksdb::WriteBufferManager* wbm = this->getWriteBufferManagerRaw();
+	if (wbm == nullptr) {
+		return stats;
+	}
+	stats.enabled = true;
+	stats.bufferSize = wbm->buffer_size();
+	stats.memoryUsage = wbm->memory_usage();
+	stats.mutableMemoryUsage = wbm->mutable_memtable_memory_usage();
+	stats.stallActive = wbm->IsStallActive();
+	stats.stallActiveMs = this->writeBufferManagerStallActiveMs.load(std::memory_order_relaxed);
+	if (includeColumnFamilies) {
+		DBRegistry::CollectWriteBufferManagerInventory(
+			wbm, stats.columnFamilies, stats.maxWriteBufferSizeToMaintain
+		);
+	}
+	return stats;
 }
 
 /**
@@ -208,6 +380,12 @@ napi_value DBSettings::Config(napi_env env, napi_callback_info info) {
 		// the RocksDB-supported runtime knob.
 		if (wbmAlreadyCreated && allowStallProvided) {
 			settings.writeBufferManager->SetAllowStall(newAllowStall);
+			if (newAllowStall) {
+				// Stalling was just enabled on a live manager, so the databases
+				// already attached to it can now stall without any further open
+				// to start the watchdog.
+				settings.ensureWriteBufferManagerWatchdog();
+			}
 		}
 	}
 
@@ -233,7 +411,43 @@ napi_value DBSettings::Config(napi_env env, napi_callback_info info) {
 }
 
 /**
- * Exports the `config()` function to JavaScript.
+ * The `getWriteBufferManagerStats()` JavaScript function. Process-wide: the
+ * WriteBufferManager is a singleton shared by every database opened in this
+ * process, including from worker threads.
+ */
+napi_value DBSettings::GetWriteBufferManagerStats(napi_env env, napi_callback_info info) {
+	WriteBufferManagerStats stats = DBSettings::getInstance().getWriteBufferManagerStats(true);
+
+	napi_value result;
+	NAPI_STATUS_THROWS(::napi_create_object(env, &result));
+	NAPI_STATUS_THROWS(setNumberProperty(env, result, "bufferSize", stats.bufferSize));
+	NAPI_STATUS_THROWS(setNumberProperty(env, result, "memoryUsage", stats.memoryUsage));
+	NAPI_STATUS_THROWS(setNumberProperty(env, result, "mutableMemoryUsage", stats.mutableMemoryUsage));
+	NAPI_STATUS_THROWS(setNumberProperty(env, result, "stallActiveMs", stats.stallActiveMs));
+	NAPI_STATUS_THROWS(setNumberProperty(env, result, "columnFamilies", stats.columnFamilies));
+	NAPI_STATUS_THROWS(setBoolProperty(env, result, "enabled", stats.enabled));
+	NAPI_STATUS_THROWS(setBoolProperty(env, result, "allowStall", stats.allowStall));
+	NAPI_STATUS_THROWS(setBoolProperty(env, result, "costToCache", stats.costToCache));
+	NAPI_STATUS_THROWS(setBoolProperty(env, result, "stallActive", stats.stallActive));
+	NAPI_STATUS_THROWS(setBoolProperty(env, result, "watchdogRunning", stats.watchdogRunning));
+
+	napi_value targets;
+	NAPI_STATUS_THROWS(::napi_create_object(env, &targets));
+	for (const auto& [target, count] : stats.maxWriteBufferSizeToMaintain) {
+		napi_value countValue;
+		NAPI_STATUS_THROWS(::napi_create_int64(env, static_cast<int64_t>(count), &countValue));
+		NAPI_STATUS_THROWS(::napi_set_named_property(
+			env, targets, std::to_string(target).c_str(), countValue
+		));
+	}
+	NAPI_STATUS_THROWS(::napi_set_named_property(env, result, "maxWriteBufferSizeToMaintain", targets));
+
+	return result;
+}
+
+/**
+ * Exports the `config()` and `getWriteBufferManagerStats()` functions to
+ * JavaScript.
  *
  * @param env The Node.js environment.
  * @param exports The exports object.
@@ -250,6 +464,19 @@ void DBSettings::Init(napi_env env, napi_value exports) {
 	));
 
 	NAPI_STATUS_THROWS_VOID(::napi_set_named_property(env, exports, "config", configFn));
+
+	napi_value wbmStatsFn;
+	NAPI_STATUS_THROWS_VOID(::napi_create_function(
+		env,
+		"getWriteBufferManagerStats",
+		NAPI_AUTO_LENGTH,
+		DBSettings::GetWriteBufferManagerStats,
+		nullptr,
+		&wbmStatsFn
+	));
+	NAPI_STATUS_THROWS_VOID(
+		::napi_set_named_property(env, exports, "getWriteBufferManagerStats", wbmStatsFn)
+	);
 }
 
 }

--- a/src/binding/database/db_settings.cpp
+++ b/src/binding/database/db_settings.cpp
@@ -376,6 +376,7 @@ napi_value DBSettings::Config(napi_env env, napi_callback_info info) {
 	// consistent view of the manager. Throwing happens before any state
 	// mutation, so a rejected costToCache change leaves the live manager
 	// untouched.
+	bool retireWatchdog = false;
 	{
 		std::lock_guard<std::mutex> lock(settings.writeBufferManagerMutex);
 		const bool wbmAlreadyCreated = (settings.writeBufferManager != nullptr);
@@ -416,9 +417,17 @@ napi_value DBSettings::Config(napi_env env, napi_callback_info info) {
 			} else {
 				// Nothing can stall any more, so the thread would poll forever and
 				// report watchdogRunning against allowStall: false.
-				settings.joinWriteBufferManagerWatchdog();
+				retireWatchdog = true;
 			}
 		}
+	}
+
+	// Joined outside the critical section: the watchdog's report path writes to
+	// stderr, which blocks on a full pipe, and every DBDescriptor::open needs
+	// writeBufferManagerMutex. Same split, and the same reason, as the teardown
+	// path in binding.cpp.
+	if (retireWatchdog) {
+		settings.joinWriteBufferManagerWatchdog();
 	}
 
 	NAPI_STATUS_THROWS(rocksdb_js::getProperty(env, params, "compactOnClose", settings.compactOnClose, false));

--- a/src/binding/database/db_settings.cpp
+++ b/src/binding/database/db_settings.cpp
@@ -173,6 +173,16 @@ void DBSettings::ensureWriteBufferManagerWatchdog() {
 		// Set here, not on the new thread: a caller that enables stalling and reads
 		// back immediately must not be told the watchdog is absent.
 		this->writeBufferManagerWatchdogRunning.store(true, std::memory_order_relaxed);
+		if (!this->watchdogAtexitRegistered) {
+			// Registered while the thread starts, so on the process.exit() path
+			// (which skips the module cleanup hook) the join runs ahead of every
+			// static destructor registered earlier — DBRegistry's among them, since
+			// its instance is a class static registered before main while this
+			// object is first touched by config(). ~DBSettings stays as the
+			// backstop; both calls are idempotent.
+			this->watchdogAtexitRegistered =
+				::atexit([]() { DBSettings::getInstance().joinWriteBufferManagerWatchdog(); }) == 0;
+		}
 	} catch (...) {
 		this->watchdogStarted = false;
 		this->writeBufferManagerWatchdogRunning.store(false, std::memory_order_relaxed);

--- a/src/binding/database/db_settings.cpp
+++ b/src/binding/database/db_settings.cpp
@@ -164,6 +164,7 @@ void DBSettings::ensureWriteBufferManagerWatchdog() {
 		return;
 	}
 	this->watchdogStopRequested = false;
+	this->writeBufferManagerWatchdogStopping.store(false, std::memory_order_relaxed);
 	const uint64_t generation = ++this->watchdogGeneration;
 	try {
 		this->watchdogThread =
@@ -182,6 +183,7 @@ void DBSettings::requestWriteBufferManagerWatchdogStop() {
 	{
 		std::lock_guard<std::mutex> lock(this->watchdogMutex);
 		this->watchdogStopRequested = true;
+		this->writeBufferManagerWatchdogStopping.store(true, std::memory_order_relaxed);
 	}
 	this->watchdogCv.notify_all();
 }
@@ -191,6 +193,7 @@ void DBSettings::joinWriteBufferManagerWatchdog() {
 	{
 		std::lock_guard<std::mutex> lock(this->watchdogMutex);
 		this->watchdogStopRequested = true;
+		this->writeBufferManagerWatchdogStopping.store(true, std::memory_order_relaxed);
 		if (this->watchdogStarted) {
 			toJoin = std::move(this->watchdogThread);
 			this->watchdogStarted = false;
@@ -239,7 +242,8 @@ void DBSettings::sampleWriteBufferManagerStall(WbmStallWatchdogState& state, uin
 		wbm->IsStallActive(), WbmStallWatchdogState::Clock::now(), thresholdMs
 	);
 	this->writeBufferManagerStallActiveMs.store(sample.stallActiveMs, std::memory_order_relaxed);
-	if (!sample.reportNow) {
+	if (!sample.reportNow ||
+		this->writeBufferManagerWatchdogStopping.load(std::memory_order_relaxed)) {
 		return;
 	}
 
@@ -428,6 +432,15 @@ napi_value DBSettings::Config(napi_env env, napi_callback_info info) {
 	// path in binding.cpp.
 	if (retireWatchdog) {
 		settings.joinWriteBufferManagerWatchdog();
+		// Reconcile against the state that is actually current, not this call's
+		// own argument: another env re-enabling stalling in the unlocked window
+		// above would have found the thread still started and declined to start
+		// one, leaving allowStall on with no alarm behind it.
+		std::lock_guard<std::mutex> lock(settings.writeBufferManagerMutex);
+		if (settings.writeBufferManagerAllowStall.load(std::memory_order_relaxed) &&
+			settings.writeBufferManager) {
+			settings.ensureWriteBufferManagerWatchdog();
+		}
 	}
 
 	NAPI_STATUS_THROWS(rocksdb_js::getProperty(env, params, "compactOnClose", settings.compactOnClose, false));

--- a/src/binding/database/db_settings.cpp
+++ b/src/binding/database/db_settings.cpp
@@ -169,6 +169,9 @@ void DBSettings::ensureWriteBufferManagerWatchdog() {
 		this->watchdogThread =
 			std::thread([this, generation]() { this->runWriteBufferManagerWatchdog(generation); });
 		this->watchdogStarted = true;
+		// Set here, not on the new thread: a caller that enables stalling and reads
+		// back immediately must not be told the watchdog is absent.
+		this->writeBufferManagerWatchdogRunning.store(true, std::memory_order_relaxed);
 	} catch (...) {
 		this->watchdogStarted = false;
 		this->writeBufferManagerWatchdogRunning.store(false, std::memory_order_relaxed);
@@ -201,7 +204,6 @@ void DBSettings::joinWriteBufferManagerWatchdog() {
 
 void DBSettings::runWriteBufferManagerWatchdog(uint64_t generation) {
 	setThreadName("rocksdb-wbm-watchdog");
-	this->writeBufferManagerWatchdogRunning.store(true, std::memory_order_relaxed);
 	const uint64_t thresholdMs = writeBufferManagerStallWarnMs();
 	WbmStallWatchdogState state;
 	std::unique_lock<std::mutex> lock(this->watchdogMutex);
@@ -408,10 +410,13 @@ napi_value DBSettings::Config(napi_env env, napi_callback_info info) {
 		if (wbmAlreadyCreated && allowStallProvided) {
 			settings.writeBufferManager->SetAllowStall(newAllowStall);
 			if (newAllowStall) {
-				// Stalling was just enabled on a live manager, so the databases
-				// already attached to it can now stall without any further open
-				// to start the watchdog.
+				// The databases already attached can stall from here on, with no
+				// further open to start the watchdog.
 				settings.ensureWriteBufferManagerWatchdog();
+			} else {
+				// Nothing can stall any more, so the thread would poll forever and
+				// report watchdogRunning against allowStall: false.
+				settings.joinWriteBufferManagerWatchdog();
 			}
 		}
 	}

--- a/src/binding/database/db_settings.cpp
+++ b/src/binding/database/db_settings.cpp
@@ -1,10 +1,7 @@
 #include "database/db_settings.h"
-#include <cstdio>
 #include <random>
+#include "database/db_stats.h"
 #include "napi/macros.h"
-#include "core/platform.h"
-#include "database/db_registry.h"
-#include "napi/global_events.h"
 #include "napi/helpers.h"
 #include "napi/async.h"
 #include "rocksdb/advanced_cache.h"
@@ -18,44 +15,6 @@ uint64_t generateSeed() {
 	uint64_t hi = static_cast<uint64_t>(rd());
 	uint64_t lo = static_cast<uint64_t>(rd());
 	return (hi << 32) | lo;
-}
-
-// Resolved once per process: the watchdog runs on its own thread, and ::getenv
-// there is not safe against a concurrent process.env write on any JS thread
-// (same reasoning as ROCKSDB_JS_PARK_TIMEOUT_MS).
-uint64_t writeBufferManagerStallWarnMs() {
-	static const uint64_t value = [] {
-		const char* raw = ::getenv("ROCKSDB_JS_WBM_STALL_WARN_MS");
-		bool rejected = false;
-		uint64_t resolved = resolveWbmStallWarnMs(raw, &rejected);
-		if (rejected) {
-			::fprintf(stderr,
-				"[rocksdb-js] ignoring ROCKSDB_JS_WBM_STALL_WARN_MS=\"%s\" (not an integer in "
-				"[0, %llu] ms); using %llu\n",
-				raw, static_cast<unsigned long long>(WBM_STALL_WARN_MS_MAX),
-				static_cast<unsigned long long>(resolved));
-		}
-		return resolved;
-	}();
-	return value;
-}
-
-napi_status setNumberProperty(napi_env env, napi_value target, const char* key, uint64_t value) {
-	napi_value jsValue;
-	napi_status status = ::napi_create_double(env, static_cast<double>(value), &jsValue);
-	if (status != napi_ok) {
-		return status;
-	}
-	return ::napi_set_named_property(env, target, key, jsValue);
-}
-
-napi_status setBoolProperty(napi_env env, napi_value target, const char* key, bool value) {
-	napi_value jsValue;
-	napi_status status = ::napi_get_boolean(env, value, &jsValue);
-	if (status != napi_ok) {
-		return status;
-	}
-	return ::napi_set_named_property(env, target, key, jsValue);
 }
 
 } // namespace
@@ -133,182 +92,12 @@ std::shared_ptr<rocksdb::WriteBufferManager> DBSettings::getWriteBufferManager()
 			cache,
 			writeBufferManagerAllowStall.load(std::memory_order_relaxed)
 		);
-		writeBufferManagerPtr.store(writeBufferManager.get(), std::memory_order_release);
+		DBStats::getInstance().publishWriteBufferManager(writeBufferManager.get());
 	}
 	if (writeBufferManagerAllowStall.load(std::memory_order_relaxed)) {
-		this->ensureWriteBufferManagerWatchdog();
+		DBStats::getInstance().ensureWriteBufferManagerWatchdog();
 	}
 	return writeBufferManager;
-}
-
-/**
- * Starts the stall watchdog if it is not already running. Only a stalling manager
- * can stall (`WriteBufferManager::ShouldStall` short-circuits on `allow_stall`),
- * so nothing is started otherwise.
- *
- * Thread creation is allowed to fail without taking the caller down with it: this
- * is an observability feature, and turning thread exhaustion into a failed
- * `config()` or database open would be strictly worse than losing the warn line.
- * The failure is visible as `watchdogRunning: false`.
- */
-void DBSettings::ensureWriteBufferManagerWatchdog() {
-	if (writeBufferManagerStallWarnMs() == 0) {
-		return;
-	}
-	std::lock_guard<std::mutex> lock(this->watchdogMutex);
-	// A stop that has been requested but not yet joined is left to its joiner:
-	// this path runs under databasesMutex (DBRegistry::OpenDB holds it across
-	// DBDescriptor::open), and the watchdog takes databasesMutex to collect its
-	// inventory, so joining here could deadlock against a sample in flight.
-	if (this->watchdogStarted) {
-		return;
-	}
-	this->watchdogStopRequested = false;
-	this->writeBufferManagerWatchdogStopping.store(false, std::memory_order_relaxed);
-	const uint64_t generation = ++this->watchdogGeneration;
-	try {
-		this->watchdogThread =
-			std::thread([this, generation]() { this->runWriteBufferManagerWatchdog(generation); });
-		this->watchdogStarted = true;
-		// Set here, not on the new thread: a caller that enables stalling and reads
-		// back immediately must not be told the watchdog is absent.
-		this->writeBufferManagerWatchdogRunning.store(true, std::memory_order_relaxed);
-		if (!this->watchdogAtexitRegistered) {
-			// Registered while the thread starts, so on the process.exit() path
-			// (which skips the module cleanup hook) the join runs ahead of every
-			// static destructor registered earlier — DBRegistry's among them, since
-			// its instance is a class static registered before main while this
-			// object is first touched by config(). ~DBSettings stays as the
-			// backstop; both calls are idempotent.
-			this->watchdogAtexitRegistered =
-				::atexit([]() { DBSettings::getInstance().joinWriteBufferManagerWatchdog(); }) == 0;
-		}
-	} catch (...) {
-		this->watchdogStarted = false;
-		this->writeBufferManagerWatchdogRunning.store(false, std::memory_order_relaxed);
-	}
-}
-
-void DBSettings::requestWriteBufferManagerWatchdogStop() {
-	{
-		std::lock_guard<std::mutex> lock(this->watchdogMutex);
-		this->watchdogStopRequested = true;
-		this->writeBufferManagerWatchdogStopping.store(true, std::memory_order_relaxed);
-	}
-	this->watchdogCv.notify_all();
-}
-
-void DBSettings::joinWriteBufferManagerWatchdog() {
-	std::thread toJoin;
-	{
-		std::lock_guard<std::mutex> lock(this->watchdogMutex);
-		this->watchdogStopRequested = true;
-		this->writeBufferManagerWatchdogStopping.store(true, std::memory_order_relaxed);
-		if (this->watchdogStarted) {
-			toJoin = std::move(this->watchdogThread);
-			this->watchdogStarted = false;
-		}
-	}
-	this->watchdogCv.notify_all();
-	if (toJoin.joinable()) {
-		toJoin.join();
-	}
-}
-
-void DBSettings::runWriteBufferManagerWatchdog(uint64_t generation) {
-	setThreadName("rocksdb-wbm-watchdog");
-	const uint64_t thresholdMs = writeBufferManagerStallWarnMs();
-	WbmStallWatchdogState state;
-	std::unique_lock<std::mutex> lock(this->watchdogMutex);
-	auto retired = [&] {
-		return this->watchdogStopRequested || this->watchdogGeneration != generation;
-	};
-	while (!retired()) {
-		this->watchdogCv.wait_for(lock, std::chrono::milliseconds(WBM_STALL_SAMPLE_INTERVAL_MS));
-		if (retired()) {
-			break;
-		}
-		lock.unlock();
-		try {
-			this->sampleWriteBufferManagerStall(state, thresholdMs);
-		} catch (...) {
-			// A report that could not be built (allocation, formatting) must not
-			// take the thread down: the next sample retries.
-		}
-		lock.lock();
-	}
-	if (this->watchdogGeneration == generation) {
-		this->writeBufferManagerStallActiveMs.store(0, std::memory_order_relaxed);
-		this->writeBufferManagerWatchdogRunning.store(false, std::memory_order_relaxed);
-	}
-}
-
-void DBSettings::sampleWriteBufferManagerStall(WbmStallWatchdogState& state, uint64_t thresholdMs) {
-	rocksdb::WriteBufferManager* wbm = this->getWriteBufferManagerRaw();
-	if (wbm == nullptr) {
-		return;
-	}
-	WbmStallWatchdogState::Sample sample = state.onSample(
-		wbm->IsStallActive(), WbmStallWatchdogState::Clock::now(), thresholdMs
-	);
-	this->writeBufferManagerStallActiveMs.store(sample.stallActiveMs, std::memory_order_relaxed);
-	if (!sample.reportNow ||
-		this->writeBufferManagerWatchdogStopping.load(std::memory_order_relaxed)) {
-		return;
-	}
-
-	WriteBufferManagerStallReport report;
-	report.stallActiveMs = sample.stallActiveMs;
-	report.bufferSize = wbm->buffer_size();
-	report.memoryUsage = wbm->memory_usage();
-	report.mutableMemoryUsage = wbm->mutable_memtable_memory_usage();
-	report.allowStall = this->writeBufferManagerAllowStall.load(std::memory_order_relaxed);
-	report.costToCache = this->writeBufferManagerCostToCache.load(std::memory_order_relaxed);
-	report.inventoryAvailable = DBRegistry::CollectWriteBufferManagerInventory(
-		wbm, report.columnFamilies, report.maxWriteBufferSizeToMaintain
-	);
-
-	std::string line = formatWriteBufferManagerStallReport(report);
-	// stderr does not depend on an application having registered a listener; the
-	// event is the one an application can route. The episode is retired once
-	// either has carried it — gating on stderr alone would re-report every second
-	// for the whole stall when fd 2 is closed but a listener is attached.
-	const bool wroteToStderr = ::fprintf(stderr, "%s\n", line.c_str()) >= 0;
-	if (wroteToStderr) {
-		::fflush(stderr);
-	}
-	const bool emitted = emitGlobalEvent("log.warn", ListenerData::fromStrings({ line }));
-	if (wroteToStderr || emitted) {
-		state.markReported();
-	}
-}
-
-WriteBufferManagerStats DBSettings::getWriteBufferManagerStats(bool includeColumnFamilies) {
-	WriteBufferManagerStats stats;
-	stats.allowStall = this->writeBufferManagerAllowStall.load(std::memory_order_relaxed);
-	stats.costToCache = this->writeBufferManagerCostToCache.load(std::memory_order_relaxed);
-	stats.watchdogRunning = this->writeBufferManagerWatchdogRunning.load(std::memory_order_relaxed);
-
-	rocksdb::WriteBufferManager* wbm = this->getWriteBufferManagerRaw();
-	if (wbm == nullptr) {
-		return stats;
-	}
-	stats.enabled = true;
-	stats.bufferSize = wbm->buffer_size();
-	stats.memoryUsage = wbm->memory_usage();
-	stats.mutableMemoryUsage = wbm->mutable_memtable_memory_usage();
-	stats.stallActive = wbm->IsStallActive();
-	stats.stallActiveMs = this->writeBufferManagerStallActiveMs.load(std::memory_order_relaxed);
-	if (includeColumnFamilies) {
-		stats.inventoryAvailable = DBRegistry::CollectWriteBufferManagerInventory(
-			wbm, stats.columnFamilies, stats.maxWriteBufferSizeToMaintain
-		);
-	}
-	return stats;
-}
-
-DBSettings::~DBSettings() {
-	this->joinWriteBufferManagerWatchdog();
 }
 
 /**
@@ -425,12 +214,8 @@ napi_value DBSettings::Config(napi_env env, napi_callback_info info) {
 		if (wbmAlreadyCreated && allowStallProvided) {
 			settings.writeBufferManager->SetAllowStall(newAllowStall);
 			if (newAllowStall) {
-				// The databases already attached can stall from here on, with no
-				// further open to start the watchdog.
-				settings.ensureWriteBufferManagerWatchdog();
+				DBStats::getInstance().ensureWriteBufferManagerWatchdog();
 			} else {
-				// Nothing can stall any more, so the thread would poll forever and
-				// report watchdogRunning against allowStall: false.
 				retireWatchdog = true;
 			}
 		}
@@ -441,7 +226,7 @@ napi_value DBSettings::Config(napi_env env, napi_callback_info info) {
 	// writeBufferManagerMutex. Same split, and the same reason, as the teardown
 	// path in binding.cpp.
 	if (retireWatchdog) {
-		settings.joinWriteBufferManagerWatchdog();
+		DBStats::getInstance().joinWriteBufferManagerWatchdog();
 		// Reconcile against the state that is actually current, not this call's
 		// own argument: another env re-enabling stalling in the unlocked window
 		// above would have found the thread still started and declined to start
@@ -449,7 +234,7 @@ napi_value DBSettings::Config(napi_env env, napi_callback_info info) {
 		std::lock_guard<std::mutex> lock(settings.writeBufferManagerMutex);
 		if (settings.writeBufferManagerAllowStall.load(std::memory_order_relaxed) &&
 			settings.writeBufferManager) {
-			settings.ensureWriteBufferManagerWatchdog();
+			DBStats::getInstance().ensureWriteBufferManagerWatchdog();
 		}
 	}
 
@@ -475,44 +260,7 @@ napi_value DBSettings::Config(napi_env env, napi_callback_info info) {
 }
 
 /**
- * The `getWriteBufferManagerStats()` JavaScript function. Process-wide: the
- * WriteBufferManager is a singleton shared by every database opened in this
- * process, including from worker threads.
- */
-napi_value DBSettings::GetWriteBufferManagerStats(napi_env env, napi_callback_info info) {
-	WriteBufferManagerStats stats = DBSettings::getInstance().getWriteBufferManagerStats(true);
-
-	napi_value result;
-	NAPI_STATUS_THROWS(::napi_create_object(env, &result));
-	NAPI_STATUS_THROWS(setNumberProperty(env, result, "bufferSize", stats.bufferSize));
-	NAPI_STATUS_THROWS(setNumberProperty(env, result, "memoryUsage", stats.memoryUsage));
-	NAPI_STATUS_THROWS(setNumberProperty(env, result, "mutableMemoryUsage", stats.mutableMemoryUsage));
-	NAPI_STATUS_THROWS(setNumberProperty(env, result, "stallActiveMs", stats.stallActiveMs));
-	NAPI_STATUS_THROWS(setNumberProperty(env, result, "columnFamilies", stats.columnFamilies));
-	NAPI_STATUS_THROWS(setBoolProperty(env, result, "enabled", stats.enabled));
-	NAPI_STATUS_THROWS(setBoolProperty(env, result, "allowStall", stats.allowStall));
-	NAPI_STATUS_THROWS(setBoolProperty(env, result, "costToCache", stats.costToCache));
-	NAPI_STATUS_THROWS(setBoolProperty(env, result, "stallActive", stats.stallActive));
-	NAPI_STATUS_THROWS(setBoolProperty(env, result, "watchdogRunning", stats.watchdogRunning));
-	NAPI_STATUS_THROWS(setBoolProperty(env, result, "inventoryAvailable", stats.inventoryAvailable));
-
-	napi_value targets;
-	NAPI_STATUS_THROWS(::napi_create_object(env, &targets));
-	for (const auto& [target, count] : stats.maxWriteBufferSizeToMaintain) {
-		napi_value countValue;
-		NAPI_STATUS_THROWS(::napi_create_int64(env, static_cast<int64_t>(count), &countValue));
-		NAPI_STATUS_THROWS(::napi_set_named_property(
-			env, targets, std::to_string(target).c_str(), countValue
-		));
-	}
-	NAPI_STATUS_THROWS(::napi_set_named_property(env, result, "maxWriteBufferSizeToMaintain", targets));
-
-	return result;
-}
-
-/**
- * Exports the `config()` and `getWriteBufferManagerStats()` functions to
- * JavaScript.
+ * Exports the `config()` function to JavaScript.
  *
  * @param env The Node.js environment.
  * @param exports The exports object.
@@ -529,19 +277,6 @@ void DBSettings::Init(napi_env env, napi_value exports) {
 	));
 
 	NAPI_STATUS_THROWS_VOID(::napi_set_named_property(env, exports, "config", configFn));
-
-	napi_value wbmStatsFn;
-	NAPI_STATUS_THROWS_VOID(::napi_create_function(
-		env,
-		"getWriteBufferManagerStats",
-		NAPI_AUTO_LENGTH,
-		DBSettings::GetWriteBufferManagerStats,
-		nullptr,
-		&wbmStatsFn
-	));
-	NAPI_STATUS_THROWS_VOID(
-		::napi_set_named_property(env, exports, "getWriteBufferManagerStats", wbmStatsFn)
-	);
 }
 
 }

--- a/src/binding/database/db_settings.cpp
+++ b/src/binding/database/db_settings.cpp
@@ -179,7 +179,6 @@ napi_value DBSettings::Config(napi_env env, napi_callback_info info) {
 	// consistent view of the manager. Throwing happens before any state
 	// mutation, so a rejected costToCache change leaves the live manager
 	// untouched.
-	bool retireWatchdog = false;
 	{
 		std::lock_guard<std::mutex> lock(settings.writeBufferManagerMutex);
 		const bool wbmAlreadyCreated = (settings.writeBufferManager != nullptr);
@@ -216,25 +215,8 @@ napi_value DBSettings::Config(napi_env env, napi_callback_info info) {
 			if (newAllowStall) {
 				DBStats::getInstance().ensureWriteBufferManagerWatchdog();
 			} else {
-				retireWatchdog = true;
+				DBStats::getInstance().disableWriteBufferManagerWatchdog();
 			}
-		}
-	}
-
-	// Joined outside the critical section: the watchdog's report path writes to
-	// stderr, which blocks on a full pipe, and every DBDescriptor::open needs
-	// writeBufferManagerMutex. Same split, and the same reason, as the teardown
-	// path in binding.cpp.
-	if (retireWatchdog) {
-		DBStats::getInstance().joinWriteBufferManagerWatchdog();
-		// Reconcile against the state that is actually current, not this call's
-		// own argument: another env re-enabling stalling in the unlocked window
-		// above would have found the thread still started and declined to start
-		// one, leaving allowStall on with no alarm behind it.
-		std::lock_guard<std::mutex> lock(settings.writeBufferManagerMutex);
-		if (settings.writeBufferManagerAllowStall.load(std::memory_order_relaxed) &&
-			settings.writeBufferManager) {
-			DBStats::getInstance().ensureWriteBufferManagerWatchdog();
 		}
 	}
 

--- a/src/binding/database/db_settings.h
+++ b/src/binding/database/db_settings.h
@@ -35,6 +35,12 @@ struct WriteBufferManagerStats final {
 	bool watchdogRunning = false;
 	uint64_t columnFamilies = 0;
 	std::map<int64_t, uint64_t> maxWriteBufferSizeToMaintain;
+	/**
+	 * False when the registry lock was held by a close that is itself wedged on
+	 * the stall being diagnosed, so the two fields above are empty rather than
+	 * measured. A diagnostic that blocks on that lock answers nothing at all.
+	 */
+	bool inventoryAvailable = true;
 };
 
 /**
@@ -98,9 +104,14 @@ private:
 	std::condition_variable watchdogCv;
 	bool watchdogStarted = false;
 	bool watchdogStopRequested = false;
+	// Bumped on every start. A thread whose generation is stale exits even if a
+	// new start has already cleared `watchdogStopRequested`: the joiner releases
+	// watchdogMutex before `join()`, so without this the retiring thread can
+	// observe the reset flag and loop forever with its joiner blocked on it.
+	uint64_t watchdogGeneration = 0;
 
 	void ensureWriteBufferManagerWatchdog();
-	void runWriteBufferManagerWatchdog();
+	void runWriteBufferManagerWatchdog(uint64_t generation);
 	void sampleWriteBufferManagerStall(WbmStallWatchdogState& state, uint64_t thresholdMs);
 
 	bool compactOnClose;
@@ -176,6 +187,14 @@ public:
 
 	/** Joins the stall watchdog. Idempotent, and restartable afterwards. */
 	void joinWriteBufferManagerWatchdog();
+
+	/**
+	 * Joins the watchdog if the module's cleanup hook never ran. `process.exit()`
+	 * skips N-API env cleanup, and destroying a joinable `std::thread` calls
+	 * `std::terminate()` — an observability feature must not turn a clean exit
+	 * into SIGABRT. Mirrors `~CommitWorker`.
+	 */
+	~DBSettings();
 
 	inline bool getCompactOnClose() const {
 		return compactOnClose;

--- a/src/binding/database/db_settings.h
+++ b/src/binding/database/db_settings.h
@@ -1,14 +1,41 @@
 #ifndef __DB_SETTINGS_H__
 #define __DB_SETTINGS_H__
 
+#include <atomic>
+#include <condition_variable>
+#include <map>
 #include <memory>
 #include <mutex>
 #include <node_api.h>
+#include <thread>
 #include "rocksdb/cache.h"
 #include "rocksdb/write_buffer_manager.h"
 #include "core/verification_table.h"
+#include "core/wbm_stall_watchdog.h"
 
 namespace rocksdb_js {
+
+/**
+ * Live state of the process-wide `WriteBufferManager`, as reported by
+ * `db.getStats()` / `db.getStat()` and `RocksDatabase.getWriteBufferManagerStats()`.
+ *
+ * The column-family inventory is filled in only when the caller asks for it: it
+ * walks the database registry, while everything above it is a handful of atomic
+ * loads. `getStats()` is a scrape path and takes the cheap half.
+ */
+struct WriteBufferManagerStats final {
+	bool enabled = false;
+	uint64_t bufferSize = 0;
+	uint64_t memoryUsage = 0;
+	uint64_t mutableMemoryUsage = 0;
+	bool allowStall = false;
+	bool costToCache = false;
+	bool stallActive = false;
+	uint64_t stallActiveMs = 0;
+	bool watchdogRunning = false;
+	uint64_t columnFamilies = 0;
+	std::map<int64_t, uint64_t> maxWriteBufferSizeToMaintain;
+};
 
 /**
  * Stores the global settings for RocksDB databases as well as various global
@@ -47,6 +74,34 @@ private:
 
 	std::shared_ptr<rocksdb::WriteBufferManager> writeBufferManager;
 	std::mutex writeBufferManagerMutex;
+
+	// The manager, published with release ordering once it is fully constructed
+	// and never reset — a runtime `writeBufferManagerSize: 0` is a "no new
+	// attachments" signal, not a teardown, so the raw pointer stays valid for the
+	// process lifetime. Read paths take one acquire load instead of
+	// writeBufferManagerMutex: a metrics scrape must not contend with config()
+	// or a database open.
+	std::atomic<rocksdb::WriteBufferManager*> writeBufferManagerPtr{nullptr};
+
+	// Published by the watchdog thread each sample; 0 when no stall is active.
+	std::atomic<uint64_t> writeBufferManagerStallActiveMs{0};
+	std::atomic<bool> writeBufferManagerWatchdogRunning{false};
+
+	// Watchdog lifecycle. The start path runs under databasesMutex ->
+	// writeBufferManagerMutex (DBRegistry::OpenDB holds the former across
+	// DBDescriptor::open), so watchdogMutex is the innermost lock and the
+	// watchdog thread must never hold it while taking either of the other two —
+	// it drops watchdogMutex before every sample, and the sample's inventory walk
+	// is the one place it takes databasesMutex.
+	std::thread watchdogThread;
+	std::mutex watchdogMutex;
+	std::condition_variable watchdogCv;
+	bool watchdogStarted = false;
+	bool watchdogStopRequested = false;
+
+	void ensureWriteBufferManagerWatchdog();
+	void runWriteBufferManagerWatchdog();
+	void sampleWriteBufferManagerStall(WbmStallWatchdogState& state, uint64_t thresholdMs);
 
 	bool compactOnClose;
 
@@ -94,6 +149,34 @@ public:
 
 	std::shared_ptr<rocksdb::WriteBufferManager> getWriteBufferManager();
 
+	/**
+	 * Returns the manager if one has already been created, without creating it.
+	 * Lock-free and safe from any thread — a stats read must never materialize
+	 * the manager as a side effect (the peer of `getVerificationTableRaw()`,
+	 * without its mutex).
+	 */
+	rocksdb::WriteBufferManager* getWriteBufferManagerRaw() const {
+		return this->writeBufferManagerPtr.load(std::memory_order_acquire);
+	}
+
+	/**
+	 * Samples the manager's live state. `includeColumnFamilies` additionally walks
+	 * the database registry for the attached, writable column-family inventory,
+	 * which is O(open column families) — leave it off on scrape paths.
+	 */
+	WriteBufferManagerStats getWriteBufferManagerStats(bool includeColumnFamilies);
+
+	/**
+	 * Signals the stall watchdog to stop without waiting for it. Split from the
+	 * join so teardown can shut databases down (and flush) while the watchdog is
+	 * still winding down: its warn line goes to stderr, which can block on a full
+	 * pipe, and a logging stall must never sit in front of the flush path.
+	 */
+	void requestWriteBufferManagerWatchdogStop();
+
+	/** Joins the stall watchdog. Idempotent, and restartable afterwards. */
+	void joinWriteBufferManagerWatchdog();
+
 	inline bool getCompactOnClose() const {
 		return compactOnClose;
 	}
@@ -116,6 +199,8 @@ public:
 	VerificationTable* getVerificationTableRaw();
 
 	static napi_value Config(napi_env env, napi_callback_info info);
+
+	static napi_value GetWriteBufferManagerStats(napi_env env, napi_callback_info info);
 
 	static void Init(napi_env env, napi_value exports);
 };

--- a/src/binding/database/db_settings.h
+++ b/src/binding/database/db_settings.h
@@ -113,6 +113,7 @@ private:
 	// watchdogMutex before `join()`, so without this the retiring thread can
 	// observe the reset flag and loop forever with its joiner blocked on it.
 	uint64_t watchdogGeneration = 0;
+	bool watchdogAtexitRegistered = false;
 
 	void ensureWriteBufferManagerWatchdog();
 	void runWriteBufferManagerWatchdog(uint64_t generation);
@@ -193,10 +194,11 @@ public:
 	void joinWriteBufferManagerWatchdog();
 
 	/**
-	 * Joins the watchdog if the module's cleanup hook never ran. `process.exit()`
-	 * skips N-API env cleanup, and destroying a joinable `std::thread` calls
-	 * `std::terminate()` — an observability feature must not turn a clean exit
-	 * into SIGABRT. Mirrors `~CommitWorker`.
+	 * Joins the watchdog if neither the module's cleanup hook nor the `atexit`
+	 * handler registered at watchdog start ran. `process.exit()` skips N-API env
+	 * cleanup, and destroying a joinable `std::thread` calls `std::terminate()` —
+	 * an observability feature must not turn a clean exit into SIGABRT. Mirrors
+	 * `~CommitWorker`.
 	 */
 	~DBSettings();
 

--- a/src/binding/database/db_settings.h
+++ b/src/binding/database/db_settings.h
@@ -89,7 +89,6 @@ private:
 	// or a database open.
 	std::atomic<rocksdb::WriteBufferManager*> writeBufferManagerPtr{nullptr};
 
-	// Published by the watchdog thread each sample; 0 when no stall is active.
 	std::atomic<uint64_t> writeBufferManagerStallActiveMs{0};
 	std::atomic<bool> writeBufferManagerWatchdogRunning{false};
 

--- a/src/binding/database/db_settings.h
+++ b/src/binding/database/db_settings.h
@@ -91,6 +91,11 @@ private:
 
 	std::atomic<uint64_t> writeBufferManagerStallActiveMs{0};
 	std::atomic<bool> writeBufferManagerWatchdogRunning{false};
+	// Lock-free mirror of watchdogStopRequested, so the sample path can abandon a
+	// report before writing it. The report's stderr write is unbounded on a full
+	// pipe and a joiner waits behind it; this bounds that wait to a write already
+	// in progress rather than one about to start.
+	std::atomic<bool> writeBufferManagerWatchdogStopping{false};
 
 	// Watchdog lifecycle. The start path runs under databasesMutex ->
 	// writeBufferManagerMutex (DBRegistry::OpenDB holds the former across

--- a/src/binding/database/db_settings.h
+++ b/src/binding/database/db_settings.h
@@ -2,46 +2,14 @@
 #define __DB_SETTINGS_H__
 
 #include <atomic>
-#include <condition_variable>
-#include <map>
 #include <memory>
 #include <mutex>
 #include <node_api.h>
-#include <thread>
 #include "rocksdb/cache.h"
 #include "rocksdb/write_buffer_manager.h"
 #include "core/verification_table.h"
-#include "core/wbm_stall_watchdog.h"
 
 namespace rocksdb_js {
-
-/**
- * Live state of the process-wide `WriteBufferManager`, as reported by
- * `db.getStats()` / `db.getStat()` and `RocksDatabase.getWriteBufferManagerStats()`.
- *
- * The column-family inventory is filled in only when the caller asks for it: it
- * walks the database registry, while everything above it is a handful of atomic
- * loads. `getStats()` is a scrape path and takes the cheap half.
- */
-struct WriteBufferManagerStats final {
-	bool enabled = false;
-	uint64_t bufferSize = 0;
-	uint64_t memoryUsage = 0;
-	uint64_t mutableMemoryUsage = 0;
-	bool allowStall = false;
-	bool costToCache = false;
-	bool stallActive = false;
-	uint64_t stallActiveMs = 0;
-	bool watchdogRunning = false;
-	uint64_t columnFamilies = 0;
-	std::map<int64_t, uint64_t> maxWriteBufferSizeToMaintain;
-	/**
-	 * False when the registry lock was held by a close that is itself wedged on
-	 * the stall being diagnosed, so the two fields above are empty rather than
-	 * measured. A diagnostic that blocks on that lock answers nothing at all.
-	 */
-	bool inventoryAvailable = true;
-};
 
 /**
  * Stores the global settings for RocksDB databases as well as various global
@@ -80,44 +48,6 @@ private:
 
 	std::shared_ptr<rocksdb::WriteBufferManager> writeBufferManager;
 	std::mutex writeBufferManagerMutex;
-
-	// The manager, published with release ordering once it is fully constructed
-	// and never reset — a runtime `writeBufferManagerSize: 0` is a "no new
-	// attachments" signal, not a teardown, so the raw pointer stays valid for the
-	// process lifetime. Read paths take one acquire load instead of
-	// writeBufferManagerMutex: a metrics scrape must not contend with config()
-	// or a database open.
-	std::atomic<rocksdb::WriteBufferManager*> writeBufferManagerPtr{nullptr};
-
-	std::atomic<uint64_t> writeBufferManagerStallActiveMs{0};
-	std::atomic<bool> writeBufferManagerWatchdogRunning{false};
-	// Lock-free mirror of watchdogStopRequested, so the sample path can abandon a
-	// report before writing it. The report's stderr write is unbounded on a full
-	// pipe and a joiner waits behind it; this bounds that wait to a write already
-	// in progress rather than one about to start.
-	std::atomic<bool> writeBufferManagerWatchdogStopping{false};
-
-	// Watchdog lifecycle. The start path runs under databasesMutex ->
-	// writeBufferManagerMutex (DBRegistry::OpenDB holds the former across
-	// DBDescriptor::open), so watchdogMutex is the innermost lock and the
-	// watchdog thread must never hold it while taking either of the other two —
-	// it drops watchdogMutex before every sample, and the sample's inventory walk
-	// is the one place it takes databasesMutex.
-	std::thread watchdogThread;
-	std::mutex watchdogMutex;
-	std::condition_variable watchdogCv;
-	bool watchdogStarted = false;
-	bool watchdogStopRequested = false;
-	// Bumped on every start. A thread whose generation is stale exits even if a
-	// new start has already cleared `watchdogStopRequested`: the joiner releases
-	// watchdogMutex before `join()`, so without this the retiring thread can
-	// observe the reset flag and loop forever with its joiner blocked on it.
-	uint64_t watchdogGeneration = 0;
-	bool watchdogAtexitRegistered = false;
-
-	void ensureWriteBufferManagerWatchdog();
-	void runWriteBufferManagerWatchdog(uint64_t generation);
-	void sampleWriteBufferManagerStall(WbmStallWatchdogState& state, uint64_t thresholdMs);
 
 	bool compactOnClose;
 
@@ -165,43 +95,6 @@ public:
 
 	std::shared_ptr<rocksdb::WriteBufferManager> getWriteBufferManager();
 
-	/**
-	 * Returns the manager if one has already been created, without creating it.
-	 * Lock-free and safe from any thread — a stats read must never materialize
-	 * the manager as a side effect (the peer of `getVerificationTableRaw()`,
-	 * without its mutex).
-	 */
-	rocksdb::WriteBufferManager* getWriteBufferManagerRaw() const {
-		return this->writeBufferManagerPtr.load(std::memory_order_acquire);
-	}
-
-	/**
-	 * Samples the manager's live state. `includeColumnFamilies` additionally walks
-	 * the database registry for the attached, writable column-family inventory,
-	 * which is O(open column families) — leave it off on scrape paths.
-	 */
-	WriteBufferManagerStats getWriteBufferManagerStats(bool includeColumnFamilies);
-
-	/**
-	 * Signals the stall watchdog to stop without waiting for it. Split from the
-	 * join so teardown can shut databases down (and flush) while the watchdog is
-	 * still winding down: its warn line goes to stderr, which can block on a full
-	 * pipe, and a logging stall must never sit in front of the flush path.
-	 */
-	void requestWriteBufferManagerWatchdogStop();
-
-	/** Joins the stall watchdog. Idempotent, and restartable afterwards. */
-	void joinWriteBufferManagerWatchdog();
-
-	/**
-	 * Joins the watchdog if neither the module's cleanup hook nor the `atexit`
-	 * handler registered at watchdog start ran. `process.exit()` skips N-API env
-	 * cleanup, and destroying a joinable `std::thread` calls `std::terminate()` —
-	 * an observability feature must not turn a clean exit into SIGABRT. Mirrors
-	 * `~CommitWorker`.
-	 */
-	~DBSettings();
-
 	inline bool getCompactOnClose() const {
 		return compactOnClose;
 	}
@@ -224,8 +117,6 @@ public:
 	VerificationTable* getVerificationTableRaw();
 
 	static napi_value Config(napi_env env, napi_callback_info info);
-
-	static napi_value GetWriteBufferManagerStats(napi_env env, napi_callback_info info);
 
 	static void Init(napi_env env, napi_value exports);
 };

--- a/src/binding/database/db_stats.cpp
+++ b/src/binding/database/db_stats.cpp
@@ -200,8 +200,8 @@ void DBStats::joinWriteBufferManagerWatchdog() {
 			// A join() failure (e.g. the deadlock/invalid-argument error
 			// conditions) can leave the thread object still joinable; letting
 			// it destruct in that state calls std::terminate(). Detach so the
-			// object destructs safely — RetireGuard above has already reset
-			// the flags, so no other caller stays wedged on this attempt.
+			// object destructs safely; RetireGuard still resets the flags on
+			// scope exit below, so no other caller stays wedged on this attempt.
 			if (toJoin.joinable()) {
 				toJoin.detach();
 			}
@@ -260,11 +260,19 @@ void DBStats::sampleWriteBufferManagerStall(
 	WbmStallWatchdogState::Sample sample = state.onSample(
 		writeBufferManager->IsStallActive(), WbmStallWatchdogState::Clock::now(), thresholdMs
 	);
-	if (this->writeBufferManagerWatchdogStopping.load(std::memory_order_relaxed) ||
-		this->watchdogGeneration.load(std::memory_order_relaxed) != generation) {
-		return;
+	{
+		// Locked so this check-then-store can't interleave with
+		// disableWriteBufferManagerWatchdog()'s own locked reset of these same
+		// two fields — otherwise a disable() landing between the unlocked check
+		// and the store below could zero stallActiveMs and then have this write
+		// clobber it right back with a stale value the caller just turned off.
+		std::lock_guard<std::mutex> lock(this->watchdogMutex);
+		if (this->writeBufferManagerWatchdogStopping.load(std::memory_order_relaxed) ||
+			this->watchdogGeneration.load(std::memory_order_relaxed) != generation) {
+			return;
+		}
+		this->writeBufferManagerStallActiveMs.store(sample.stallActiveMs, std::memory_order_relaxed);
 	}
-	this->writeBufferManagerStallActiveMs.store(sample.stallActiveMs, std::memory_order_relaxed);
 	if (!sample.reportNow) {
 		return;
 	}

--- a/src/binding/database/db_stats.cpp
+++ b/src/binding/database/db_stats.cpp
@@ -89,7 +89,15 @@ void DBStats::ensureWriteBufferManagerWatchdog() {
 		return;
 	}
 	std::lock_guard<std::mutex> lock(this->watchdogMutex);
-	if (this->watchdogStopRequested || this->watchdogArmed) {
+	if (this->watchdogStopRequested) {
+		this->watchdogArmPendingAfterStop = true;
+		return;
+	}
+	this->armWatchdogLocked();
+}
+
+void DBStats::armWatchdogLocked() {
+	if (this->watchdogArmed) {
 		return;
 	}
 	this->watchdogArmed = true;
@@ -157,15 +165,31 @@ void DBStats::joinWriteBufferManagerWatchdog() {
 		}
 	}
 	this->watchdogCv.notify_all();
+
+	// Reset-and-notify runs on scope exit, not just after a normal join: join()
+	// can throw std::system_error, and without this a throw here would leave
+	// watchdogRetiring stuck true forever, permanently wedging a concurrent
+	// joiner parked in the wait above (and dropping an ensure() call that
+	// arrived mid-stop, leaving its database with no watchdog for good).
+	struct RetireGuard {
+		DBStats* self;
+		~RetireGuard() {
+			{
+				std::lock_guard<std::mutex> lock(self->watchdogMutex);
+				self->watchdogRetiring = false;
+				self->watchdogStopRequested = false;
+				if (self->watchdogArmPendingAfterStop) {
+					self->watchdogArmPendingAfterStop = false;
+					self->armWatchdogLocked();
+				}
+			}
+			self->watchdogCv.notify_all();
+		}
+	} retireGuard{this};
+
 	if (toJoin.joinable()) {
 		toJoin.join();
 	}
-	{
-		std::lock_guard<std::mutex> lock(this->watchdogMutex);
-		this->watchdogRetiring = false;
-		this->watchdogStopRequested = false;
-	}
-	this->watchdogCv.notify_all();
 }
 
 void DBStats::runWriteBufferManagerWatchdog() {

--- a/src/binding/database/db_stats.cpp
+++ b/src/binding/database/db_stats.cpp
@@ -89,30 +89,47 @@ void DBStats::ensureWriteBufferManagerWatchdog() {
 		return;
 	}
 	std::lock_guard<std::mutex> lock(this->watchdogMutex);
-	// This path can run under databasesMutex -> writeBufferManagerMutex. Joining
-	// here would deadlock against a retiring sample collecting registry inventory.
-	if (this->watchdogStarted) {
+	if (this->watchdogStopRequested || this->watchdogArmed) {
 		return;
 	}
-	this->watchdogStopRequested = false;
+	this->watchdogArmed = true;
 	this->writeBufferManagerWatchdogStopping.store(false, std::memory_order_relaxed);
-	const uint64_t generation = ++this->watchdogGeneration;
+	this->watchdogGeneration.fetch_add(1, std::memory_order_relaxed);
+	if (this->watchdogStarted) {
+		this->writeBufferManagerWatchdogRunning.store(true, std::memory_order_relaxed);
+		this->watchdogCv.notify_all();
+		return;
+	}
 	try {
-		this->watchdogThread =
-			std::thread([this, generation]() { this->runWriteBufferManagerWatchdog(generation); });
+		this->watchdogThread = std::thread([this]() { this->runWriteBufferManagerWatchdog(); });
 		this->watchdogStarted = true;
 		this->writeBufferManagerWatchdogRunning.store(true, std::memory_order_relaxed);
 	} catch (...) {
+		this->watchdogArmed = false;
 		this->watchdogStarted = false;
+		this->writeBufferManagerWatchdogStopping.store(true, std::memory_order_relaxed);
 		this->writeBufferManagerWatchdogRunning.store(false, std::memory_order_relaxed);
 	}
+}
+
+void DBStats::disableWriteBufferManagerWatchdog() {
+	{
+		std::lock_guard<std::mutex> lock(this->watchdogMutex);
+		this->watchdogArmed = false;
+		this->writeBufferManagerWatchdogStopping.store(true, std::memory_order_relaxed);
+		this->writeBufferManagerWatchdogRunning.store(false, std::memory_order_relaxed);
+		this->writeBufferManagerStallActiveMs.store(0, std::memory_order_relaxed);
+	}
+	this->watchdogCv.notify_all();
 }
 
 void DBStats::requestWriteBufferManagerWatchdogStop() {
 	{
 		std::lock_guard<std::mutex> lock(this->watchdogMutex);
+		this->watchdogArmed = false;
 		this->watchdogStopRequested = true;
 		this->writeBufferManagerWatchdogStopping.store(true, std::memory_order_relaxed);
+		this->writeBufferManagerWatchdogRunning.store(false, std::memory_order_relaxed);
 	}
 	this->watchdogCv.notify_all();
 }
@@ -121,8 +138,10 @@ void DBStats::joinWriteBufferManagerWatchdog() {
 	std::thread toJoin;
 	{
 		std::lock_guard<std::mutex> lock(this->watchdogMutex);
+		this->watchdogArmed = false;
 		this->watchdogStopRequested = true;
 		this->writeBufferManagerWatchdogStopping.store(true, std::memory_order_relaxed);
+		this->writeBufferManagerWatchdogRunning.store(false, std::memory_order_relaxed);
 		if (this->watchdogStarted) {
 			toJoin = std::move(this->watchdogThread);
 			this->watchdogStarted = false;
@@ -134,34 +153,48 @@ void DBStats::joinWriteBufferManagerWatchdog() {
 	}
 }
 
-void DBStats::runWriteBufferManagerWatchdog(uint64_t generation) {
+void DBStats::runWriteBufferManagerWatchdog() {
 	setThreadName("rocksdb-wbm-watchdog");
 	const uint64_t thresholdMs = writeBufferManagerStallWarnMs();
 	WbmStallWatchdogState state;
+	uint64_t activeGeneration = 0;
 	std::unique_lock<std::mutex> lock(this->watchdogMutex);
-	auto retired = [&] {
-		return this->watchdogStopRequested || this->watchdogGeneration != generation;
-	};
-	while (!retired()) {
-		this->watchdogCv.wait_for(lock, std::chrono::milliseconds(WBM_STALL_SAMPLE_INTERVAL_MS));
-		if (retired()) {
+	while (!this->watchdogStopRequested) {
+		this->watchdogCv.wait(lock, [this]() {
+			return this->watchdogStopRequested || this->watchdogArmed;
+		});
+		if (this->watchdogStopRequested) {
 			break;
+		}
+		const uint64_t generation = this->watchdogGeneration.load(std::memory_order_relaxed);
+		if (activeGeneration != generation) {
+			state = WbmStallWatchdogState();
+			activeGeneration = generation;
+		}
+		if (this->watchdogCv.wait_for(
+				lock,
+				std::chrono::milliseconds(WBM_STALL_SAMPLE_INTERVAL_MS),
+				[this, activeGeneration]() {
+					return this->watchdogStopRequested || !this->watchdogArmed ||
+						this->watchdogGeneration.load(std::memory_order_relaxed) != activeGeneration;
+				}
+		)) {
+			continue;
 		}
 		lock.unlock();
 		try {
-			this->sampleWriteBufferManagerStall(state, thresholdMs);
+			this->sampleWriteBufferManagerStall(state, thresholdMs, activeGeneration);
 		} catch (...) {}
 		lock.lock();
 	}
-	if (this->watchdogGeneration == generation) {
-		this->writeBufferManagerStallActiveMs.store(0, std::memory_order_relaxed);
-		this->writeBufferManagerWatchdogRunning.store(false, std::memory_order_relaxed);
-	}
+	this->writeBufferManagerStallActiveMs.store(0, std::memory_order_relaxed);
+	this->writeBufferManagerWatchdogRunning.store(false, std::memory_order_relaxed);
 }
 
 void DBStats::sampleWriteBufferManagerStall(
 	WbmStallWatchdogState& state,
-	uint64_t thresholdMs
+	uint64_t thresholdMs,
+	uint64_t generation
 ) {
 	rocksdb::WriteBufferManager* writeBufferManager =
 		this->writeBufferManager.load(std::memory_order_acquire);
@@ -171,9 +204,12 @@ void DBStats::sampleWriteBufferManagerStall(
 	WbmStallWatchdogState::Sample sample = state.onSample(
 		writeBufferManager->IsStallActive(), WbmStallWatchdogState::Clock::now(), thresholdMs
 	);
+	if (this->writeBufferManagerWatchdogStopping.load(std::memory_order_relaxed) ||
+		this->watchdogGeneration.load(std::memory_order_relaxed) != generation) {
+		return;
+	}
 	this->writeBufferManagerStallActiveMs.store(sample.stallActiveMs, std::memory_order_relaxed);
-	if (!sample.reportNow ||
-		this->writeBufferManagerWatchdogStopping.load(std::memory_order_relaxed)) {
+	if (!sample.reportNow) {
 		return;
 	}
 
@@ -188,6 +224,10 @@ void DBStats::sampleWriteBufferManagerStall(
 	report.inventoryAvailable = DBRegistry::CollectWriteBufferManagerInventory(
 		writeBufferManager, report.columnFamilies, report.maxWriteBufferSizeToMaintain
 	);
+	if (this->writeBufferManagerWatchdogStopping.load(std::memory_order_relaxed) ||
+		this->watchdogGeneration.load(std::memory_order_relaxed) != generation) {
+		return;
+	}
 
 	std::string line = formatWriteBufferManagerStallReport(report);
 	const bool wroteToStderr = ::fprintf(stderr, "%s\n", line.c_str()) >= 0;

--- a/src/binding/database/db_stats.cpp
+++ b/src/binding/database/db_stats.cpp
@@ -16,7 +16,6 @@ constexpr const char* WBM_MUTABLE_MEMORY_USAGE_KEY = "writeBufferManager.mutable
 constexpr const char* WBM_STALL_ACTIVE_KEY = "writeBufferManager.stallActive";
 constexpr const char* WBM_STALL_ACTIVE_MS_KEY = "writeBufferManager.stallActiveMs";
 
-// See the call site in sampleWriteBufferManagerStall() for why this retries at all.
 // A WAL-recovery-sized hold on databasesMutex/columnsMutex runs to the hundreds of
 // milliseconds; ~450ms of total budget covers that without meaningfully delaying
 // the once-per-episode alarm against a 5s+ threshold.
@@ -121,10 +120,8 @@ void DBStats::armWatchdogLocked() {
 		this->watchdogStarted = false;
 		this->writeBufferManagerWatchdogStopping.store(true, std::memory_order_relaxed);
 		this->writeBufferManagerWatchdogRunning.store(false, std::memory_order_relaxed);
-		// Deliberately no stderr line here: `ensure` runs under `databasesMutex` ->
-		// `writeBufferManagerMutex` -> `watchdogMutex`, so a blocked write would
-		// stall every database open and shutdown's flush. The failure is visible as
-		// `watchdogRunning: false`, and the next open retries.
+		// Same no-stderr-under-lock reasoning as `stallWarnMs` above. Visible as
+		// `watchdogRunning: false`; the next open retries.
 	}
 }
 

--- a/src/binding/database/db_stats.cpp
+++ b/src/binding/database/db_stats.cpp
@@ -92,6 +92,7 @@ void DBStats::ensureWriteBufferManagerWatchdog() {
 		return;
 	}
 	std::lock_guard<std::mutex> lock(this->watchdogMutex);
+	++this->watchdogArmRequestGeneration;
 	if (this->watchdogStopRequested) {
 		this->watchdogArmPendingAfterStop = true;
 		return;
@@ -120,8 +121,6 @@ void DBStats::armWatchdogLocked() {
 		this->watchdogStarted = false;
 		this->writeBufferManagerWatchdogStopping.store(true, std::memory_order_relaxed);
 		this->writeBufferManagerWatchdogRunning.store(false, std::memory_order_relaxed);
-		// Same no-stderr-under-lock reasoning as `stallWarnMs` above. Visible as
-		// `watchdogRunning: false`; the next open retries.
 	}
 }
 
@@ -141,21 +140,21 @@ void DBStats::disableWriteBufferManagerWatchdog() {
 	this->watchdogCv.notify_all();
 }
 
-void DBStats::requestWriteBufferManagerWatchdogStop() {
-	{
-		std::lock_guard<std::mutex> lock(this->watchdogMutex);
-		this->watchdogArmed = false;
-		this->watchdogStopRequested = true;
-		this->writeBufferManagerWatchdogStopping.store(true, std::memory_order_relaxed);
-		this->writeBufferManagerWatchdogRunning.store(false, std::memory_order_relaxed);
-	}
-	this->watchdogCv.notify_all();
+uint64_t DBStats::beginWriteBufferManagerWatchdogShutdown() {
+	std::lock_guard<std::mutex> lock(this->watchdogMutex);
+	return this->watchdogArmRequestGeneration;
 }
 
-void DBStats::joinWriteBufferManagerWatchdog(bool allowRearm) {
+void DBStats::joinWriteBufferManagerWatchdog(bool allowRearm, uint64_t shutdownGeneration) {
 	std::thread toJoin;
 	{
 		std::unique_lock<std::mutex> lock(this->watchdogMutex);
+		if (this->watchdogRetiring) {
+			this->watchdogCv.wait(lock, [this]() { return !this->watchdogRetiring; });
+		}
+		if (allowRearm && shutdownGeneration != this->watchdogArmRequestGeneration) {
+			return;
+		}
 		this->watchdogArmed = false;
 		this->watchdogStopRequested = true;
 		this->writeBufferManagerWatchdogStopping.store(true, std::memory_order_relaxed);
@@ -164,20 +163,10 @@ void DBStats::joinWriteBufferManagerWatchdog(bool allowRearm) {
 			toJoin = std::move(this->watchdogThread);
 			this->watchdogStarted = false;
 			this->watchdogRetiring = true;
-		} else if (this->watchdogRetiring) {
-			this->watchdogCv.notify_all();
-			this->watchdogCv.wait(lock, [this]() { return !this->watchdogRetiring; });
-			return;
 		}
 	}
 	this->watchdogCv.notify_all();
 
-	// Reset-and-notify runs on scope exit rather than only after the join
-	// below, so any future fallible step added between here and the end of
-	// the function still releases a concurrent joiner parked in the wait
-	// above (and still replays an ensure() call that arrived mid-stop, when
-	// this caller allows it) instead of leaving watchdogRetiring stuck true
-	// forever.
 	struct RetireGuard {
 		DBStats* self;
 		bool allowRearm;
@@ -254,11 +243,7 @@ void DBStats::sampleWriteBufferManagerStall(
 		writeBufferManager->IsStallActive(), WbmStallWatchdogState::Clock::now(), thresholdMs
 	);
 	{
-		// Locked so this check-then-store can't interleave with
-		// disableWriteBufferManagerWatchdog()'s own locked reset of these same
-		// two fields — otherwise a disable() landing between the unlocked check
-		// and the store below could zero stallActiveMs and then have this write
-		// clobber it right back with a stale value the caller just turned off.
+		// Keep the generation check and duration write atomic against disable().
 		std::lock_guard<std::mutex> lock(this->watchdogMutex);
 		if (this->writeBufferManagerWatchdogStopping.load(std::memory_order_relaxed) ||
 			this->watchdogGeneration.load(std::memory_order_relaxed) != generation) {
@@ -278,7 +263,6 @@ void DBStats::sampleWriteBufferManagerStall(
 	report.mutableMemoryUsage = writeBufferManager->mutable_memtable_memory_usage();
 	report.allowStall = settings.getWriteBufferManagerAllowStall();
 	report.costToCache = settings.getWriteBufferManagerCostToCache();
-	// This is the one report an episode ever gets; see the retry constants above.
 	report.inventoryAvailable = DBRegistry::CollectWriteBufferManagerInventory(
 		writeBufferManager, report.columnFamilies, report.maxWriteBufferSizeToMaintain
 	);
@@ -404,9 +388,7 @@ void DBStats::Init(napi_env env, napi_value exports) {
 }
 
 DBStats::~DBStats() {
-	// True process exit: never spawn a replacement thread here, since nothing
-	// will join it again.
-	this->joinWriteBufferManagerWatchdog(false);
+	this->joinWriteBufferManagerWatchdog(false, 0);
 }
 
 } // namespace rocksdb_js

--- a/src/binding/database/db_stats.cpp
+++ b/src/binding/database/db_stats.cpp
@@ -150,9 +150,7 @@ void DBStats::runWriteBufferManagerWatchdog(uint64_t generation) {
 		lock.unlock();
 		try {
 			this->sampleWriteBufferManagerStall(state, thresholdMs);
-		} catch (...) {
-			// A failed diagnostic must not take down the process; the next sample retries.
-		}
+		} catch (...) {}
 		lock.lock();
 	}
 	if (this->watchdogGeneration == generation) {
@@ -219,8 +217,10 @@ WriteBufferManagerStats DBStats::getWriteBufferManagerStats(bool includeColumnFa
 	stats.memoryUsage = writeBufferManager->memory_usage();
 	stats.mutableMemoryUsage = writeBufferManager->mutable_memtable_memory_usage();
 	stats.stallActive = writeBufferManager->IsStallActive();
-	stats.stallActiveMs =
-		this->writeBufferManagerStallActiveMs.load(std::memory_order_relaxed);
+	if (stats.stallActive) {
+		stats.stallActiveMs =
+			this->writeBufferManagerStallActiveMs.load(std::memory_order_relaxed);
+	}
 	if (includeColumnFamilies) {
 		stats.inventoryAvailable = DBRegistry::CollectWriteBufferManagerInventory(
 			writeBufferManager, stats.columnFamilies, stats.maxWriteBufferSizeToMaintain

--- a/src/binding/database/db_stats.cpp
+++ b/src/binding/database/db_stats.cpp
@@ -155,15 +155,16 @@ void DBStats::joinWriteBufferManagerWatchdog(bool allowRearm, uint64_t shutdownG
 		if (allowRearm && shutdownGeneration != this->watchdogArmRequestGeneration) {
 			return;
 		}
+		if (!this->watchdogStarted) {
+			return;
+		}
 		this->watchdogArmed = false;
 		this->watchdogStopRequested = true;
 		this->writeBufferManagerWatchdogStopping.store(true, std::memory_order_relaxed);
 		this->writeBufferManagerWatchdogRunning.store(false, std::memory_order_relaxed);
-		if (this->watchdogStarted) {
-			toJoin = std::move(this->watchdogThread);
-			this->watchdogStarted = false;
-			this->watchdogRetiring = true;
-		}
+		toJoin = std::move(this->watchdogThread);
+		this->watchdogStarted = false;
+		this->watchdogRetiring = true;
 	}
 	this->watchdogCv.notify_all();
 

--- a/src/binding/database/db_stats.cpp
+++ b/src/binding/database/db_stats.cpp
@@ -16,10 +16,12 @@ constexpr const char* WBM_MUTABLE_MEMORY_USAGE_KEY = "writeBufferManager.mutable
 constexpr const char* WBM_STALL_ACTIVE_KEY = "writeBufferManager.stallActive";
 constexpr const char* WBM_STALL_ACTIVE_MS_KEY = "writeBufferManager.stallActiveMs";
 
-/** Bounds how long a degraded (`inventoryAvailable: false`) stall report retries
- *  before giving up: see the call site in `sampleWriteBufferManagerStall`. */
-constexpr int WBM_STALL_INVENTORY_COLLECT_ATTEMPTS = 5;
-constexpr int WBM_STALL_INVENTORY_RETRY_DELAY_MS = 20;
+// See the call site in sampleWriteBufferManagerStall() for why this retries at all.
+// A WAL-recovery-sized hold on databasesMutex/columnsMutex runs to the hundreds of
+// milliseconds; ~450ms of total budget covers that without meaningfully delaying
+// the once-per-episode alarm against a 5s+ threshold.
+constexpr int WBM_STALL_INVENTORY_COLLECT_ATTEMPTS = 10;
+constexpr int WBM_STALL_INVENTORY_RETRY_DELAY_MS = 50;
 
 uint64_t writeBufferManagerStallWarnMs() {
 	static const uint64_t value = [] {

--- a/src/binding/database/db_stats.cpp
+++ b/src/binding/database/db_stats.cpp
@@ -147,10 +147,6 @@ void DBStats::joinWriteBufferManagerWatchdog() {
 			this->watchdogStarted = false;
 			this->watchdogRetiring = true;
 		} else if (this->watchdogRetiring) {
-			// Another env is already retiring the thread. Wait for it instead of
-			// clearing the stop latch out from under it: the thread may not have
-			// observed the stop yet, and clearing it would park the thread again
-			// with the owner blocked in join() forever.
 			this->watchdogCv.notify_all();
 			this->watchdogCv.wait(lock, [this]() { return !this->watchdogRetiring; });
 			return;
@@ -163,8 +159,6 @@ void DBStats::joinWriteBufferManagerWatchdog() {
 	{
 		std::lock_guard<std::mutex> lock(this->watchdogMutex);
 		this->watchdogRetiring = false;
-		// Held until here so `ensure` cannot start a replacement alongside a
-		// thread that is still exiting.
 		this->watchdogStopRequested = false;
 	}
 	this->watchdogCv.notify_all();

--- a/src/binding/database/db_stats.cpp
+++ b/src/binding/database/db_stats.cpp
@@ -151,6 +151,10 @@ void DBStats::joinWriteBufferManagerWatchdog() {
 	if (toJoin.joinable()) {
 		toJoin.join();
 	}
+	{
+		std::lock_guard<std::mutex> lock(this->watchdogMutex);
+		this->watchdogStopRequested = false;
+	}
 }
 
 void DBStats::runWriteBufferManagerWatchdog() {

--- a/src/binding/database/db_stats.cpp
+++ b/src/binding/database/db_stats.cpp
@@ -1,6 +1,5 @@
 #include "database/db_stats.h"
 #include <cstdio>
-#include <system_error>
 #include "core/platform.h"
 #include "database/db_registry.h"
 #include "database/db_settings.h"
@@ -16,6 +15,11 @@ constexpr const char* WBM_MEMORY_USAGE_KEY = "writeBufferManager.memoryUsage";
 constexpr const char* WBM_MUTABLE_MEMORY_USAGE_KEY = "writeBufferManager.mutableMemoryUsage";
 constexpr const char* WBM_STALL_ACTIVE_KEY = "writeBufferManager.stallActive";
 constexpr const char* WBM_STALL_ACTIVE_MS_KEY = "writeBufferManager.stallActiveMs";
+
+/** Bounds how long a degraded (`inventoryAvailable: false`) stall report retries
+ *  before giving up: see the call site in `sampleWriteBufferManagerStall`. */
+constexpr int WBM_STALL_INVENTORY_COLLECT_ATTEMPTS = 5;
+constexpr int WBM_STALL_INVENTORY_RETRY_DELAY_MS = 20;
 
 uint64_t writeBufferManagerStallWarnMs() {
 	static const uint64_t value = [] {
@@ -198,18 +202,7 @@ void DBStats::joinWriteBufferManagerWatchdog(bool allowRearm) {
 	} retireGuard{this, allowRearm};
 
 	if (toJoin.joinable()) {
-		try {
-			toJoin.join();
-		} catch (const std::system_error&) {
-			// A join() failure (e.g. the deadlock/invalid-argument error
-			// conditions) can leave the thread object still joinable; letting
-			// it destruct in that state calls std::terminate(). Detach so the
-			// object destructs safely; RetireGuard still resets the flags on
-			// scope exit below, so no other caller stays wedged on this attempt.
-			if (toJoin.joinable()) {
-				toJoin.detach();
-			}
-		}
+		toJoin.join();
 	}
 }
 
@@ -289,9 +282,27 @@ void DBStats::sampleWriteBufferManagerStall(
 	report.mutableMemoryUsage = writeBufferManager->mutable_memtable_memory_usage();
 	report.allowStall = settings.getWriteBufferManagerAllowStall();
 	report.costToCache = settings.getWriteBufferManagerCostToCache();
+	// This is the one report an episode ever gets, so a `databasesMutex`/
+	// `columnsMutex` holder that is merely busy (e.g. `DBRegistry::OpenDB`
+	// running WAL recovery, typically sub-second) shouldn't leave it
+	// permanently missing the retention histogram that is the entire point
+	// of #821. Retries stay non-blocking (still a `try_lock` each attempt)
+	// and are bounded and brief so a holder that never lets go still gets a
+	// degraded-but-timely alarm rather than delaying it.
 	report.inventoryAvailable = DBRegistry::CollectWriteBufferManagerInventory(
 		writeBufferManager, report.columnFamilies, report.maxWriteBufferSizeToMaintain
 	);
+	for (int attempt = 1; !report.inventoryAvailable && attempt < WBM_STALL_INVENTORY_COLLECT_ATTEMPTS;
+		 attempt++) {
+		if (this->writeBufferManagerWatchdogStopping.load(std::memory_order_relaxed) ||
+			this->watchdogGeneration.load(std::memory_order_relaxed) != generation) {
+			return;
+		}
+		std::this_thread::sleep_for(std::chrono::milliseconds(WBM_STALL_INVENTORY_RETRY_DELAY_MS));
+		report.inventoryAvailable = DBRegistry::CollectWriteBufferManagerInventory(
+			writeBufferManager, report.columnFamilies, report.maxWriteBufferSizeToMaintain
+		);
+	}
 	if (this->writeBufferManagerWatchdogStopping.load(std::memory_order_relaxed) ||
 		this->watchdogGeneration.load(std::memory_order_relaxed) != generation) {
 		return;
@@ -345,23 +356,11 @@ bool DBStats::getWriteBufferManagerStat(const std::string& statName, double& val
 
 void DBStats::setWriteBufferManagerStatsOnObject(napi_env env, napi_value result) {
 	WriteBufferManagerStats stats = this->getWriteBufferManagerStats(false);
-	static constexpr const char* keys[] = {
-		WBM_BUFFER_SIZE_KEY,
-		WBM_MEMORY_USAGE_KEY,
-		WBM_MUTABLE_MEMORY_USAGE_KEY,
-		WBM_STALL_ACTIVE_KEY,
-		WBM_STALL_ACTIVE_MS_KEY,
-	};
-	for (const char* key : keys) {
-		double value = 0;
-		if (!lookupWriteBufferManagerStat(key, stats, value)) {
-			continue;
-		}
-		napi_value jsValue;
-		if (::napi_create_double(env, value, &jsValue) == napi_ok) {
-			::napi_set_named_property(env, result, key, jsValue);
-		}
-	}
+	setNumberProperty(env, result, WBM_BUFFER_SIZE_KEY, stats.bufferSize);
+	setNumberProperty(env, result, WBM_MEMORY_USAGE_KEY, stats.memoryUsage);
+	setNumberProperty(env, result, WBM_MUTABLE_MEMORY_USAGE_KEY, stats.mutableMemoryUsage);
+	setNumberProperty(env, result, WBM_STALL_ACTIVE_KEY, stats.stallActive ? 1 : 0);
+	setNumberProperty(env, result, WBM_STALL_ACTIVE_MS_KEY, stats.stallActiveMs);
 }
 
 napi_value DBStats::GetWriteBufferManagerStats(napi_env env, napi_callback_info info) {

--- a/src/binding/database/db_stats.cpp
+++ b/src/binding/database/db_stats.cpp
@@ -1,0 +1,313 @@
+#include "database/db_stats.h"
+#include <cstdio>
+#include "core/platform.h"
+#include "database/db_registry.h"
+#include "database/db_settings.h"
+#include "napi/global_events.h"
+#include "napi/macros.h"
+
+namespace rocksdb_js {
+
+namespace {
+
+constexpr const char* WBM_BUFFER_SIZE_KEY = "writeBufferManager.bufferSize";
+constexpr const char* WBM_MEMORY_USAGE_KEY = "writeBufferManager.memoryUsage";
+constexpr const char* WBM_MUTABLE_MEMORY_USAGE_KEY = "writeBufferManager.mutableMemoryUsage";
+constexpr const char* WBM_STALL_ACTIVE_KEY = "writeBufferManager.stallActive";
+constexpr const char* WBM_STALL_ACTIVE_MS_KEY = "writeBufferManager.stallActiveMs";
+
+uint64_t writeBufferManagerStallWarnMs() {
+	static const uint64_t value = [] {
+		const char* raw = ::getenv("ROCKSDB_JS_WBM_STALL_WARN_MS");
+		bool rejected = false;
+		uint64_t resolved = resolveWbmStallWarnMs(raw, &rejected);
+		if (rejected) {
+			::fprintf(stderr,
+				"[rocksdb-js] ignoring ROCKSDB_JS_WBM_STALL_WARN_MS=\"%s\" (not an integer in "
+				"[0, %llu] ms); using %llu\n",
+				raw, static_cast<unsigned long long>(WBM_STALL_WARN_MS_MAX),
+				static_cast<unsigned long long>(resolved));
+		}
+		return resolved;
+	}();
+	return value;
+}
+
+bool lookupWriteBufferManagerStat(
+	const std::string& statName,
+	const WriteBufferManagerStats& stats,
+	double& value
+) {
+	if (statName == WBM_BUFFER_SIZE_KEY) {
+		value = static_cast<double>(stats.bufferSize);
+	} else if (statName == WBM_MEMORY_USAGE_KEY) {
+		value = static_cast<double>(stats.memoryUsage);
+	} else if (statName == WBM_MUTABLE_MEMORY_USAGE_KEY) {
+		value = static_cast<double>(stats.mutableMemoryUsage);
+	} else if (statName == WBM_STALL_ACTIVE_KEY) {
+		value = stats.stallActive ? 1 : 0;
+	} else if (statName == WBM_STALL_ACTIVE_MS_KEY) {
+		value = static_cast<double>(stats.stallActiveMs);
+	} else {
+		return false;
+	}
+	return true;
+}
+
+napi_status setNumberProperty(napi_env env, napi_value target, const char* key, uint64_t value) {
+	napi_value jsValue;
+	napi_status status = ::napi_create_double(env, static_cast<double>(value), &jsValue);
+	if (status != napi_ok) {
+		return status;
+	}
+	return ::napi_set_named_property(env, target, key, jsValue);
+}
+
+napi_status setBoolProperty(napi_env env, napi_value target, const char* key, bool value) {
+	napi_value jsValue;
+	napi_status status = ::napi_get_boolean(env, value, &jsValue);
+	if (status != napi_ok) {
+		return status;
+	}
+	return ::napi_set_named_property(env, target, key, jsValue);
+}
+
+} // namespace
+
+DBStats::DBStats() {
+	// These dependencies must be destroyed after the watchdog owner.
+	(void)DBSettings::getInstance();
+	(void)GlobalEvents::getInstance();
+}
+
+void DBStats::publishWriteBufferManager(rocksdb::WriteBufferManager* writeBufferManager) {
+	this->writeBufferManager.store(writeBufferManager, std::memory_order_release);
+}
+
+void DBStats::ensureWriteBufferManagerWatchdog() {
+	if (writeBufferManagerStallWarnMs() == 0) {
+		return;
+	}
+	std::lock_guard<std::mutex> lock(this->watchdogMutex);
+	// This path can run under databasesMutex -> writeBufferManagerMutex. Joining
+	// here would deadlock against a retiring sample collecting registry inventory.
+	if (this->watchdogStarted) {
+		return;
+	}
+	this->watchdogStopRequested = false;
+	this->writeBufferManagerWatchdogStopping.store(false, std::memory_order_relaxed);
+	const uint64_t generation = ++this->watchdogGeneration;
+	try {
+		this->watchdogThread =
+			std::thread([this, generation]() { this->runWriteBufferManagerWatchdog(generation); });
+		this->watchdogStarted = true;
+		this->writeBufferManagerWatchdogRunning.store(true, std::memory_order_relaxed);
+	} catch (...) {
+		this->watchdogStarted = false;
+		this->writeBufferManagerWatchdogRunning.store(false, std::memory_order_relaxed);
+	}
+}
+
+void DBStats::requestWriteBufferManagerWatchdogStop() {
+	{
+		std::lock_guard<std::mutex> lock(this->watchdogMutex);
+		this->watchdogStopRequested = true;
+		this->writeBufferManagerWatchdogStopping.store(true, std::memory_order_relaxed);
+	}
+	this->watchdogCv.notify_all();
+}
+
+void DBStats::joinWriteBufferManagerWatchdog() {
+	std::thread toJoin;
+	{
+		std::lock_guard<std::mutex> lock(this->watchdogMutex);
+		this->watchdogStopRequested = true;
+		this->writeBufferManagerWatchdogStopping.store(true, std::memory_order_relaxed);
+		if (this->watchdogStarted) {
+			toJoin = std::move(this->watchdogThread);
+			this->watchdogStarted = false;
+		}
+	}
+	this->watchdogCv.notify_all();
+	if (toJoin.joinable()) {
+		toJoin.join();
+	}
+}
+
+void DBStats::runWriteBufferManagerWatchdog(uint64_t generation) {
+	setThreadName("rocksdb-wbm-watchdog");
+	const uint64_t thresholdMs = writeBufferManagerStallWarnMs();
+	WbmStallWatchdogState state;
+	std::unique_lock<std::mutex> lock(this->watchdogMutex);
+	auto retired = [&] {
+		return this->watchdogStopRequested || this->watchdogGeneration != generation;
+	};
+	while (!retired()) {
+		this->watchdogCv.wait_for(lock, std::chrono::milliseconds(WBM_STALL_SAMPLE_INTERVAL_MS));
+		if (retired()) {
+			break;
+		}
+		lock.unlock();
+		try {
+			this->sampleWriteBufferManagerStall(state, thresholdMs);
+		} catch (...) {
+			// A failed diagnostic must not take down the process; the next sample retries.
+		}
+		lock.lock();
+	}
+	if (this->watchdogGeneration == generation) {
+		this->writeBufferManagerStallActiveMs.store(0, std::memory_order_relaxed);
+		this->writeBufferManagerWatchdogRunning.store(false, std::memory_order_relaxed);
+	}
+}
+
+void DBStats::sampleWriteBufferManagerStall(
+	WbmStallWatchdogState& state,
+	uint64_t thresholdMs
+) {
+	rocksdb::WriteBufferManager* writeBufferManager =
+		this->writeBufferManager.load(std::memory_order_acquire);
+	if (writeBufferManager == nullptr) {
+		return;
+	}
+	WbmStallWatchdogState::Sample sample = state.onSample(
+		writeBufferManager->IsStallActive(), WbmStallWatchdogState::Clock::now(), thresholdMs
+	);
+	this->writeBufferManagerStallActiveMs.store(sample.stallActiveMs, std::memory_order_relaxed);
+	if (!sample.reportNow ||
+		this->writeBufferManagerWatchdogStopping.load(std::memory_order_relaxed)) {
+		return;
+	}
+
+	DBSettings& settings = DBSettings::getInstance();
+	WriteBufferManagerStallReport report;
+	report.stallActiveMs = sample.stallActiveMs;
+	report.bufferSize = writeBufferManager->buffer_size();
+	report.memoryUsage = writeBufferManager->memory_usage();
+	report.mutableMemoryUsage = writeBufferManager->mutable_memtable_memory_usage();
+	report.allowStall = settings.getWriteBufferManagerAllowStall();
+	report.costToCache = settings.getWriteBufferManagerCostToCache();
+	report.inventoryAvailable = DBRegistry::CollectWriteBufferManagerInventory(
+		writeBufferManager, report.columnFamilies, report.maxWriteBufferSizeToMaintain
+	);
+
+	std::string line = formatWriteBufferManagerStallReport(report);
+	const bool wroteToStderr = ::fprintf(stderr, "%s\n", line.c_str()) >= 0;
+	if (wroteToStderr) {
+		::fflush(stderr);
+	}
+	const bool emitted = emitGlobalEvent("log.warn", ListenerData::fromStrings({ line }));
+	if (wroteToStderr || emitted) {
+		state.markReported();
+	}
+}
+
+WriteBufferManagerStats DBStats::getWriteBufferManagerStats(bool includeColumnFamilies) {
+	DBSettings& settings = DBSettings::getInstance();
+	WriteBufferManagerStats stats;
+	stats.allowStall = settings.getWriteBufferManagerAllowStall();
+	stats.costToCache = settings.getWriteBufferManagerCostToCache();
+	stats.watchdogRunning = this->writeBufferManagerWatchdogRunning.load(std::memory_order_relaxed);
+
+	rocksdb::WriteBufferManager* writeBufferManager =
+		this->writeBufferManager.load(std::memory_order_acquire);
+	if (writeBufferManager == nullptr) {
+		return stats;
+	}
+	stats.enabled = true;
+	stats.bufferSize = writeBufferManager->buffer_size();
+	stats.memoryUsage = writeBufferManager->memory_usage();
+	stats.mutableMemoryUsage = writeBufferManager->mutable_memtable_memory_usage();
+	stats.stallActive = writeBufferManager->IsStallActive();
+	stats.stallActiveMs =
+		this->writeBufferManagerStallActiveMs.load(std::memory_order_relaxed);
+	if (includeColumnFamilies) {
+		stats.inventoryAvailable = DBRegistry::CollectWriteBufferManagerInventory(
+			writeBufferManager, stats.columnFamilies, stats.maxWriteBufferSizeToMaintain
+		);
+	}
+	return stats;
+}
+
+bool DBStats::getWriteBufferManagerStat(const std::string& statName, double& value) {
+	return lookupWriteBufferManagerStat(
+		statName, this->getWriteBufferManagerStats(false), value
+	);
+}
+
+void DBStats::setWriteBufferManagerStatsOnObject(napi_env env, napi_value result) {
+	WriteBufferManagerStats stats = this->getWriteBufferManagerStats(false);
+	static constexpr const char* keys[] = {
+		WBM_BUFFER_SIZE_KEY,
+		WBM_MEMORY_USAGE_KEY,
+		WBM_MUTABLE_MEMORY_USAGE_KEY,
+		WBM_STALL_ACTIVE_KEY,
+		WBM_STALL_ACTIVE_MS_KEY,
+	};
+	for (const char* key : keys) {
+		double value = 0;
+		if (!lookupWriteBufferManagerStat(key, stats, value)) {
+			continue;
+		}
+		napi_value jsValue;
+		if (::napi_create_double(env, value, &jsValue) == napi_ok) {
+			::napi_set_named_property(env, result, key, jsValue);
+		}
+	}
+}
+
+napi_value DBStats::GetWriteBufferManagerStats(napi_env env, napi_callback_info info) {
+	WriteBufferManagerStats stats = DBStats::getInstance().getWriteBufferManagerStats(true);
+
+	napi_value result;
+	NAPI_STATUS_THROWS(::napi_create_object(env, &result));
+	NAPI_STATUS_THROWS(setNumberProperty(env, result, "bufferSize", stats.bufferSize));
+	NAPI_STATUS_THROWS(setNumberProperty(env, result, "memoryUsage", stats.memoryUsage));
+	NAPI_STATUS_THROWS(setNumberProperty(env, result, "mutableMemoryUsage", stats.mutableMemoryUsage));
+	NAPI_STATUS_THROWS(setNumberProperty(env, result, "stallActiveMs", stats.stallActiveMs));
+	NAPI_STATUS_THROWS(setNumberProperty(env, result, "columnFamilies", stats.columnFamilies));
+	NAPI_STATUS_THROWS(setBoolProperty(env, result, "enabled", stats.enabled));
+	NAPI_STATUS_THROWS(setBoolProperty(env, result, "allowStall", stats.allowStall));
+	NAPI_STATUS_THROWS(setBoolProperty(env, result, "costToCache", stats.costToCache));
+	NAPI_STATUS_THROWS(setBoolProperty(env, result, "stallActive", stats.stallActive));
+	NAPI_STATUS_THROWS(setBoolProperty(env, result, "watchdogRunning", stats.watchdogRunning));
+	NAPI_STATUS_THROWS(setBoolProperty(env, result, "inventoryAvailable", stats.inventoryAvailable));
+
+	napi_value targets;
+	NAPI_STATUS_THROWS(::napi_create_object(env, &targets));
+	for (const auto& [target, count] : stats.maxWriteBufferSizeToMaintain) {
+		napi_value countValue;
+		NAPI_STATUS_THROWS(::napi_create_int64(env, static_cast<int64_t>(count), &countValue));
+		NAPI_STATUS_THROWS(::napi_set_named_property(
+			env, targets, std::to_string(target).c_str(), countValue
+		));
+	}
+	NAPI_STATUS_THROWS(::napi_set_named_property(
+		env, result, "maxWriteBufferSizeToMaintain", targets
+	));
+
+	return result;
+}
+
+void DBStats::Init(napi_env env, napi_value exports) {
+	(void)DBStats::getInstance();
+
+	napi_value writeBufferManagerStatsFn;
+	NAPI_STATUS_THROWS_VOID(::napi_create_function(
+		env,
+		"getWriteBufferManagerStats",
+		NAPI_AUTO_LENGTH,
+		DBStats::GetWriteBufferManagerStats,
+		nullptr,
+		&writeBufferManagerStatsFn
+	));
+	NAPI_STATUS_THROWS_VOID(::napi_set_named_property(
+		env, exports, "getWriteBufferManagerStats", writeBufferManagerStatsFn
+	));
+}
+
+DBStats::~DBStats() {
+	this->joinWriteBufferManagerWatchdog();
+}
+
+} // namespace rocksdb_js

--- a/src/binding/database/db_stats.cpp
+++ b/src/binding/database/db_stats.cpp
@@ -1,5 +1,6 @@
 #include "database/db_stats.h"
 #include <cstdio>
+#include <system_error>
 #include "core/platform.h"
 #include "database/db_registry.h"
 #include "database/db_settings.h"
@@ -128,6 +129,11 @@ void DBStats::disableWriteBufferManagerWatchdog() {
 	{
 		std::lock_guard<std::mutex> lock(this->watchdogMutex);
 		this->watchdogArmed = false;
+		// An explicit disable is the most recent intent and must win over an
+		// ensure() that raced an in-flight stop and is still waiting to replay
+		// once that stop resolves — otherwise the replay re-arms a watchdog
+		// this call was just told to turn off.
+		this->watchdogArmPendingAfterStop = false;
 		this->writeBufferManagerWatchdogStopping.store(true, std::memory_order_relaxed);
 		this->writeBufferManagerWatchdogRunning.store(false, std::memory_order_relaxed);
 		this->writeBufferManagerStallActiveMs.store(0, std::memory_order_relaxed);
@@ -166,11 +172,11 @@ void DBStats::joinWriteBufferManagerWatchdog() {
 	}
 	this->watchdogCv.notify_all();
 
-	// Reset-and-notify runs on scope exit, not just after a normal join: join()
-	// can throw std::system_error, and without this a throw here would leave
-	// watchdogRetiring stuck true forever, permanently wedging a concurrent
-	// joiner parked in the wait above (and dropping an ensure() call that
-	// arrived mid-stop, leaving its database with no watchdog for good).
+	// Reset-and-notify runs on scope exit rather than only after the join
+	// below, so any future fallible step added between here and the end of
+	// the function still releases a concurrent joiner parked in the wait
+	// above (and still replays an ensure() call that arrived mid-stop)
+	// instead of leaving watchdogRetiring stuck true forever.
 	struct RetireGuard {
 		DBStats* self;
 		~RetireGuard() {
@@ -188,7 +194,18 @@ void DBStats::joinWriteBufferManagerWatchdog() {
 	} retireGuard{this};
 
 	if (toJoin.joinable()) {
-		toJoin.join();
+		try {
+			toJoin.join();
+		} catch (const std::system_error&) {
+			// A join() failure (e.g. the deadlock/invalid-argument error
+			// conditions) can leave the thread object still joinable; letting
+			// it destruct in that state calls std::terminate(). Detach so the
+			// object destructs safely — RetireGuard above has already reset
+			// the flags, so no other caller stays wedged on this attempt.
+			if (toJoin.joinable()) {
+				toJoin.detach();
+			}
+		}
 	}
 }
 

--- a/src/binding/database/db_stats.cpp
+++ b/src/binding/database/db_stats.cpp
@@ -109,6 +109,13 @@ void DBStats::ensureWriteBufferManagerWatchdog() {
 		this->watchdogStarted = false;
 		this->writeBufferManagerWatchdogStopping.store(true, std::memory_order_relaxed);
 		this->writeBufferManagerWatchdogRunning.store(false, std::memory_order_relaxed);
+		// An alarm that failed to arm must not be silent — that is the failure this
+		// whole feature exists to remove. Reported, not thrown: a diagnostic thread
+		// the OS refused is no reason to fail the database open that asked for it,
+		// and the next open retries.
+		::fprintf(stderr,
+			"[rocksdb-js] could not start the WriteBufferManager stall watchdog; a write "
+			"stall will not be reported until it starts\n");
 	}
 }
 

--- a/src/binding/database/db_stats.cpp
+++ b/src/binding/database/db_stats.cpp
@@ -137,7 +137,7 @@ void DBStats::requestWriteBufferManagerWatchdogStop() {
 void DBStats::joinWriteBufferManagerWatchdog() {
 	std::thread toJoin;
 	{
-		std::lock_guard<std::mutex> lock(this->watchdogMutex);
+		std::unique_lock<std::mutex> lock(this->watchdogMutex);
 		this->watchdogArmed = false;
 		this->watchdogStopRequested = true;
 		this->writeBufferManagerWatchdogStopping.store(true, std::memory_order_relaxed);
@@ -145,6 +145,15 @@ void DBStats::joinWriteBufferManagerWatchdog() {
 		if (this->watchdogStarted) {
 			toJoin = std::move(this->watchdogThread);
 			this->watchdogStarted = false;
+			this->watchdogRetiring = true;
+		} else if (this->watchdogRetiring) {
+			// Another env is already retiring the thread. Wait for it instead of
+			// clearing the stop latch out from under it: the thread may not have
+			// observed the stop yet, and clearing it would park the thread again
+			// with the owner blocked in join() forever.
+			this->watchdogCv.notify_all();
+			this->watchdogCv.wait(lock, [this]() { return !this->watchdogRetiring; });
+			return;
 		}
 	}
 	this->watchdogCv.notify_all();
@@ -153,8 +162,12 @@ void DBStats::joinWriteBufferManagerWatchdog() {
 	}
 	{
 		std::lock_guard<std::mutex> lock(this->watchdogMutex);
+		this->watchdogRetiring = false;
+		// Held until here so `ensure` cannot start a replacement alongside a
+		// thread that is still exiting.
 		this->watchdogStopRequested = false;
 	}
+	this->watchdogCv.notify_all();
 }
 
 void DBStats::runWriteBufferManagerWatchdog() {

--- a/src/binding/database/db_stats.cpp
+++ b/src/binding/database/db_stats.cpp
@@ -109,13 +109,10 @@ void DBStats::ensureWriteBufferManagerWatchdog() {
 		this->watchdogStarted = false;
 		this->writeBufferManagerWatchdogStopping.store(true, std::memory_order_relaxed);
 		this->writeBufferManagerWatchdogRunning.store(false, std::memory_order_relaxed);
-		// An alarm that failed to arm must not be silent — that is the failure this
-		// whole feature exists to remove. Reported, not thrown: a diagnostic thread
-		// the OS refused is no reason to fail the database open that asked for it,
-		// and the next open retries.
-		::fprintf(stderr,
-			"[rocksdb-js] could not start the WriteBufferManager stall watchdog; a write "
-			"stall will not be reported until it starts\n");
+		// Deliberately no stderr line here: `ensure` runs under `databasesMutex` ->
+		// `writeBufferManagerMutex` -> `watchdogMutex`, so a blocked write would
+		// stall every database open and shutdown's flush. The failure is visible as
+		// `watchdogRunning: false`, and the next open retries.
 	}
 }
 

--- a/src/binding/database/db_stats.cpp
+++ b/src/binding/database/db_stats.cpp
@@ -23,21 +23,18 @@ constexpr const char* WBM_STALL_ACTIVE_MS_KEY = "writeBufferManager.stallActiveM
 constexpr int WBM_STALL_INVENTORY_COLLECT_ATTEMPTS = 10;
 constexpr int WBM_STALL_INVENTORY_RETRY_DELAY_MS = 50;
 
-uint64_t writeBufferManagerStallWarnMs() {
-	static const uint64_t value = [] {
-		const char* raw = ::getenv("ROCKSDB_JS_WBM_STALL_WARN_MS");
-		bool rejected = false;
-		uint64_t resolved = resolveWbmStallWarnMs(raw, &rejected);
-		if (rejected) {
-			::fprintf(stderr,
-				"[rocksdb-js] ignoring ROCKSDB_JS_WBM_STALL_WARN_MS=\"%s\" (not an integer in "
-				"[0, %llu] ms); using %llu\n",
-				raw, static_cast<unsigned long long>(WBM_STALL_WARN_MS_MAX),
-				static_cast<unsigned long long>(resolved));
-		}
-		return resolved;
-	}();
-	return value;
+uint64_t resolveWbmStallWarnMsAndWarn() {
+	const char* raw = ::getenv("ROCKSDB_JS_WBM_STALL_WARN_MS");
+	bool rejected = false;
+	uint64_t resolved = resolveWbmStallWarnMs(raw, &rejected);
+	if (rejected) {
+		::fprintf(stderr,
+			"[rocksdb-js] ignoring ROCKSDB_JS_WBM_STALL_WARN_MS=\"%s\" (not an integer in "
+			"[0, %llu] ms); using %llu\n",
+			raw, static_cast<unsigned long long>(WBM_STALL_WARN_MS_MAX),
+			static_cast<unsigned long long>(resolved));
+	}
+	return resolved;
 }
 
 bool lookupWriteBufferManagerStat(
@@ -81,7 +78,7 @@ napi_status setBoolProperty(napi_env env, napi_value target, const char* key, bo
 
 } // namespace
 
-DBStats::DBStats() {
+DBStats::DBStats() : stallWarnMs(resolveWbmStallWarnMsAndWarn()) {
 	// These dependencies must be destroyed after the watchdog owner.
 	(void)DBSettings::getInstance();
 	(void)GlobalEvents::getInstance();
@@ -92,7 +89,7 @@ void DBStats::publishWriteBufferManager(rocksdb::WriteBufferManager* writeBuffer
 }
 
 void DBStats::ensureWriteBufferManagerWatchdog() {
-	if (writeBufferManagerStallWarnMs() == 0) {
+	if (this->stallWarnMs == 0) {
 		return;
 	}
 	std::lock_guard<std::mutex> lock(this->watchdogMutex);
@@ -210,7 +207,7 @@ void DBStats::joinWriteBufferManagerWatchdog(bool allowRearm) {
 
 void DBStats::runWriteBufferManagerWatchdog() {
 	setThreadName("rocksdb-wbm-watchdog");
-	const uint64_t thresholdMs = writeBufferManagerStallWarnMs();
+	const uint64_t thresholdMs = this->stallWarnMs;
 	WbmStallWatchdogState state;
 	uint64_t activeGeneration = 0;
 	std::unique_lock<std::mutex> lock(this->watchdogMutex);
@@ -284,13 +281,7 @@ void DBStats::sampleWriteBufferManagerStall(
 	report.mutableMemoryUsage = writeBufferManager->mutable_memtable_memory_usage();
 	report.allowStall = settings.getWriteBufferManagerAllowStall();
 	report.costToCache = settings.getWriteBufferManagerCostToCache();
-	// This is the one report an episode ever gets, so a `databasesMutex`/
-	// `columnsMutex` holder that is merely busy (e.g. `DBRegistry::OpenDB`
-	// running WAL recovery, typically sub-second) shouldn't leave it
-	// permanently missing the retention histogram that is the entire point
-	// of #821. Retries stay non-blocking (still a `try_lock` each attempt)
-	// and are bounded and brief so a holder that never lets go still gets a
-	// degraded-but-timely alarm rather than delaying it.
+	// This is the one report an episode ever gets; see the retry constants above.
 	report.inventoryAvailable = DBRegistry::CollectWriteBufferManagerInventory(
 		writeBufferManager, report.columnFamilies, report.maxWriteBufferSizeToMaintain
 	);

--- a/src/binding/database/db_stats.cpp
+++ b/src/binding/database/db_stats.cpp
@@ -152,7 +152,7 @@ void DBStats::requestWriteBufferManagerWatchdogStop() {
 	this->watchdogCv.notify_all();
 }
 
-void DBStats::joinWriteBufferManagerWatchdog() {
+void DBStats::joinWriteBufferManagerWatchdog(bool allowRearm) {
 	std::thread toJoin;
 	{
 		std::unique_lock<std::mutex> lock(this->watchdogMutex);
@@ -175,10 +175,12 @@ void DBStats::joinWriteBufferManagerWatchdog() {
 	// Reset-and-notify runs on scope exit rather than only after the join
 	// below, so any future fallible step added between here and the end of
 	// the function still releases a concurrent joiner parked in the wait
-	// above (and still replays an ensure() call that arrived mid-stop)
-	// instead of leaving watchdogRetiring stuck true forever.
+	// above (and still replays an ensure() call that arrived mid-stop, when
+	// this caller allows it) instead of leaving watchdogRetiring stuck true
+	// forever.
 	struct RetireGuard {
 		DBStats* self;
+		bool allowRearm;
 		~RetireGuard() {
 			{
 				std::lock_guard<std::mutex> lock(self->watchdogMutex);
@@ -186,12 +188,14 @@ void DBStats::joinWriteBufferManagerWatchdog() {
 				self->watchdogStopRequested = false;
 				if (self->watchdogArmPendingAfterStop) {
 					self->watchdogArmPendingAfterStop = false;
-					self->armWatchdogLocked();
+					if (allowRearm) {
+						self->armWatchdogLocked();
+					}
 				}
 			}
 			self->watchdogCv.notify_all();
 		}
-	} retireGuard{this};
+	} retireGuard{this, allowRearm};
 
 	if (toJoin.joinable()) {
 		try {
@@ -411,7 +415,9 @@ void DBStats::Init(napi_env env, napi_value exports) {
 }
 
 DBStats::~DBStats() {
-	this->joinWriteBufferManagerWatchdog();
+	// True process exit: never spawn a replacement thread here, since nothing
+	// will join it again.
+	this->joinWriteBufferManagerWatchdog(false);
 }
 
 } // namespace rocksdb_js

--- a/src/binding/database/db_stats.h
+++ b/src/binding/database/db_stats.h
@@ -55,6 +55,7 @@ private:
 	bool watchdogStopRequested = false;
 	/** One joiner owns the retiring thread; the rest wait for it. */
 	bool watchdogRetiring = false;
+	uint64_t watchdogArmRequestGeneration = 0;
 	/**
 	 * An `ensure` call arrived while a stop was in flight (e.g. `db.open()`
 	 * racing `shutdown()`'s `DBRegistry::Shutdown()`, which closes databases
@@ -86,17 +87,12 @@ public:
 	void publishWriteBufferManager(rocksdb::WriteBufferManager* writeBufferManager);
 	void ensureWriteBufferManagerWatchdog();
 	void disableWriteBufferManagerWatchdog();
-	void requestWriteBufferManagerWatchdogStop();
+	uint64_t beginWriteBufferManagerWatchdogShutdown();
 	/**
-	 * `allowRearm` distinguishes the two callers: the explicit, JS-callable
-	 * `shutdown()` documents that databases may reopen afterward, so an
-	 * `ensure` that raced its stop should replay once the join resolves. The
-	 * module's last-env cleanup hook and ~DBStats() cannot tell "shutdown,
-	 * may reopen" from "process is ending" — a thread spawned there could
-	 * outlive the join that is supposed to retire it — so both pass false
-	 * and simply drop a queued replay, same as before this ever tracked one.
+	 * The explicit shutdown path may rearm after a concurrent open. Its
+	 * generation prevents an older shutdown caller from retiring that replacement.
 	 */
-	void joinWriteBufferManagerWatchdog(bool allowRearm);
+	void joinWriteBufferManagerWatchdog(bool allowRearm, uint64_t shutdownGeneration);
 
 	bool getWriteBufferManagerStat(const std::string& statName, double& value);
 	void setWriteBufferManagerStatsOnObject(napi_env env, napi_value result);

--- a/src/binding/database/db_stats.h
+++ b/src/binding/database/db_stats.h
@@ -77,7 +77,16 @@ public:
 	void ensureWriteBufferManagerWatchdog();
 	void disableWriteBufferManagerWatchdog();
 	void requestWriteBufferManagerWatchdogStop();
-	void joinWriteBufferManagerWatchdog();
+	/**
+	 * `allowRearm` distinguishes the two callers: the explicit, JS-callable
+	 * `shutdown()` documents that databases may reopen afterward, so an
+	 * `ensure` that raced its stop should replay once the join resolves. The
+	 * module's last-env cleanup hook and ~DBStats() cannot tell "shutdown,
+	 * may reopen" from "process is ending" — a thread spawned there could
+	 * outlive the join that is supposed to retire it — so both pass false
+	 * and simply drop a queued replay, same as before this ever tracked one.
+	 */
+	void joinWriteBufferManagerWatchdog(bool allowRearm);
 
 	bool getWriteBufferManagerStat(const std::string& statName, double& value);
 	void setWriteBufferManagerStatsOnObject(napi_env env, napi_value result);

--- a/src/binding/database/db_stats.h
+++ b/src/binding/database/db_stats.h
@@ -32,8 +32,6 @@ class DBStats final {
 private:
 	DBStats();
 
-	// DBSettings owns the manager and outlives this singleton. The raw pointer is
-	// published once so scrape paths never contend with config() or database open.
 	std::atomic<rocksdb::WriteBufferManager*> writeBufferManager{nullptr};
 	std::atomic<uint64_t> writeBufferManagerStallActiveMs{0};
 	std::atomic<bool> writeBufferManagerWatchdogRunning{false};

--- a/src/binding/database/db_stats.h
+++ b/src/binding/database/db_stats.h
@@ -53,7 +53,7 @@ private:
 	bool watchdogStarted = false;
 	bool watchdogArmed = false;
 	bool watchdogStopRequested = false;
-	/** One joiner owns the retiring thread; the rest wait for it. */
+	/** One joiner owns the retirement; the rest wait for it. */
 	bool watchdogRetiring = false;
 	uint64_t watchdogArmRequestGeneration = 0;
 	/**

--- a/src/binding/database/db_stats.h
+++ b/src/binding/database/db_stats.h
@@ -41,11 +41,16 @@ private:
 	std::mutex watchdogMutex;
 	std::condition_variable watchdogCv;
 	bool watchdogStarted = false;
+	bool watchdogArmed = false;
 	bool watchdogStopRequested = false;
-	uint64_t watchdogGeneration = 0;
+	std::atomic<uint64_t> watchdogGeneration{0};
 
-	void runWriteBufferManagerWatchdog(uint64_t generation);
-	void sampleWriteBufferManagerStall(WbmStallWatchdogState& state, uint64_t thresholdMs);
+	void runWriteBufferManagerWatchdog();
+	void sampleWriteBufferManagerStall(
+		WbmStallWatchdogState& state,
+		uint64_t thresholdMs,
+		uint64_t generation
+	);
 	WriteBufferManagerStats getWriteBufferManagerStats(bool includeColumnFamilies);
 
 	static napi_value GetWriteBufferManagerStats(napi_env env, napi_callback_info info);
@@ -58,6 +63,7 @@ public:
 
 	void publishWriteBufferManager(rocksdb::WriteBufferManager* writeBufferManager);
 	void ensureWriteBufferManagerWatchdog();
+	void disableWriteBufferManagerWatchdog();
 	void requestWriteBufferManagerWatchdogStop();
 	void joinWriteBufferManagerWatchdog();
 

--- a/src/binding/database/db_stats.h
+++ b/src/binding/database/db_stats.h
@@ -43,6 +43,8 @@ private:
 	bool watchdogStarted = false;
 	bool watchdogArmed = false;
 	bool watchdogStopRequested = false;
+	/** One joiner owns the retiring thread; the rest wait for it. */
+	bool watchdogRetiring = false;
 	std::atomic<uint64_t> watchdogGeneration{0};
 
 	void runWriteBufferManagerWatchdog();

--- a/src/binding/database/db_stats.h
+++ b/src/binding/database/db_stats.h
@@ -1,0 +1,75 @@
+#ifndef __DB_STATS_H__
+#define __DB_STATS_H__
+
+#include <atomic>
+#include <condition_variable>
+#include <map>
+#include <mutex>
+#include <node_api.h>
+#include <string>
+#include <thread>
+#include "core/wbm_stall_watchdog.h"
+#include "rocksdb/write_buffer_manager.h"
+
+namespace rocksdb_js {
+
+struct WriteBufferManagerStats final {
+	bool enabled = false;
+	uint64_t bufferSize = 0;
+	uint64_t memoryUsage = 0;
+	uint64_t mutableMemoryUsage = 0;
+	bool allowStall = false;
+	bool costToCache = false;
+	bool stallActive = false;
+	uint64_t stallActiveMs = 0;
+	bool watchdogRunning = false;
+	uint64_t columnFamilies = 0;
+	std::map<int64_t, uint64_t> maxWriteBufferSizeToMaintain;
+	bool inventoryAvailable = true;
+};
+
+class DBStats final {
+private:
+	DBStats();
+
+	// DBSettings owns the manager and outlives this singleton. The raw pointer is
+	// published once so scrape paths never contend with config() or database open.
+	std::atomic<rocksdb::WriteBufferManager*> writeBufferManager{nullptr};
+	std::atomic<uint64_t> writeBufferManagerStallActiveMs{0};
+	std::atomic<bool> writeBufferManagerWatchdogRunning{false};
+	std::atomic<bool> writeBufferManagerWatchdogStopping{false};
+
+	std::thread watchdogThread;
+	std::mutex watchdogMutex;
+	std::condition_variable watchdogCv;
+	bool watchdogStarted = false;
+	bool watchdogStopRequested = false;
+	uint64_t watchdogGeneration = 0;
+
+	void runWriteBufferManagerWatchdog(uint64_t generation);
+	void sampleWriteBufferManagerStall(WbmStallWatchdogState& state, uint64_t thresholdMs);
+	WriteBufferManagerStats getWriteBufferManagerStats(bool includeColumnFamilies);
+
+	static napi_value GetWriteBufferManagerStats(napi_env env, napi_callback_info info);
+
+public:
+	static DBStats& getInstance() {
+		static DBStats instance;
+		return instance;
+	}
+
+	void publishWriteBufferManager(rocksdb::WriteBufferManager* writeBufferManager);
+	void ensureWriteBufferManagerWatchdog();
+	void requestWriteBufferManagerWatchdogStop();
+	void joinWriteBufferManagerWatchdog();
+
+	bool getWriteBufferManagerStat(const std::string& statName, double& value);
+	void setWriteBufferManagerStatsOnObject(napi_env env, napi_value result);
+
+	static void Init(napi_env env, napi_value exports);
+	~DBStats();
+};
+
+} // namespace rocksdb_js
+
+#endif

--- a/src/binding/database/db_stats.h
+++ b/src/binding/database/db_stats.h
@@ -32,6 +32,16 @@ class DBStats final {
 private:
 	DBStats();
 
+	/**
+	 * Resolved once, in the constructor (`DBStats::Init` materializes the
+	 * singleton at module load, on the JS thread, with no locks held) —
+	 * never lazily from `ensureWriteBufferManagerWatchdog()`, which callers
+	 * reach under `databasesMutex -> writeBufferManagerMutex`. A malformed
+	 * env var's warning is a blocking stderr write, and resolving lazily
+	 * would risk making that first, one-time write run under those locks.
+	 */
+	const uint64_t stallWarnMs;
+
 	std::atomic<rocksdb::WriteBufferManager*> writeBufferManager{nullptr};
 	std::atomic<uint64_t> writeBufferManagerStallActiveMs{0};
 	std::atomic<bool> writeBufferManagerWatchdogRunning{false};

--- a/src/binding/database/db_stats.h
+++ b/src/binding/database/db_stats.h
@@ -45,8 +45,18 @@ private:
 	bool watchdogStopRequested = false;
 	/** One joiner owns the retiring thread; the rest wait for it. */
 	bool watchdogRetiring = false;
+	/**
+	 * An `ensure` call arrived while a stop was in flight (e.g. `db.open()`
+	 * racing `shutdown()`'s `DBRegistry::Shutdown()`, which closes databases
+	 * without holding `databasesMutex`). `watchdogStopRequested` is the only
+	 * signal that stop is resolved, so without this flag that reset is the
+	 * last anyone hears from the bailed call: the database it was arming for
+	 * is left with no watchdog for the rest of the process.
+	 */
+	bool watchdogArmPendingAfterStop = false;
 	std::atomic<uint64_t> watchdogGeneration{0};
 
+	void armWatchdogLocked();
 	void runWriteBufferManagerWatchdog();
 	void sampleWriteBufferManagerStall(
 		WbmStallWatchdogState& state,

--- a/src/binding/napi/global_events.h
+++ b/src/binding/napi/global_events.h
@@ -23,10 +23,18 @@ public:
 	 * Uses C++11 magic-static initialization, mirroring `DBSettings::getInstance`,
 	 * so concurrent first-callers from worker threads don't race during
 	 * construction.
+	 *
+	 * Deliberately leaked. Block-scope statics are destroyed in reverse order of
+	 * construction, and this one is normally constructed *after* `DBSettings` (it
+	 * takes a listener registration or an emit; `DBSettings` takes the first
+	 * `config()`), so it would be destroyed *first* — while `~DBSettings` is still
+	 * joining the WriteBufferManager stall watchdog, whose report path emits here.
+	 * On the `process.exit()` path that skips the module's cleanup hook, that is a
+	 * lock on a destroyed mutex during exactly the stall this exists to report.
 	 */
 	static EventEmitter& getInstance() {
-		static EventEmitter instance;
-		return instance;
+		static EventEmitter* instance = new EventEmitter();
+		return *instance;
 	}
 
 	GlobalEvents() = delete;

--- a/src/binding/napi/global_events.h
+++ b/src/binding/napi/global_events.h
@@ -24,17 +24,12 @@ public:
 	 * so concurrent first-callers from worker threads don't race during
 	 * construction.
 	 *
-	 * Deliberately leaked. Block-scope statics are destroyed in reverse order of
-	 * construction, and this one is normally constructed *after* `DBSettings` (it
-	 * takes a listener registration or an emit; `DBSettings` takes the first
-	 * `config()`), so it would be destroyed *first* — while `~DBSettings` is still
-	 * joining the WriteBufferManager stall watchdog, whose report path emits here.
-	 * On the `process.exit()` path that skips the module's cleanup hook, that is a
-	 * lock on a destroyed mutex during exactly the stall this exists to report.
+	 * `DBStats` constructs this before its watchdog-owning singleton completes,
+	 * so the emitter outlives the watchdog during static destruction.
 	 */
 	static EventEmitter& getInstance() {
-		static EventEmitter* instance = new EventEmitter();
-		return *instance;
+		static EventEmitter instance;
+		return instance;
 	}
 
 	GlobalEvents() = delete;

--- a/src/binding/napi/global_events.h
+++ b/src/binding/napi/global_events.h
@@ -23,9 +23,6 @@ public:
 	 * Uses C++11 magic-static initialization, mirroring `DBSettings::getInstance`,
 	 * so concurrent first-callers from worker threads don't race during
 	 * construction.
-	 *
-	 * `DBStats` constructs this before its watchdog-owning singleton completes,
-	 * so the emitter outlives the watchdog during static destruction.
 	 */
 	static EventEmitter& getInstance() {
 		static EventEmitter instance;

--- a/src/binding/transaction_log/transaction_log.cpp
+++ b/src/binding/transaction_log/transaction_log.cpp
@@ -336,8 +336,9 @@ napi_value TransactionLog::GetPath(napi_env env, napi_callback_info info) {
 	UNWRAP_TRANSACTION_LOG_HANDLE("GetPath");
 	auto store = (*txnLogHandle)->store.lock();
 	if (store) {
+		const auto path = store->displayPath.string();
 		napi_value result;
-		NAPI_STATUS_THROWS(::napi_create_string_utf8(env, store->path.string().c_str(), store->path.string().size(), &result));
+		NAPI_STATUS_THROWS(::napi_create_string_utf8(env, path.c_str(), path.size(), &result));
 		return result;
 	}
 	NAPI_RETURN_UNDEFINED();

--- a/src/binding/transaction_log/transaction_log_store.cpp
+++ b/src/binding/transaction_log/transaction_log_store.cpp
@@ -459,8 +459,9 @@ std::vector<TransactionLogBackupEntry> TransactionLogStore::snapshotForBackup() 
 				// back up. Other open failures propagate: the segment may be healthy,
 				// and reporting success would publish an incomplete backup.
 				if (!file->malformedBackupWarningEmitted.exchange(true, std::memory_order_relaxed)) {
+					const auto displayFilePath = this->displayPath / file->path.filename();
 					std::ostringstream msg;
-					msg << "Transaction log segment " << file->path.string()
+					msg << "Transaction log segment " << displayFilePath.string()
 						<< " could not be opened to measure its extent (" << e.what()
 						<< "); it is excluded from this backup.";
 					DEBUG_LOG("%p TransactionLogStore::snapshotForBackup WARNING: %s\n", this, msg.str().c_str());

--- a/src/database.ts
+++ b/src/database.ts
@@ -11,6 +11,7 @@ import type { BufferWithDataView, Encoder, EncoderFunction, Key } from './encodi
 import {
 	addGlobalListener,
 	config,
+	getWriteBufferManagerStats,
 	globalListenerCount,
 	globalNotify,
 	removeGlobalListener,
@@ -21,6 +22,7 @@ import {
 	type PurgeLogsOptions,
 	type RocksDatabaseConfig,
 	type NativeTransactionOptions,
+	type WriteBufferManagerStats,
 } from './load-binding.ts';
 import type { StatsAll, StatsDefault, StatsValue } from './stats.ts';
 import {
@@ -363,6 +365,35 @@ export class RocksDatabase extends DBI<DBITransactional> {
 	 */
 	static config(options: RocksDatabaseConfig): void {
 		config(options);
+	}
+
+	/**
+	 * Reads the live state of the `WriteBufferManager`: its budget, how much
+	 * memtable memory is charged against it, how much of that is still mutable,
+	 * and whether it is currently stalling writes.
+	 *
+	 * **Process-wide, not per-database.** The manager is a singleton shared by
+	 * every database opened in this process, `worker_threads` included, so these
+	 * values describe the whole process no matter which database prompted the
+	 * call. The same values (minus the column-family inventory, which walks the
+	 * database registry) are also in `db.getStats()` under the same
+	 * `writeBufferManager.` prefix, for scraping.
+	 *
+	 * A stall here is invisible to RocksDB's own counters — `rocksdb.stall.micros`
+	 * and the `'writeStall'` event both track the WriteController, which a
+	 * WriteBufferManager stall never goes through — so `stallActive` is the signal
+	 * that distinguishes a stalled process from an idle one.
+	 *
+	 * @example
+	 * ```typescript
+	 * const wbm = RocksDatabase.getWriteBufferManagerStats();
+	 * if (wbm.stallActive) {
+	 * 	log.warn(`writes stalled for ${wbm.stallActiveMs}ms: ${wbm.memoryUsage}/${wbm.bufferSize}`);
+	 * }
+	 * ```
+	 */
+	static getWriteBufferManagerStats(): WriteBufferManagerStats {
+		return getWriteBufferManagerStats();
 	}
 
 	/**

--- a/src/database.ts
+++ b/src/database.ts
@@ -11,7 +11,6 @@ import type { BufferWithDataView, Encoder, EncoderFunction, Key } from './encodi
 import {
 	addGlobalListener,
 	config,
-	getWriteBufferManagerStats,
 	globalListenerCount,
 	globalNotify,
 	removeGlobalListener,
@@ -22,7 +21,6 @@ import {
 	type PurgeLogsOptions,
 	type RocksDatabaseConfig,
 	type NativeTransactionOptions,
-	type WriteBufferManagerStats,
 } from './load-binding.ts';
 import type { StatsAll, StatsDefault, StatsValue } from './stats.ts';
 import {
@@ -365,35 +363,6 @@ export class RocksDatabase extends DBI<DBITransactional> {
 	 */
 	static config(options: RocksDatabaseConfig): void {
 		config(options);
-	}
-
-	/**
-	 * Reads the live state of the `WriteBufferManager`: its budget, how much
-	 * memtable memory is charged against it, how much of that is still mutable,
-	 * and whether it is currently stalling writes.
-	 *
-	 * **Process-wide, not per-database.** The manager is a singleton shared by
-	 * every database opened in this process, `worker_threads` included, so these
-	 * values describe the whole process no matter which database prompted the
-	 * call. The same values (minus the column-family inventory, which walks the
-	 * database registry) are also in `db.getStats()` under the same
-	 * `writeBufferManager.` prefix, for scraping.
-	 *
-	 * A stall here is invisible to RocksDB's own counters — `rocksdb.stall.micros`
-	 * and the `'writeStall'` event both track the WriteController, which a
-	 * WriteBufferManager stall never goes through — so `stallActive` is the signal
-	 * that distinguishes a stalled process from an idle one.
-	 *
-	 * @example
-	 * ```typescript
-	 * const wbm = RocksDatabase.getWriteBufferManagerStats();
-	 * if (wbm.stallActive) {
-	 * 	log.warn(`writes stalled for ${wbm.stallActiveMs}ms: ${wbm.memoryUsage}/${wbm.bufferSize}`);
-	 * }
-	 * ```
-	 */
-	static getWriteBufferManagerStats(): WriteBufferManagerStats {
-		return getWriteBufferManagerStats();
 	}
 
 	/**

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,7 @@ export {
 	coolTransactionLogs,
 	currentThreadId,
 	fileLockRelease,
+	getWriteBufferManagerStats,
 	tryFileLock,
 	registryStatus,
 	stats,
@@ -36,6 +37,7 @@ export {
 	type TransactionEntry,
 	type TransactionLogPosition,
 	type TransactionLogStats,
+	type WriteBufferManagerStats,
 } from './load-binding.ts';
 export * from './parse-transaction-log.ts';
 export {

--- a/src/load-binding.ts
+++ b/src/load-binding.ts
@@ -681,7 +681,13 @@ export const BackgroundError: new (
  * {@link getWriteBufferManagerStats}.
  */
 export type WriteBufferManagerStats = {
-	/** Whether a manager has been created in this process. All other values are 0/false when not. */
+	/**
+	 * Whether a manager has been created in this process. `bufferSize`,
+	 * `memoryUsage`, `mutableMemoryUsage`, `stallActive`, `stallActiveMs`,
+	 * `watchdogRunning` and `columnFamilies` are 0/false when not; `allowStall`
+	 * and `costToCache` still reflect the configured setting, and
+	 * `inventoryAvailable` is `true`.
+	 */
 	enabled: boolean;
 	/** The manager's budget in bytes (`writeBufferManagerSize`, live). */
 	bufferSize: number;

--- a/src/load-binding.ts
+++ b/src/load-binding.ts
@@ -849,6 +849,12 @@ export const transactionLogMapCount: () => number = binding.transactionLogMapCou
  */
 export const forceTryAgainForTesting: (count: number) => void = binding.forceTryAgainForTesting;
 
+/** Delays one selected watchdog join in the concurrent-shutdown regression test. */
+export const setWriteBufferManagerJoinDelayForTesting: (
+	countdown: number,
+	delayMs: number
+) => void = binding.setWriteBufferManagerJoinDelayForTesting;
+
 /**
  * Creates a native file lock using the specified file path (`flock` on POSIX,
  * `LockFileEx` on Windows), creating the file and any missing parent

--- a/src/load-binding.ts
+++ b/src/load-binding.ts
@@ -697,7 +697,6 @@ export type WriteBufferManagerStats = {
 	mutableMemoryUsage: number;
 	allowStall: boolean;
 	costToCache: boolean;
-	/** Whether the manager is currently stalling writes. */
 	stallActive: boolean;
 	/**
 	 * How long the current stall has been active, in milliseconds; 0 when not

--- a/src/load-binding.ts
+++ b/src/load-binding.ts
@@ -676,7 +676,48 @@ export const BackgroundError: new (
 	> & { type?: string }
 ) => BackgroundError = binding.BackgroundError;
 
+/**
+ * Live state of the process-wide `WriteBufferManager` singleton — see
+ * {@link RocksDatabase.getWriteBufferManagerStats}.
+ */
+export type WriteBufferManagerStats = {
+	/** Whether a manager has been created in this process. All other values are 0/false when not. */
+	enabled: boolean;
+	/** The manager's budget in bytes (`writeBufferManagerSize`, live). */
+	bufferSize: number;
+	/** Total memtable memory charged to the manager, in bytes. */
+	memoryUsage: number;
+	/** The share of `memoryUsage` held by active (mutable) memtables, in bytes. */
+	mutableMemoryUsage: number;
+	allowStall: boolean;
+	costToCache: boolean;
+	/** Whether the manager is currently stalling writes. */
+	stallActive: boolean;
+	/**
+	 * How long the current stall has been active, in milliseconds; 0 when not
+	 * stalled. Sampled once a second by the stall watchdog, so it is 0 for the
+	 * first second of a stall and whenever `watchdogRunning` is false.
+	 */
+	stallActiveMs: number;
+	/**
+	 * Whether the stall watchdog is running. It runs only while a manager exists
+	 * with `writeBufferManagerAllowStall`, and only when
+	 * `ROCKSDB_JS_WBM_STALL_WARN_MS` is not `0`.
+	 */
+	watchdogRunning: boolean;
+	/** Live column families across every writable database attached to this manager. */
+	columnFamilies: number;
+	/**
+	 * Effective per-column-family `max_write_buffer_size_to_maintain` (as a decimal
+	 * string) to the number of those column families holding it. Effective, not
+	 * requested: RocksDB rewrites a requested `0` for a transaction database.
+	 */
+	maxWriteBufferSizeToMaintain: Record<string, number>;
+};
+
 export const config: (options: RocksDatabaseConfig) => void = binding.config;
+export const getWriteBufferManagerStats: () => WriteBufferManagerStats =
+	binding.getWriteBufferManagerStats;
 export const FRESH_VERSION_FLAG: number = binding.constants.FRESH_VERSION_FLAG;
 export const addGlobalListener: (event: string, callback: (...args: any[]) => void) => void =
 	binding.addListener;

--- a/src/load-binding.ts
+++ b/src/load-binding.ts
@@ -705,7 +705,11 @@ export type WriteBufferManagerStats = {
 	 * `ROCKSDB_JS_WBM_STALL_WARN_MS` is not `0`.
 	 */
 	watchdogRunning: boolean;
-	/** Live column families across every writable database attached to this manager. */
+	/**
+	 * Live column families across every database attached to this manager. A
+	 * dropped column family keeps charging the manager until its last handle
+	 * closes, so it is counted until then.
+	 */
 	columnFamilies: number;
 	/**
 	 * `false` when the column-family inventory could not be collected because the

--- a/src/load-binding.ts
+++ b/src/load-binding.ts
@@ -678,7 +678,7 @@ export const BackgroundError: new (
 
 /**
  * Live state of the process-wide `WriteBufferManager` singleton — see
- * {@link RocksDatabase.getWriteBufferManagerStats}.
+ * {@link getWriteBufferManagerStats}.
  */
 export type WriteBufferManagerStats = {
 	/** Whether a manager has been created in this process. All other values are 0/false when not. */
@@ -723,6 +723,25 @@ export type WriteBufferManagerStats = {
 };
 
 export const config: (options: RocksDatabaseConfig) => void = binding.config;
+/**
+ * Reads the live state of the process-wide `WriteBufferManager`: its budget,
+ * charged memory, mutable share, stall state, and attached column-family
+ * inventory. The manager is shared by every database and worker thread in the
+ * process.
+ *
+ * A WriteBufferManager stall does not pass through RocksDB's `WriteController`,
+ * so it is not reflected by `rocksdb.stall.micros`, `db.isWriteStalled()`, or
+ * the `'writeStall'` event. Use `stallActive` to distinguish this condition from
+ * an idle database.
+ *
+ * @example
+ * ```typescript
+ * const wbm = getWriteBufferManagerStats();
+ * if (wbm.stallActive) {
+ * 	log.warn(`writes stalled for ${wbm.stallActiveMs}ms`);
+ * }
+ * ```
+ */
 export const getWriteBufferManagerStats: () => WriteBufferManagerStats =
 	binding.getWriteBufferManagerStats;
 export const FRESH_VERSION_FLAG: number = binding.constants.FRESH_VERSION_FLAG;

--- a/src/load-binding.ts
+++ b/src/load-binding.ts
@@ -708,6 +708,13 @@ export type WriteBufferManagerStats = {
 	/** Live column families across every writable database attached to this manager. */
 	columnFamilies: number;
 	/**
+	 * `false` when the column-family inventory could not be collected because the
+	 * database registry was locked — most plausibly by a close that is itself
+	 * waiting out this stall. `columnFamilies` is then `0` and
+	 * `maxWriteBufferSizeToMaintain` empty; every other field is still live.
+	 */
+	inventoryAvailable: boolean;
+	/**
 	 * Effective per-column-family `max_write_buffer_size_to_maintain` (as a decimal
 	 * string) to the number of those column families holding it. Effective, not
 	 * requested: RocksDB rewrites a requested `0` for a transaction database.

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -1,4 +1,10 @@
-/** Database-level RocksDB statistics types for `db.getStats()` / `db.getStat()`. */
+/**
+ * Database-level RocksDB statistics types for `db.getStats()` / `db.getStat()`.
+ *
+ * The `writeBufferManager.*` keys are the exception to "database-level": the
+ * WriteBufferManager is a process-wide singleton, so those values describe every
+ * database in the process. See `RocksDatabase.getWriteBufferManagerStats()`.
+ */
 
 export type StatsHistogramData = {
 	average: number;
@@ -52,6 +58,11 @@ export type StatsBasics = {
 	'txnlog.replayGapBytes': number;
 	'commitPipeline.logQueueDepth': number;
 	'commitPipeline.commitQueueDepth': number;
+	'writeBufferManager.bufferSize': number;
+	'writeBufferManager.memoryUsage': number;
+	'writeBufferManager.mutableMemoryUsage': number;
+	'writeBufferManager.stallActive': number;
+	'writeBufferManager.stallActiveMs': number;
 };
 
 export type StatsCuratedExtras = {

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -3,7 +3,7 @@
  *
  * The `writeBufferManager.*` keys are the exception to "database-level": the
  * WriteBufferManager is a process-wide singleton, so those values describe every
- * database in the process. See `RocksDatabase.getWriteBufferManagerStats()`.
+ * database in the process. See `getWriteBufferManagerStats()`.
  */
 
 export type StatsHistogramData = {

--- a/test/backup-transaction-logs.test.ts
+++ b/test/backup-transaction-logs.test.ts
@@ -14,9 +14,8 @@ import {
 	writeFileSync,
 } from 'node:fs';
 import { basename, join } from 'node:path';
-import { setTimeout as delay } from 'node:timers/promises';
 import * as tar from 'tar';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 const tempPaths: string[] = [];
 const {
@@ -137,8 +136,7 @@ describe('Transaction log backups', () => {
 
 				expect(existsSync(join(backedUpStore, basename(lazySegment)))).toBe(false);
 				expect(readdirSync(backedUpStore).length).toBe(63);
-				await delay(0);
-				expect(warnings).toHaveLength(1);
+				await vi.waitFor(() => expect(warnings).toHaveLength(1));
 			} finally {
 				RocksDatabase.off('log.warn', onWarning);
 			}

--- a/test/fixtures/fork-wbm-stall-watchdog.mts
+++ b/test/fixtures/fork-wbm-stall-watchdog.mts
@@ -1,0 +1,92 @@
+import { RocksDatabase } from '../../src/index.ts';
+import { createWorkerBootstrapScript } from '../lib/worker-bootstrap.ts';
+import { setTimeout as delay } from 'node:timers/promises';
+import { Worker } from 'node:worker_threads';
+
+const dbPath = process.argv[2];
+
+if (!dbPath) {
+	console.error('Usage: fork-wbm-stall-watchdog.mts <dbPath>');
+	process.exit(1);
+}
+
+const COLUMN_FAMILIES = 4;
+// Explicit, and far above the budget: the derived default already resolves to 0
+// under a stalling manager, so only an explicit retention target fills the budget
+// with history nothing can release.
+const MAINTAIN = 32 * 1024 * 1024;
+const BUDGET = 4 * 1024 * 1024;
+
+RocksDatabase.config({
+	blockCacheSize: 8 * 1024 * 1024,
+	writeBufferManagerSize: BUDGET,
+	writeBufferManagerAllowStall: true,
+});
+
+// This thread never writes: it is the observer, and a write here would park it in
+// the same stall it is trying to report on.
+const db = RocksDatabase.open(dbPath, { maxWriteBufferSizeToMaintain: MAINTAIN });
+
+const worker = new Worker(
+	createWorkerBootstrapScript('./test/workers/wbm-stall-writer-worker.mts'),
+	{
+		eval: true,
+		workerData: { path: dbPath, columnFamilies: COLUMN_FAMILIES, maintain: MAINTAIN },
+	}
+);
+worker.unref();
+await new Promise<void>((resolve, reject) => {
+	worker.once('message', () => resolve());
+	worker.once('error', reject);
+});
+
+// Poll until the stall has been active long enough for the watchdog to have
+// reported, plus several more of its samples to prove it does not repeat.
+const OBSERVE_AFTER_REPORT_MS = 6000;
+const deadline = Date.now() + 90_000;
+let sawStall = false;
+let stalledSince = 0;
+while (Date.now() < deadline) {
+	const stats = RocksDatabase.getWriteBufferManagerStats();
+	const fromGetStats = db.getStats();
+	console.log(
+		`STATS ${JSON.stringify({
+			stats,
+			getStats: {
+				bufferSize: fromGetStats['writeBufferManager.bufferSize'],
+				memoryUsage: fromGetStats['writeBufferManager.memoryUsage'],
+				mutableMemoryUsage: fromGetStats['writeBufferManager.mutableMemoryUsage'],
+				stallActive: fromGetStats['writeBufferManager.stallActive'],
+				stallActiveMs: fromGetStats['writeBufferManager.stallActiveMs'],
+			},
+			getStat: {
+				bufferSize: db.getStat('writeBufferManager.bufferSize'),
+				stallActive: db.getStat('writeBufferManager.stallActive'),
+				stallActiveMs: db.getStat('writeBufferManager.stallActiveMs'),
+			},
+		})}`
+	);
+	if (stats.stallActive) {
+		if (!sawStall) {
+			sawStall = true;
+			stalledSince = Date.now();
+		}
+	} else if (sawStall) {
+		// The stall cleared before the observation window closed; this run cannot
+		// prove the one-line property, so say so rather than assert on it.
+		console.log('CLEARED');
+		break;
+	}
+	if (sawStall && Date.now() - stalledSince > OBSERVE_AFTER_REPORT_MS) {
+		break;
+	}
+	await delay(250);
+}
+
+console.log(sawStall ? 'STALLED' : 'NEVER_STALLED');
+
+// The parent owns the deadline and kills this process. It cannot exit on its own:
+// the writer thread is parked inside RocksDB, so teardown would wedge in close()
+// waiting on the same stall (see AGENTS.md note 16) — which is precisely why a
+// test that reaches a real stall has to be driven from a killable child.
+setInterval(() => {}, 1000);

--- a/test/fixtures/fork-wbm-stall-watchdog.mts
+++ b/test/fixtures/fork-wbm-stall-watchdog.mts
@@ -27,6 +27,12 @@ RocksDatabase.config({
 // the same stall it is trying to report on.
 const db = RocksDatabase.open(dbPath, { maxWriteBufferSizeToMaintain: MAINTAIN });
 
+// The programmatic half of the warn line. It reaches this thread through a
+// threadsafe function, so it is only delivered because nothing here is blocked.
+RocksDatabase.on('log.warn', (message: string) => {
+	console.log(`WARNED ${message}`);
+});
+
 const worker = new Worker(
 	createWorkerBootstrapScript('./test/workers/wbm-stall-writer-worker.mts'),
 	{

--- a/test/fixtures/fork-wbm-stall-watchdog.mts
+++ b/test/fixtures/fork-wbm-stall-watchdog.mts
@@ -51,6 +51,7 @@ await new Promise<void>((resolve, reject) => {
 const OBSERVE_AFTER_REPORT_MS = 6000;
 const deadline = Date.now() + 90_000;
 let sawStall = false;
+let cleared = false;
 let stalledSince = 0;
 while (Date.now() < deadline) {
 	const stats = RocksDatabase.getWriteBufferManagerStats();
@@ -78,9 +79,10 @@ while (Date.now() < deadline) {
 			stalledSince = Date.now();
 		}
 	} else if (sawStall) {
-		// The stall cleared before the observation window closed; this run cannot
-		// prove the one-line property, so say so rather than assert on it.
-		console.log('CLEARED');
+		// A stall that cleared mid-window could produce a second episode, and with
+		// it a second warn line, so this run cannot prove the once-per-episode
+		// property. Report it as its own outcome instead of as a reached stall.
+		cleared = true;
 		break;
 	}
 	if (sawStall && Date.now() - stalledSince > OBSERVE_AFTER_REPORT_MS) {
@@ -89,7 +91,7 @@ while (Date.now() < deadline) {
 	await delay(250);
 }
 
-console.log(sawStall ? 'STALLED' : 'NEVER_STALLED');
+console.log(cleared ? 'CLEARED' : sawStall ? 'STALLED' : 'NEVER_STALLED');
 
 // The parent owns the deadline and kills this process. It cannot exit on its own:
 // the writer thread is parked inside RocksDB, so teardown would wedge in close()

--- a/test/fixtures/fork-wbm-stall-watchdog.mts
+++ b/test/fixtures/fork-wbm-stall-watchdog.mts
@@ -49,11 +49,11 @@ await new Promise<void>((resolve, reject) => {
 // Poll until the stall has been active long enough for the watchdog to have
 // reported, plus several more of its samples to prove it does not repeat.
 const OBSERVE_AFTER_REPORT_MS = 6000;
-const deadline = Date.now() + 90_000;
+const deadline = performance.now() + 90_000;
 let sawStall = false;
 let cleared = false;
 let stalledSince = 0;
-while (Date.now() < deadline) {
+while (performance.now() < deadline) {
 	const stats = RocksDatabase.getWriteBufferManagerStats();
 	const fromGetStats = db.getStats();
 	console.log(
@@ -76,7 +76,7 @@ while (Date.now() < deadline) {
 	if (stats.stallActive) {
 		if (!sawStall) {
 			sawStall = true;
-			stalledSince = Date.now();
+			stalledSince = performance.now();
 		}
 	} else if (sawStall) {
 		// A stall that cleared mid-window could produce a second episode, and with
@@ -85,7 +85,7 @@ while (Date.now() < deadline) {
 		cleared = true;
 		break;
 	}
-	if (sawStall && Date.now() - stalledSince > OBSERVE_AFTER_REPORT_MS) {
+	if (sawStall && performance.now() - stalledSince > OBSERVE_AFTER_REPORT_MS) {
 		break;
 	}
 	await delay(250);

--- a/test/fixtures/fork-wbm-stall-watchdog.mts
+++ b/test/fixtures/fork-wbm-stall-watchdog.mts
@@ -23,12 +23,8 @@ RocksDatabase.config({
 	writeBufferManagerAllowStall: true,
 });
 
-// This thread never writes: it is the observer, and a write here would park it in
-// the same stall it is trying to report on.
 const db = RocksDatabase.open(dbPath, { maxWriteBufferSizeToMaintain: MAINTAIN });
 
-// The programmatic half of the warn line. It reaches this thread through a
-// threadsafe function, so it is only delivered because nothing here is blocked.
 RocksDatabase.on('log.warn', (message: string) => {
 	console.log(`WARNED ${message}`);
 });

--- a/test/fixtures/fork-wbm-stall-watchdog.mts
+++ b/test/fixtures/fork-wbm-stall-watchdog.mts
@@ -1,4 +1,4 @@
-import { RocksDatabase } from '../../src/index.ts';
+import { getWriteBufferManagerStats, RocksDatabase } from '../../src/index.ts';
 import { createWorkerBootstrapScript } from '../lib/worker-bootstrap.ts';
 import { setTimeout as delay } from 'node:timers/promises';
 import { Worker } from 'node:worker_threads';
@@ -54,7 +54,7 @@ let sawStall = false;
 let cleared = false;
 let stalledSince = 0;
 while (performance.now() < deadline) {
-	const stats = RocksDatabase.getWriteBufferManagerStats();
+	const stats = getWriteBufferManagerStats();
 	const fromGetStats = db.getStats();
 	console.log(
 		`STATS ${JSON.stringify({

--- a/test/fixtures/fork-wbm-stall-watchdog.mts
+++ b/test/fixtures/fork-wbm-stall-watchdog.mts
@@ -43,8 +43,6 @@ await new Promise<void>((resolve, reject) => {
 	worker.once('error', reject);
 });
 
-// Poll until the stall has been active long enough for the watchdog to have
-// reported, plus several more of its samples to prove it does not repeat.
 const OBSERVE_AFTER_REPORT_MS = 6000;
 const deadline = performance.now() + 90_000;
 let sawStall = false;

--- a/test/fixtures/fork-wbm-stall-watchdog.mts
+++ b/test/fixtures/fork-wbm-stall-watchdog.mts
@@ -1,9 +1,10 @@
-import { getWriteBufferManagerStats, RocksDatabase } from '../../src/index.ts';
+import { getWriteBufferManagerStats, RocksDatabase, shutdown } from '../../src/index.ts';
 import { createWorkerBootstrapScript } from '../lib/worker-bootstrap.ts';
 import { setTimeout as delay } from 'node:timers/promises';
 import { Worker } from 'node:worker_threads';
 
 const dbPath = process.argv[2];
+const shutdownWhenStalled = process.argv[3] === 'shutdown';
 
 if (!dbPath) {
 	console.error('Usage: fork-wbm-stall-watchdog.mts <dbPath>');
@@ -73,6 +74,11 @@ while (performance.now() < deadline) {
 		if (!sawStall) {
 			sawStall = true;
 			stalledSince = performance.now();
+			if (shutdownWhenStalled) {
+				console.log('SHUTTING_DOWN');
+				shutdown();
+				process.exit(2);
+			}
 		}
 	} else if (sawStall) {
 		// A stall that cleared mid-window could produce a second episode, and with
@@ -88,9 +94,4 @@ while (performance.now() < deadline) {
 }
 
 console.log(cleared ? 'CLEARED' : sawStall ? 'STALLED' : 'NEVER_STALLED');
-
-// The parent owns the deadline and kills this process. It cannot exit on its own:
-// the writer thread is parked inside RocksDB, so teardown would wedge in close()
-// waiting on the same stall (see AGENTS.md note 16) — which is precisely why a
-// test that reaches a real stall has to be driven from a killable child.
 setInterval(() => {}, 1000);

--- a/test/fixtures/fork-wbm-unconfigured.mts
+++ b/test/fixtures/fork-wbm-unconfigured.mts
@@ -1,0 +1,17 @@
+// The manager is a process-wide singleton shared by every worker thread in the
+// process, so a vitest worker can only observe the "never configured" shape if no
+// other test file in that process has configured one — which nothing guarantees.
+import { getWriteBufferManagerStats, RocksDatabase } from '../../src/index.ts';
+
+const dbPath = process.argv[2];
+if (!dbPath) {
+	process.exit(1);
+}
+
+const db = RocksDatabase.open(dbPath);
+db.putSync('foo', 'bar');
+const stats = getWriteBufferManagerStats();
+const dbStats = db.getStats();
+db.close();
+
+console.log(JSON.stringify({ stats, dbStats }));

--- a/test/fixtures/fork-wbm-watchdog-disabled.mts
+++ b/test/fixtures/fork-wbm-watchdog-disabled.mts
@@ -1,5 +1,4 @@
-// In a child so `ROCKSDB_JS_WBM_STALL_WARN_MS` can be set: it is read once per
-// process, and the vitest worker's value is fixed before any test runs.
+// In a child so `ROCKSDB_JS_WBM_STALL_WARN_MS` can be set: it is read once per process.
 import { getWriteBufferManagerStats, RocksDatabase } from '../../src/index.ts';
 
 const dbPath = process.argv[2];

--- a/test/fixtures/fork-wbm-watchdog-disabled.mts
+++ b/test/fixtures/fork-wbm-watchdog-disabled.mts
@@ -1,0 +1,19 @@
+// In a child so `ROCKSDB_JS_WBM_STALL_WARN_MS` can be set: it is read once per
+// process, and the vitest worker's value is fixed before any test runs.
+import { getWriteBufferManagerStats, RocksDatabase } from '../../src/index.ts';
+
+const dbPath = process.argv[2];
+if (!dbPath) {
+	process.exit(1);
+}
+
+RocksDatabase.config({
+	writeBufferManagerSize: 64 * 1024 * 1024,
+	writeBufferManagerAllowStall: true,
+});
+const db = RocksDatabase.open(dbPath);
+db.putSync('foo', 'bar');
+const stats = getWriteBufferManagerStats();
+db.close();
+
+console.log(JSON.stringify(stats));

--- a/test/fixtures/fork-wbm-watchdog-exit.mts
+++ b/test/fixtures/fork-wbm-watchdog-exit.mts
@@ -1,0 +1,25 @@
+import { RocksDatabase } from '../../src/index.ts';
+
+const dbPath = process.argv[2];
+const listenerOrder = process.argv[3];
+
+if (!dbPath || (listenerOrder !== 'before' && listenerOrder !== 'after')) {
+	process.exit(1);
+}
+
+const addListener = () => RocksDatabase.on('log.warn', () => {});
+if (listenerOrder === 'before') {
+	addListener();
+}
+
+RocksDatabase.config({
+	writeBufferManagerSize: 16 * 1024 * 1024,
+	writeBufferManagerAllowStall: true,
+});
+const db = RocksDatabase.open(dbPath);
+
+if (listenerOrder === 'after') {
+	addListener();
+}
+
+process.exit(db.isOpen() ? 0 : 1);

--- a/test/fixtures/fork-wbm-watchdog-exit.mts
+++ b/test/fixtures/fork-wbm-watchdog-exit.mts
@@ -1,4 +1,4 @@
-import { RocksDatabase } from '../../src/index.ts';
+import { getWriteBufferManagerStats, RocksDatabase } from '../../src/index.ts';
 
 const dbPath = process.argv[2];
 const listenerOrder = process.argv[3];
@@ -22,4 +22,7 @@ if (listenerOrder === 'after') {
 	addListener();
 }
 
-process.exit(db.isOpen() ? 0 : 1);
+if (!db.isOpen()) {
+	process.exit(1);
+}
+process.exit(getWriteBufferManagerStats().watchdogRunning ? 0 : 2);

--- a/test/fixtures/fork-wbm-watchdog-shutdown.mts
+++ b/test/fixtures/fork-wbm-watchdog-shutdown.mts
@@ -1,11 +1,8 @@
-// In a child because creating the manager is irreversible for the process: its
-// `costToCache` is fixed at construction, so doing this in the shared vitest
-// worker would decide it for every test file that runs afterwards. The parent
-// also owns the deadline — a watchdog join that deadlocks hangs this process,
-// and only a killable child turns that into a test failure.
+// In a child because creating the manager pins its `costToCache` for the process,
+// and because a join that deadlocks hangs this process — only a killable child
+// turns that into a test failure rather than a wedged run.
 import { getWriteBufferManagerStats, RocksDatabase, shutdown } from '../../src/index.ts';
 import { createWorkerBootstrapScript } from '../lib/worker-bootstrap.ts';
-import { join } from 'node:path';
 import { Worker } from 'node:worker_threads';
 
 const dbPath = process.argv[2];
@@ -13,7 +10,9 @@ if (!dbPath) {
 	process.exit(1);
 }
 
-const workerPath = join(import.meta.dirname, '..', 'workers', 'wbm-shutdown-worker.mts');
+// Cwd-relative, like the other worker fixtures: an absolute path here becomes a
+// drive-letter import that Node's ESM loader rejects on Windows.
+const workerPath = './test/workers/wbm-shutdown-worker.mts';
 const CONCURRENT_SHUTDOWNS = 4;
 const ROUNDS = 4;
 
@@ -61,10 +60,8 @@ watchdogRunning.push(getWriteBufferManagerStats().watchdogRunning);
 db.open();
 watchdogRunning.push(getWriteBufferManagerStats().watchdogRunning);
 
-// Only one caller may own the retiring thread; the others must wait for it
-// rather than clear the stop latch and strand the owner inside join(). The race
-// is narrow, so run several rounds — a lost one hangs here until the parent's
-// deadline rather than failing an assertion.
+// A lost race hangs here until the parent's deadline rather than failing an
+// assertion, and it is narrow, so run several rounds.
 for (let round = 0; round < ROUNDS; round++) {
 	await shutdownConcurrently();
 	watchdogRunning.push(getWriteBufferManagerStats().watchdogRunning);

--- a/test/fixtures/fork-wbm-watchdog-shutdown.mts
+++ b/test/fixtures/fork-wbm-watchdog-shutdown.mts
@@ -1,0 +1,26 @@
+// In a child because creating the manager is irreversible for the process: its
+// `costToCache` is fixed at construction, so doing this in the shared vitest
+// worker would decide it for every test file that runs afterwards.
+import { getWriteBufferManagerStats, RocksDatabase, shutdown } from '../../src/index.ts';
+
+const dbPath = process.argv[2];
+if (!dbPath) {
+	process.exit(1);
+}
+
+RocksDatabase.config({
+	writeBufferManagerSize: 64 * 1024 * 1024,
+	writeBufferManagerAllowStall: true,
+});
+
+const db = new RocksDatabase(dbPath);
+const watchdogRunning: boolean[] = [];
+db.open();
+watchdogRunning.push(getWriteBufferManagerStats().watchdogRunning);
+shutdown();
+watchdogRunning.push(getWriteBufferManagerStats().watchdogRunning);
+db.open();
+watchdogRunning.push(getWriteBufferManagerStats().watchdogRunning);
+db.close();
+
+console.log(JSON.stringify(watchdogRunning));

--- a/test/fixtures/fork-wbm-watchdog-shutdown.mts
+++ b/test/fixtures/fork-wbm-watchdog-shutdown.mts
@@ -1,11 +1,50 @@
 // In a child because creating the manager is irreversible for the process: its
 // `costToCache` is fixed at construction, so doing this in the shared vitest
-// worker would decide it for every test file that runs afterwards.
+// worker would decide it for every test file that runs afterwards. The parent
+// also owns the deadline — a watchdog join that deadlocks hangs this process,
+// and only a killable child turns that into a test failure.
 import { getWriteBufferManagerStats, RocksDatabase, shutdown } from '../../src/index.ts';
+import { createWorkerBootstrapScript } from '../lib/worker-bootstrap.ts';
+import { join } from 'node:path';
+import { Worker } from 'node:worker_threads';
 
 const dbPath = process.argv[2];
 if (!dbPath) {
 	process.exit(1);
+}
+
+const workerPath = join(import.meta.dirname, '..', 'workers', 'wbm-shutdown-worker.mts');
+const CONCURRENT_SHUTDOWNS = 4;
+const ROUNDS = 4;
+
+/** Runs `shutdown()` from several envs at once, all released from one gate. */
+async function shutdownConcurrently(): Promise<void> {
+	const gate = new SharedArrayBuffer(4);
+	const released = new Int32Array(gate);
+	let ready = 0;
+
+	await new Promise<void>((resolve, reject) => {
+		const exits: Promise<void>[] = [];
+		for (let i = 0; i < CONCURRENT_SHUTDOWNS; i++) {
+			const worker = new Worker(createWorkerBootstrapScript(workerPath), {
+				eval: true,
+				workerData: { gate },
+			});
+			exits.push(
+				new Promise<void>((done, fail) => {
+					worker.on('error', fail);
+					worker.on('exit', (code) => (code === 0 ? done() : fail(new Error(`exit ${code}`))));
+				})
+			);
+			worker.on('message', () => {
+				if (++ready === CONCURRENT_SHUTDOWNS) {
+					Atomics.store(released, 0, 1);
+					Atomics.notify(released, 0);
+				}
+			});
+		}
+		Promise.all(exits).then(() => resolve(), reject);
+	});
 }
 
 RocksDatabase.config({
@@ -21,6 +60,17 @@ shutdown();
 watchdogRunning.push(getWriteBufferManagerStats().watchdogRunning);
 db.open();
 watchdogRunning.push(getWriteBufferManagerStats().watchdogRunning);
+
+// Only one caller may own the retiring thread; the others must wait for it
+// rather than clear the stop latch and strand the owner inside join(). The race
+// is narrow, so run several rounds — a lost one hangs here until the parent's
+// deadline rather than failing an assertion.
+for (let round = 0; round < ROUNDS; round++) {
+	await shutdownConcurrently();
+	watchdogRunning.push(getWriteBufferManagerStats().watchdogRunning);
+	db.open();
+	watchdogRunning.push(getWriteBufferManagerStats().watchdogRunning);
+}
 db.close();
 
 console.log(JSON.stringify(watchdogRunning));

--- a/test/fixtures/fork-wbm-watchdog-shutdown.mts
+++ b/test/fixtures/fork-wbm-watchdog-shutdown.mts
@@ -2,6 +2,7 @@
 // and because a join that deadlocks hangs this process — only a killable child
 // turns that into a test failure rather than a wedged run.
 import { getWriteBufferManagerStats, RocksDatabase, shutdown } from '../../src/index.ts';
+import { setWriteBufferManagerJoinDelayForTesting } from '../../src/load-binding.ts';
 import { createWorkerBootstrapScript } from '../lib/worker-bootstrap.ts';
 import { Worker } from 'node:worker_threads';
 
@@ -18,17 +19,22 @@ const ROUNDS = 4;
 
 /** Runs `shutdown()` from several envs at once, all released from one gate. */
 async function shutdownConcurrently(): Promise<void> {
+	await Promise.all(await startConcurrentShutdowns(CONCURRENT_SHUTDOWNS));
+}
+
+async function startConcurrentShutdowns(count: number): Promise<Promise<void>[]> {
 	const gate = new SharedArrayBuffer(4);
 	const released = new Int32Array(gate);
 	let ready = 0;
+	const exits: Promise<void>[] = [];
 
 	await new Promise<void>((resolve, reject) => {
-		const exits: Promise<void>[] = [];
-		for (let i = 0; i < CONCURRENT_SHUTDOWNS; i++) {
+		for (let i = 0; i < count; i++) {
 			const worker = new Worker(createWorkerBootstrapScript(workerPath), {
 				eval: true,
 				workerData: { gate },
 			});
+			worker.on('error', reject);
 			exits.push(
 				new Promise<void>((done, fail) => {
 					worker.on('error', fail);
@@ -36,14 +42,15 @@ async function shutdownConcurrently(): Promise<void> {
 				})
 			);
 			worker.on('message', () => {
-				if (++ready === CONCURRENT_SHUTDOWNS) {
+				if (++ready === count) {
 					Atomics.store(released, 0, 1);
 					Atomics.notify(released, 0);
+					resolve();
 				}
 			});
 		}
-		Promise.all(exits).then(() => resolve(), reject);
 	});
+	return exits;
 }
 
 RocksDatabase.config({
@@ -60,8 +67,17 @@ watchdogRunning.push(getWriteBufferManagerStats().watchdogRunning);
 db.open();
 watchdogRunning.push(getWriteBufferManagerStats().watchdogRunning);
 
-// A lost race hangs here until the parent's deadline rather than failing an
-// assertion, and it is narrow, so run several rounds.
+setWriteBufferManagerJoinDelayForTesting(2, 5000);
+try {
+	const delayedShutdowns = await startConcurrentShutdowns(2);
+	await Promise.race(delayedShutdowns);
+	db.open();
+	await Promise.all(delayedShutdowns);
+	watchdogRunning.push(getWriteBufferManagerStats().watchdogRunning);
+} finally {
+	setWriteBufferManagerJoinDelayForTesting(0, 0);
+}
+
 for (let round = 0; round < ROUNDS; round++) {
 	await shutdownConcurrently();
 	watchdogRunning.push(getWriteBufferManagerStats().watchdogRunning);

--- a/test/fixtures/fork-wbm-watchdog-shutdown.mts
+++ b/test/fixtures/fork-wbm-watchdog-shutdown.mts
@@ -17,7 +17,6 @@ const workerPath = './test/workers/wbm-shutdown-worker.mts';
 const CONCURRENT_SHUTDOWNS = 4;
 const ROUNDS = 4;
 
-/** Runs `shutdown()` from several envs at once, all released from one gate. */
 async function shutdownConcurrently(): Promise<void> {
 	await Promise.all(await startConcurrentShutdowns(CONCURRENT_SHUTDOWNS));
 }

--- a/test/lock-tracker.test.ts
+++ b/test/lock-tracker.test.ts
@@ -252,12 +252,15 @@ describe('Coordinated retry — bounded park timeout (#741)', () => {
 
 			const start = performance.now();
 			db.close();
-			// Settled, not resolved: `commit()`'s `aftercommit` notify rejects
-			// once the database is closed, whatever the native result was.
+			// Node usually rejects when the post-commit notification observes the
+			// closed database. Alternate N-API runtimes can instead preserve the
+			// native RETRY_NOW result; either proves the close drained the park.
 			const [settled] = await Promise.allSettled([commit]);
 			const elapsed = performance.now() - start;
 
-			expect(settled.status).toBe('rejected');
+			if (settled.status === 'fulfilled') {
+				expect(settled.value).toBe(RETRY_NOW);
+			}
 			// Under the deadline, so this can only have come from the close.
 			expect(elapsed).toBeLessThan(4000);
 		}));

--- a/test/native/wbm_stall_watchdog_test.cc
+++ b/test/native/wbm_stall_watchdog_test.cc
@@ -119,6 +119,20 @@ TEST(ResolveWbmStallWarnMs, DefaultsWhenUnsetOrMalformed) {
 	EXPECT_EQ(resolveWbmStallWarnMs("86400001"), 5000u);
 }
 
+TEST(ResolveWbmStallWarnMs, ReportsWhichInputsItRefused) {
+	bool rejected = true;
+	EXPECT_EQ(resolveWbmStallWarnMs(nullptr, &rejected), 5000u);
+	EXPECT_FALSE(rejected); // unset is not a rejection
+	EXPECT_EQ(resolveWbmStallWarnMs("2500", &rejected), 2500u);
+	EXPECT_FALSE(rejected);
+	EXPECT_EQ(resolveWbmStallWarnMs("1", &rejected), 1000u);
+	EXPECT_FALSE(rejected); // clamped up, not refused
+	EXPECT_EQ(resolveWbmStallWarnMs("abc", &rejected), 5000u);
+	EXPECT_TRUE(rejected);
+	EXPECT_EQ(resolveWbmStallWarnMs("86400001", &rejected), 5000u);
+	EXPECT_TRUE(rejected);
+}
+
 TEST(ResolveWbmStallWarnMs, ZeroDisablesAndSubSampleClampsUp) {
 	EXPECT_EQ(resolveWbmStallWarnMs("0"), 0u);
 	EXPECT_EQ(resolveWbmStallWarnMs("1"), 1000u);
@@ -162,6 +176,19 @@ TEST(FormatWriteBufferManagerStallReport, GroupsAMixedRetentionInventory) {
 		),
 		std::string::npos
 	);
+}
+
+TEST(FormatWriteBufferManagerStallReport, SaysSoWhenTheInventoryCouldNotBeCollected) {
+	WriteBufferManagerStallReport report;
+	report.bufferSize = 1024;
+	report.memoryUsage = 1024;
+	report.inventoryAvailable = false;
+	std::string line = formatWriteBufferManagerStallReport(report);
+	// The alarm still fires: it must not wait on a registry lock held by a close
+	// that is itself stuck behind this stall.
+	EXPECT_NE(line.find("usage=1.0KB"), std::string::npos);
+	EXPECT_NE(line.find("columnFamilies=unavailable"), std::string::npos);
+	EXPECT_NE(line.find("maxWriteBufferSizeToMaintain=unavailable"), std::string::npos);
 }
 
 TEST(FormatWriteBufferManagerStallReport, OmitsPercentagesWhenThereIsNoBudget) {

--- a/test/native/wbm_stall_watchdog_test.cc
+++ b/test/native/wbm_stall_watchdog_test.cc
@@ -70,8 +70,8 @@ TEST(WbmStallWatchdogState, KeepsReportingDurationAfterTheReport) {
 	state.onSample(true, at(0), kThreshold);
 	state.onSample(true, at(5000), kThreshold);
 	state.markReported();
-	// stallActiveMs is the live gauge behind writeBufferManager.stallActiveMs, so
-	// it must keep climbing after the one-shot line has been emitted.
+	// It backs the live writeBufferManager.stallActiveMs gauge, so it must keep
+	// climbing after the one-shot line has been emitted.
 	EXPECT_EQ(state.onSample(true, at(42000), kThreshold).stallActiveMs, 42000u);
 }
 

--- a/test/native/wbm_stall_watchdog_test.cc
+++ b/test/native/wbm_stall_watchdog_test.cc
@@ -1,0 +1,174 @@
+#include <gtest/gtest.h>
+#include <chrono>
+#include <string>
+#include "core/wbm_stall_watchdog.h"
+
+using rocksdb_js::formatWriteBufferManagerStallReport;
+using rocksdb_js::resolveWbmStallWarnMs;
+using rocksdb_js::WbmStallWatchdogState;
+using rocksdb_js::WriteBufferManagerStallReport;
+
+namespace {
+
+using Clock = WbmStallWatchdogState::Clock;
+
+// A fixed base so tests can express times as millisecond offsets.
+Clock::time_point at(long long ms) {
+	return Clock::time_point{} + std::chrono::milliseconds(ms);
+}
+
+constexpr uint64_t kThreshold = 5000;
+
+} // namespace
+
+TEST(WbmStallWatchdogState, IdleReportsNothing) {
+	WbmStallWatchdogState state;
+	for (long long ms = 0; ms <= 60000; ms += 1000) {
+		auto sample = state.onSample(false, at(ms), kThreshold);
+		EXPECT_FALSE(sample.reportNow);
+		EXPECT_EQ(sample.stallActiveMs, 0u);
+	}
+}
+
+TEST(WbmStallWatchdogState, FirstSampleOfAStallIsTheEdgeNotADuration) {
+	WbmStallWatchdogState state;
+	auto sample = state.onSample(true, at(0), kThreshold);
+	EXPECT_FALSE(sample.reportNow);
+	// The rising edge is when the stall was first *seen*; nothing is known about
+	// how long it was already running.
+	EXPECT_EQ(sample.stallActiveMs, 0u);
+}
+
+TEST(WbmStallWatchdogState, ReportsOnceWhenTheThresholdIsCrossed) {
+	WbmStallWatchdogState state;
+	state.onSample(true, at(0), kThreshold);
+	EXPECT_FALSE(state.onSample(true, at(4000), kThreshold).reportNow);
+
+	auto crossed = state.onSample(true, at(5000), kThreshold);
+	EXPECT_TRUE(crossed.reportNow);
+	EXPECT_EQ(crossed.stallActiveMs, 5000u);
+	state.markReported();
+
+	// An eight-hour wedge is one line, not one per sample.
+	for (long long ms = 6000; ms <= 3600000; ms += 1000) {
+		EXPECT_FALSE(state.onSample(true, at(ms), kThreshold).reportNow);
+	}
+}
+
+TEST(WbmStallWatchdogState, RetriesUntilTheReportIsAcknowledged) {
+	WbmStallWatchdogState state;
+	state.onSample(true, at(0), kThreshold);
+	EXPECT_TRUE(state.onSample(true, at(5000), kThreshold).reportNow);
+	// markReported() not called: a report that could not be written is retried.
+	EXPECT_TRUE(state.onSample(true, at(6000), kThreshold).reportNow);
+	state.markReported();
+	EXPECT_FALSE(state.onSample(true, at(7000), kThreshold).reportNow);
+}
+
+TEST(WbmStallWatchdogState, KeepsReportingDurationAfterTheReport) {
+	WbmStallWatchdogState state;
+	state.onSample(true, at(0), kThreshold);
+	state.onSample(true, at(5000), kThreshold);
+	state.markReported();
+	// stallActiveMs is the live gauge behind writeBufferManager.stallActiveMs, so
+	// it must keep climbing after the one-shot line has been emitted.
+	EXPECT_EQ(state.onSample(true, at(42000), kThreshold).stallActiveMs, 42000u);
+}
+
+TEST(WbmStallWatchdogState, RecoveryRearmsForTheNextEpisode) {
+	WbmStallWatchdogState state;
+	state.onSample(true, at(0), kThreshold);
+	EXPECT_TRUE(state.onSample(true, at(5000), kThreshold).reportNow);
+	state.markReported();
+
+	auto recovered = state.onSample(false, at(6000), kThreshold);
+	EXPECT_FALSE(recovered.reportNow);
+	EXPECT_EQ(recovered.stallActiveMs, 0u);
+
+	// A second genuine episode reports again. There is deliberately no quiet
+	// window on top of the threshold: it would suppress exactly this line.
+	state.onSample(true, at(7000), kThreshold);
+	EXPECT_TRUE(state.onSample(true, at(12000), kThreshold).reportNow);
+}
+
+TEST(WbmStallWatchdogState, FlappingNeverAccumulatesToTheThreshold) {
+	WbmStallWatchdogState state;
+	for (long long ms = 0; ms < 60000; ms += 2000) {
+		EXPECT_FALSE(state.onSample(true, at(ms), kThreshold).reportNow);
+		EXPECT_FALSE(state.onSample(false, at(ms + 1000), kThreshold).reportNow);
+	}
+}
+
+TEST(WbmStallWatchdogState, ZeroThresholdNeverReports) {
+	WbmStallWatchdogState state;
+	state.onSample(true, at(0), 0);
+	auto sample = state.onSample(true, at(3600000), 0);
+	EXPECT_FALSE(sample.reportNow);
+	EXPECT_EQ(sample.stallActiveMs, 3600000u);
+}
+
+TEST(ResolveWbmStallWarnMs, DefaultsWhenUnsetOrMalformed) {
+	EXPECT_EQ(resolveWbmStallWarnMs(nullptr), 5000u);
+	EXPECT_EQ(resolveWbmStallWarnMs(""), 5000u);
+	EXPECT_EQ(resolveWbmStallWarnMs("abc"), 5000u);
+	EXPECT_EQ(resolveWbmStallWarnMs("5000ms"), 5000u);
+	EXPECT_EQ(resolveWbmStallWarnMs("-1"), 5000u);
+	// Out of range rather than clamped: a threshold past a day is never intended,
+	// and silently accepting one disables the alarm.
+	EXPECT_EQ(resolveWbmStallWarnMs("99999999999999999999"), 5000u);
+	EXPECT_EQ(resolveWbmStallWarnMs("86400001"), 5000u);
+}
+
+TEST(ResolveWbmStallWarnMs, ZeroDisablesAndSubSampleClampsUp) {
+	EXPECT_EQ(resolveWbmStallWarnMs("0"), 0u);
+	EXPECT_EQ(resolveWbmStallWarnMs("1"), 1000u);
+	EXPECT_EQ(resolveWbmStallWarnMs("999"), 1000u);
+	EXPECT_EQ(resolveWbmStallWarnMs("1000"), 1000u);
+	EXPECT_EQ(resolveWbmStallWarnMs("2500"), 2500u);
+	EXPECT_EQ(resolveWbmStallWarnMs("86400000"), 86400000u);
+}
+
+TEST(FormatWriteBufferManagerStallReport, CarriesEveryDiagnosticValue) {
+	WriteBufferManagerStallReport report;
+	report.stallActiveMs = 5000;
+	report.bufferSize = 693337292; // 661.2 MiB
+	report.memoryUsage = 694386688;
+	report.mutableMemoryUsage = 13002342;
+	report.allowStall = true;
+	report.costToCache = true;
+	report.columnFamilies = 28;
+	report.maxWriteBufferSizeToMaintain[268435456] = 28;
+
+	std::string line = formatWriteBufferManagerStallReport(report);
+	EXPECT_NE(line.find("WriteBufferManager write stall active for 5.0s"), std::string::npos);
+	EXPECT_NE(line.find("budget=661.2MB"), std::string::npos);
+	EXPECT_NE(line.find("usage=662.2MB (100.2%)"), std::string::npos);
+	EXPECT_NE(line.find("mutable=12.4MB (1.9%)"), std::string::npos);
+	EXPECT_NE(line.find("allowStall=true"), std::string::npos);
+	EXPECT_NE(line.find("costToCache=true"), std::string::npos);
+	EXPECT_NE(line.find("columnFamilies=28"), std::string::npos);
+	EXPECT_NE(line.find("maxWriteBufferSizeToMaintain={268435456:28}"), std::string::npos);
+	EXPECT_EQ(line.find('\n'), std::string::npos);
+}
+
+TEST(FormatWriteBufferManagerStallReport, GroupsAMixedRetentionInventory) {
+	WriteBufferManagerStallReport report;
+	report.columnFamilies = 6;
+	report.maxWriteBufferSizeToMaintain[0] = 5;
+	report.maxWriteBufferSizeToMaintain[268435456] = 1;
+	EXPECT_NE(
+		formatWriteBufferManagerStallReport(report).find(
+			"maxWriteBufferSizeToMaintain={0:5,268435456:1}"
+		),
+		std::string::npos
+	);
+}
+
+TEST(FormatWriteBufferManagerStallReport, OmitsPercentagesWhenThereIsNoBudget) {
+	WriteBufferManagerStallReport report;
+	report.memoryUsage = 1024;
+	std::string line = formatWriteBufferManagerStallReport(report);
+	EXPECT_NE(line.find("budget=0B"), std::string::npos);
+	EXPECT_NE(line.find("usage=1.0KB"), std::string::npos);
+	EXPECT_EQ(line.find('%'), std::string::npos);
+}

--- a/test/native/wbm_stall_watchdog_test.cc
+++ b/test/native/wbm_stall_watchdog_test.cc
@@ -49,7 +49,7 @@ TEST(WbmStallWatchdogState, ReportsOnceWhenTheThresholdIsCrossed) {
 	EXPECT_EQ(crossed.stallActiveMs, 5000u);
 	state.markReported();
 
-	// An eight-hour wedge is one line, not one per sample.
+	// A wedge is one line, not one per sample.
 	for (long long ms = 6000; ms <= 3600000; ms += 1000) {
 		EXPECT_FALSE(state.onSample(true, at(ms), kThreshold).reportNow);
 	}
@@ -113,8 +113,6 @@ TEST(ResolveWbmStallWarnMs, DefaultsWhenUnsetOrMalformed) {
 	EXPECT_EQ(resolveWbmStallWarnMs("abc"), 5000u);
 	EXPECT_EQ(resolveWbmStallWarnMs("5000ms"), 5000u);
 	EXPECT_EQ(resolveWbmStallWarnMs("-1"), 5000u);
-	// Out of range rather than clamped: a threshold past a day is never intended,
-	// and silently accepting one disables the alarm.
 	EXPECT_EQ(resolveWbmStallWarnMs("99999999999999999999"), 5000u);
 	EXPECT_EQ(resolveWbmStallWarnMs("86400001"), 5000u);
 }
@@ -122,11 +120,11 @@ TEST(ResolveWbmStallWarnMs, DefaultsWhenUnsetOrMalformed) {
 TEST(ResolveWbmStallWarnMs, ReportsWhichInputsItRefused) {
 	bool rejected = true;
 	EXPECT_EQ(resolveWbmStallWarnMs(nullptr, &rejected), 5000u);
-	EXPECT_FALSE(rejected); // unset is not a rejection
+	EXPECT_FALSE(rejected);
 	EXPECT_EQ(resolveWbmStallWarnMs("2500", &rejected), 2500u);
 	EXPECT_FALSE(rejected);
 	EXPECT_EQ(resolveWbmStallWarnMs("1", &rejected), 1000u);
-	EXPECT_FALSE(rejected); // clamped up, not refused
+	EXPECT_FALSE(rejected);
 	EXPECT_EQ(resolveWbmStallWarnMs("abc", &rejected), 5000u);
 	EXPECT_TRUE(rejected);
 	EXPECT_EQ(resolveWbmStallWarnMs("86400001", &rejected), 5000u);

--- a/test/native/wbm_stall_watchdog_test.cc
+++ b/test/native/wbm_stall_watchdog_test.cc
@@ -12,7 +12,6 @@ namespace {
 
 using Clock = WbmStallWatchdogState::Clock;
 
-// A fixed base so tests can express times as millisecond offsets.
 Clock::time_point at(long long ms) {
 	return Clock::time_point{} + std::chrono::milliseconds(ms);
 }
@@ -68,8 +67,6 @@ TEST(WbmStallWatchdogState, KeepsReportingDurationAfterTheReport) {
 	state.onSample(true, at(0), kThreshold);
 	state.onSample(true, at(5000), kThreshold);
 	state.markReported();
-	// It backs the live writeBufferManager.stallActiveMs gauge, so it must keep
-	// climbing after the one-shot line has been emitted.
 	EXPECT_EQ(state.onSample(true, at(42000), kThreshold).stallActiveMs, 42000u);
 }
 

--- a/test/native/wbm_stall_watchdog_test.cc
+++ b/test/native/wbm_stall_watchdog_test.cc
@@ -49,7 +49,6 @@ TEST(WbmStallWatchdogState, ReportsOnceWhenTheThresholdIsCrossed) {
 	EXPECT_EQ(crossed.stallActiveMs, 5000u);
 	state.markReported();
 
-	// A wedge is one line, not one per sample.
 	for (long long ms = 6000; ms <= 3600000; ms += 1000) {
 		EXPECT_FALSE(state.onSample(true, at(ms), kThreshold).reportNow);
 	}
@@ -59,7 +58,6 @@ TEST(WbmStallWatchdogState, RetriesUntilTheReportIsAcknowledged) {
 	WbmStallWatchdogState state;
 	state.onSample(true, at(0), kThreshold);
 	EXPECT_TRUE(state.onSample(true, at(5000), kThreshold).reportNow);
-	// markReported() not called: a report that could not be written is retried.
 	EXPECT_TRUE(state.onSample(true, at(6000), kThreshold).reportNow);
 	state.markReported();
 	EXPECT_FALSE(state.onSample(true, at(7000), kThreshold).reportNow);

--- a/test/shutdown.test.ts
+++ b/test/shutdown.test.ts
@@ -52,7 +52,6 @@ describe('Shutdown', () => {
 					timeout: 60000,
 				});
 				expect(child.status, child.stderr).toBe(0);
-				// Open, shutdown, reopen; then four rounds of concurrent shutdown + reopen.
 				expect(JSON.parse(child.stdout.trim().split(/\r?\n/).at(-1)!)).toEqual([
 					true,
 					false,

--- a/test/shutdown.test.ts
+++ b/test/shutdown.test.ts
@@ -42,20 +42,23 @@ describe('Shutdown', () => {
 			expect(status.length).toBe(0);
 		}));
 
-	// In a child: creating the manager fixes its `costToCache` for the whole
-	// process, and every test file shares one vitest worker, so doing it here
-	// would decide it for whichever file runs next.
 	it.skipIf(process.env.ROCKSDB_JS_WBM_STALL_WARN_MS === '0')(
-		'should restart the WriteBufferManager watchdog after shutdown',
+		'should restart the WriteBufferManager watchdog after shutdown, concurrent ones included',
 		() => {
 			const path = generateDBPath();
 			try {
 				const child = spawnSync(process.execPath, [watchdogShutdownFixturePath, path], {
 					encoding: 'utf8',
-					timeout: 30000,
+					timeout: 60000,
 				});
 				expect(child.status, child.stderr).toBe(0);
-				expect(JSON.parse(child.stdout.trim().split(/\r?\n/).at(-1)!)).toEqual([true, false, true]);
+				// Open, shutdown, reopen; then four rounds of concurrent shutdown + reopen.
+				expect(JSON.parse(child.stdout.trim().split(/\r?\n/).at(-1)!)).toEqual([
+					true,
+					false,
+					true,
+					...Array.from({ length: 4 }, () => [false, true]).flat(),
+				]);
 			} finally {
 				if (!process.env.KEEP_FILES) {
 					rmSync(path, { force: true, recursive: true, maxRetries: 3, retryDelay: 500 });

--- a/test/shutdown.test.ts
+++ b/test/shutdown.test.ts
@@ -1,17 +1,15 @@
-import {
-	getWriteBufferManagerStats,
-	RocksDatabase,
-	registryStatus,
-	shutdown,
-} from '../src/index.ts';
+import { RocksDatabase, registryStatus, shutdown } from '../src/index.ts';
 import { dbRunner, generateDBPath } from './lib/util.ts';
 import { createWorkerBootstrapScript } from './lib/worker-bootstrap.ts';
-import { spawn } from 'node:child_process';
+import { spawn, spawnSync } from 'node:child_process';
+import { rmSync } from 'node:fs';
 import { mkdir, rm } from 'node:fs/promises';
 import { join } from 'node:path';
 import { setTimeout as delay } from 'node:timers/promises';
 import { Worker } from 'node:worker_threads';
 import { describe, expect, it } from 'vitest';
+
+const watchdogShutdownFixturePath = join(__dirname, 'fixtures', 'fork-wbm-watchdog-shutdown.mts');
 
 describe('Shutdown', () => {
 	it('should shutdown rocksdb-js', () =>
@@ -44,28 +42,24 @@ describe('Shutdown', () => {
 			expect(status.length).toBe(0);
 		}));
 
+	// In a child: creating the manager fixes its `costToCache` for the whole
+	// process, and every test file shares one vitest worker, so doing it here
+	// would decide it for whichever file runs next.
 	it.skipIf(process.env.ROCKSDB_JS_WBM_STALL_WARN_MS === '0')(
 		'should restart the WriteBufferManager watchdog after shutdown',
 		() => {
 			const path = generateDBPath();
-			const db = new RocksDatabase(path);
-			RocksDatabase.config({
-				writeBufferManagerSize: 64 * 1024 * 1024,
-				writeBufferManagerAllowStall: true,
-			});
 			try {
-				db.open();
-				expect(getWriteBufferManagerStats().watchdogRunning).toBe(true);
-				shutdown();
-				expect(getWriteBufferManagerStats().watchdogRunning).toBe(false);
-				db.open();
-				expect(getWriteBufferManagerStats().watchdogRunning).toBe(true);
-			} finally {
-				RocksDatabase.config({
-					writeBufferManagerSize: 0,
-					writeBufferManagerAllowStall: false,
+				const child = spawnSync(process.execPath, [watchdogShutdownFixturePath, path], {
+					encoding: 'utf8',
+					timeout: 30000,
 				});
-				db.close();
+				expect(child.status, child.stderr).toBe(0);
+				expect(JSON.parse(child.stdout.trim().split(/\r?\n/).at(-1)!)).toEqual([true, false, true]);
+			} finally {
+				if (!process.env.KEEP_FILES) {
+					rmSync(path, { force: true, recursive: true, maxRetries: 3, retryDelay: 500 });
+				}
 			}
 		}
 	);

--- a/test/shutdown.test.ts
+++ b/test/shutdown.test.ts
@@ -57,6 +57,7 @@ describe('Shutdown', () => {
 					true,
 					false,
 					true,
+					true,
 					...Array.from({ length: 4 }, () => [false, true]).flat(),
 				]);
 			} finally {

--- a/test/shutdown.test.ts
+++ b/test/shutdown.test.ts
@@ -1,4 +1,9 @@
-import { RocksDatabase, registryStatus, shutdown } from '../src/index.ts';
+import {
+	getWriteBufferManagerStats,
+	RocksDatabase,
+	registryStatus,
+	shutdown,
+} from '../src/index.ts';
 import { dbRunner, generateDBPath } from './lib/util.ts';
 import { createWorkerBootstrapScript } from './lib/worker-bootstrap.ts';
 import { spawn } from 'node:child_process';
@@ -38,6 +43,32 @@ describe('Shutdown', () => {
 			status = registryStatus();
 			expect(status.length).toBe(0);
 		}));
+
+	it.skipIf(process.env.ROCKSDB_JS_WBM_STALL_WARN_MS === '0')(
+		'should restart the WriteBufferManager watchdog after shutdown',
+		() => {
+			const path = generateDBPath();
+			const db = new RocksDatabase(path);
+			RocksDatabase.config({
+				writeBufferManagerSize: 64 * 1024 * 1024,
+				writeBufferManagerAllowStall: true,
+			});
+			try {
+				db.open();
+				expect(getWriteBufferManagerStats().watchdogRunning).toBe(true);
+				shutdown();
+				expect(getWriteBufferManagerStats().watchdogRunning).toBe(false);
+				db.open();
+				expect(getWriteBufferManagerStats().watchdogRunning).toBe(true);
+			} finally {
+				RocksDatabase.config({
+					writeBufferManagerSize: 0,
+					writeBufferManagerAllowStall: false,
+				});
+				db.close();
+			}
+		}
+	);
 
 	it('should open 10 databases, shutdown, and open them again', async () =>
 		dbRunner(

--- a/test/stats.test.ts
+++ b/test/stats.test.ts
@@ -140,10 +140,14 @@ describe('Statistics', () => {
 
 			stats = db.getStats();
 			expect(stats).toBeDefined();
-			// the curated column-family set stays small; the always-present txnlog.*
-			// and commitPipeline.* summary keys are counted separately.
+			// the curated column-family set stays small; the always-present txnlog.*,
+			// commitPipeline.* and writeBufferManager.* summary keys are counted
+			// separately.
 			const nonTxnlogKeys = Object.keys(stats).filter(
-				(key) => !key.startsWith('txnlog.') && !key.startsWith('commitPipeline.')
+				(key) =>
+					!key.startsWith('txnlog.') &&
+					!key.startsWith('commitPipeline.') &&
+					!key.startsWith('writeBufferManager.')
 			);
 			expect(nonTxnlogKeys.length).toBeLessThanOrEqual(26);
 

--- a/test/transaction-log.test.ts
+++ b/test/transaction-log.test.ts
@@ -2220,6 +2220,43 @@ describe('Transaction Log', () => {
 		);
 
 		it.skipIf(process.platform === 'win32')(
+			'should report discovered and created log paths with the spelling the caller opened',
+			() =>
+				dbRunner({ skipOpen: true }, async ({ db: unused, dbPath }) => {
+					unused.close();
+					const linkPath = `${dbPath}-link`;
+					await mkdir(dbPath, { recursive: true });
+					symlinkSync(dbPath, linkPath, 'dir');
+					try {
+						const discoveredDirectory = join(linkPath, 'transaction_logs', 'discovered');
+						await mkdir(discoveredDirectory, { recursive: true });
+						const header = Buffer.alloc(TRANSACTION_LOG_FILE_HEADER_SIZE);
+						header.writeUInt32BE(TRANSACTION_LOG_TOKEN, 0);
+						header.writeUInt8(1, 4);
+						header.writeDoubleBE(0, 5);
+						await writeFile(join(discoveredDirectory, '1.txnlog'), header);
+						await writeFile(
+							join(discoveredDirectory, 'txn.state'),
+							Buffer.from([0, 0, 0, 0, 2, 0, 0, 0])
+						);
+
+						const linked = new RocksDatabase(linkPath);
+						try {
+							linked.open();
+							expect(linked.useLog('discovered').path).toBe(discoveredDirectory);
+							expect(linked.useLog('created').path).toBe(
+								join(linkPath, 'transaction_logs', 'created')
+							);
+						} finally {
+							linked.close();
+						}
+					} finally {
+						rmSync(linkPath, { force: true });
+					}
+				})
+		);
+
+		it.skipIf(process.platform === 'win32')(
 			'should keep a custom transaction-log target after its symlink is repointed',
 			async () => {
 				const dbPath = generateDBPath();

--- a/test/txn-close-commit-uaf.test.ts
+++ b/test/txn-close-commit-uaf.test.ts
@@ -4,6 +4,9 @@ import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 const fixturePath = join(__dirname, 'fixtures', 'fork-close-commit-uaf.mts');
+// Deno/macOS has a pre-existing worker-env teardown abort (#746); use the
+// established single-retry policy from commit-teardown.test.ts on that runner.
+const retry = process.versions.deno && process.platform === 'darwin' ? 1 : 0;
 
 /**
  * Runs the repro fixture in a child process so a SIGABRT (the harper#1370
@@ -48,7 +51,7 @@ function spawnRepro(
 describe('TransactionHandle::close() vs async-commit complete callback', () => {
 	it(
 		'should survive DBDescriptor::close() racing the commit complete callback (harper#1370)',
-		() => expectSurvives(),
-		60_000
+		{ retry, timeout: 60_000 },
+		() => expectSurvives()
 	);
 });

--- a/test/workers/wbm-shutdown-worker.mts
+++ b/test/workers/wbm-shutdown-worker.mts
@@ -1,0 +1,10 @@
+import { shutdown } from '../../src/index.ts';
+import { parentPort, workerData } from 'node:worker_threads';
+
+const gate = new Int32Array(workerData.gate as SharedArrayBuffer);
+
+// Load the binding first, then block until every worker is at the gate, so the
+// shutdown calls overlap instead of queueing behind each other's module init.
+parentPort!.postMessage('ready');
+Atomics.wait(gate, 0, 0);
+shutdown();

--- a/test/workers/wbm-shutdown-worker.mts
+++ b/test/workers/wbm-shutdown-worker.mts
@@ -3,8 +3,6 @@ import { parentPort, workerData } from 'node:worker_threads';
 
 const gate = new Int32Array(workerData.gate as SharedArrayBuffer);
 
-// The gate is what makes the calls overlap instead of queueing behind each
-// other's module init.
 parentPort!.postMessage('ready');
 Atomics.wait(gate, 0, 0);
 shutdown();

--- a/test/workers/wbm-shutdown-worker.mts
+++ b/test/workers/wbm-shutdown-worker.mts
@@ -3,8 +3,8 @@ import { parentPort, workerData } from 'node:worker_threads';
 
 const gate = new Int32Array(workerData.gate as SharedArrayBuffer);
 
-// Load the binding first, then block until every worker is at the gate, so the
-// shutdown calls overlap instead of queueing behind each other's module init.
+// The gate is what makes the calls overlap instead of queueing behind each
+// other's module init.
 parentPort!.postMessage('ready');
 Atomics.wait(gate, 0, 0);
 shutdown();

--- a/test/workers/wbm-stall-writer-worker.mts
+++ b/test/workers/wbm-stall-writer-worker.mts
@@ -1,0 +1,21 @@
+import { RocksDatabase } from '../../src/index.ts';
+import { parentPort, workerData } from 'node:worker_threads';
+
+const { path, columnFamilies, maintain } = workerData as {
+	path: string;
+	columnFamilies: number;
+	maintain: number;
+};
+
+const dbs = Array.from({ length: columnFamilies }, (_, i) =>
+	RocksDatabase.open(path, { name: `cf${i}`, maxWriteBufferSizeToMaintain: maintain })
+);
+
+const value = Buffer.alloc(64 * 1024, 1);
+parentPort?.postMessage({ ready: true });
+
+// putSync blocks inside RocksDB once the manager stalls, which is the point: this
+// thread parks in the stall while the main thread stays free to observe it.
+for (let i = 0; ; i++) {
+	dbs[i % dbs.length].putSync(`stall-${i.toString().padStart(7, '0')}`, value);
+}

--- a/test/write-buffer-manager-stall-watchdog.test.ts
+++ b/test/write-buffer-manager-stall-watchdog.test.ts
@@ -73,11 +73,18 @@ describe('WriteBufferManager stall watchdog', () => {
 		try {
 			result = await runStallChild(join(dir, 'db'), 120_000);
 		} finally {
-			rmSync(dir, { recursive: true, force: true });
+			if (!process.env.KEEP_FILES) {
+				// The child was SIGKILLed a moment ago; on Windows its handles can
+				// outlive it briefly, and an EPERM thrown here would mask the real
+				// assertion result.
+				rmSync(dir, { recursive: true, force: true, maxRetries: 3, retryDelay: 500 });
+			}
 		}
 
 		expect(result.timedOut, `child never finished:\n${result.stderr}`).toBe(false);
-		expect(result.stdout, `child stderr:\n${result.stderr}`).toContain('STALLED');
+		// Anchored: 'NEVER_STALLED' also contains 'STALLED', and a run that never
+		// reached a stall must fail here rather than in the warn-count assertion.
+		expect(result.stdout.split('\n'), `child stderr:\n${result.stderr}`).toContain('STALLED');
 
 		const warnings = result.stderr
 			.split('\n')
@@ -120,6 +127,15 @@ describe('WriteBufferManager stall watchdog', () => {
 		expect(last.getStat.stallActive).toBe(1);
 		expect(last.getStat.bufferSize).toBe(last.stats.bufferSize);
 		expect(last.getStat.stallActiveMs).toBe(last.getStats.stallActiveMs);
+
+		// The `'log.warn'` event is the programmatic half of the warn line: same
+		// payload, same once-per-episode cadence.
+		const warned = result.stdout
+			.split('\n')
+			.filter((line) => line.startsWith('WARNED '))
+			.map((line) => line.slice('WARNED '.length));
+		expect(warned).toHaveLength(1);
+		expect(warned[0]).toBe(warning);
 
 		// stallActiveMs is a duration, not a flag: it has to climb across samples.
 		expect(stalled.at(-1)!.stats.stallActiveMs).toBeGreaterThan(stalled[0].stats.stallActiveMs);

--- a/test/write-buffer-manager-stall-watchdog.test.ts
+++ b/test/write-buffer-manager-stall-watchdog.test.ts
@@ -1,0 +1,127 @@
+import { spawn } from 'node:child_process';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * The WriteBufferManager stall watchdog, against a real stall.
+ *
+ * Two constraints force the child-process shape. `allowStall` is fixed when the
+ * manager singleton is constructed, so this needs a process no other manager has
+ * run in; and a real stall blocks the thread that writes, so the runner's own
+ * timeout cannot fire (HarperFast/rocksdb-js#781 item 2) — the deadline has to be
+ * the parent's, and the child is killed rather than asked to exit.
+ *
+ * The decision logic itself is unit-tested deterministically in
+ * `test/native/wbm_stall_watchdog_test.cc`; this proves the wiring: that a stall
+ * is reached, that both read surfaces see it, and that the watchdog writes exactly
+ * one line no matter how long it lasts.
+ */
+
+const fixturePath = join(__dirname, 'fixtures', 'fork-wbm-stall-watchdog.mts');
+const WARN_MS = 2000;
+
+type ChildResult = { stdout: string; stderr: string; timedOut: boolean };
+
+function runStallChild(dbPath: string, deadlineMs: number): Promise<ChildResult> {
+	return new Promise((resolve, reject) => {
+		const child = spawn(process.execPath, [fixturePath, dbPath], {
+			env: { ...process.env, ROCKSDB_JS_WBM_STALL_WARN_MS: String(WARN_MS) },
+		});
+		let stdout = '';
+		let stderr = '';
+		let timedOut = false;
+		let settled = false;
+
+		const finish = () => {
+			if (settled) {
+				return;
+			}
+			settled = true;
+			clearTimeout(deadline);
+			child.kill('SIGKILL');
+			resolve({ stdout, stderr, timedOut });
+		};
+
+		const deadline = setTimeout(() => {
+			timedOut = true;
+			finish();
+		}, deadlineMs);
+
+		child.stdout?.on('data', (chunk) => {
+			stdout += chunk.toString();
+			if (/^(STALLED|NEVER_STALLED|CLEARED)$/m.test(stdout)) {
+				finish();
+			}
+		});
+		child.stderr?.on('data', (chunk) => {
+			stderr += chunk.toString();
+		});
+		child.on('error', (error) => {
+			clearTimeout(deadline);
+			reject(error);
+		});
+		child.on('close', finish);
+	});
+}
+
+describe('WriteBufferManager stall watchdog', () => {
+	it('reports a sustained stall exactly once, and both read surfaces see it', async () => {
+		const dir = mkdtempSync(join(tmpdir(), 'rocksdb-wbm-stall-'));
+		let result: ChildResult;
+		try {
+			result = await runStallChild(join(dir, 'db'), 120_000);
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+
+		expect(result.timedOut, `child never finished:\n${result.stderr}`).toBe(false);
+		expect(result.stdout, `child stderr:\n${result.stderr}`).toContain('STALLED');
+
+		const warnings = result.stderr
+			.split('\n')
+			.filter((line) => line.includes('WriteBufferManager write stall active for'));
+		// Not one per blocked writer and not one per poll: the stall is held for
+		// several times the threshold and still yields a single line.
+		expect(warnings).toHaveLength(1);
+
+		const [warning] = warnings;
+		expect(warning).toMatch(/budget=\d/);
+		expect(warning).toMatch(/usage=\d[\d.]*[KMGT]?B \(\d/);
+		expect(warning).toMatch(/mutable=\d[\d.]*[KMGT]?B \(\d/);
+		expect(warning).toContain('allowStall=true');
+		// The retention target that filled the budget, grouped by how many column
+		// families carry it — the value that explained the production wedge.
+		expect(warning).toMatch(/columnFamilies=[1-9]\d*/);
+		expect(warning).toMatch(/maxWriteBufferSizeToMaintain=\{33554432:[1-9]\d*\}/);
+
+		const samples = result.stdout
+			.split('\n')
+			.filter((line) => line.startsWith('STATS '))
+			.map((line) => JSON.parse(line.slice('STATS '.length)));
+		const stalled = samples.filter((sample) => sample.stats.stallActive);
+		expect(stalled.length).toBeGreaterThan(0);
+
+		const last = stalled.at(-1)!;
+		expect(last.stats.enabled).toBe(true);
+		expect(last.stats.allowStall).toBe(true);
+		expect(last.stats.watchdogRunning).toBe(true);
+		expect(last.stats.memoryUsage).toBeGreaterThanOrEqual(last.stats.bufferSize);
+		expect(last.stats.mutableMemoryUsage).toBeLessThanOrEqual(last.stats.memoryUsage);
+		expect(last.stats.stallActiveMs).toBeGreaterThanOrEqual(WARN_MS);
+		expect(last.stats.columnFamilies).toBeGreaterThan(0);
+
+		// getStats()/getStat() are the scrape surfaces and must agree with the
+		// static accessor — an operator reading only one of them must not be told
+		// the process is healthy.
+		expect(last.getStats.stallActive).toBe(1);
+		expect(last.getStats.bufferSize).toBe(last.stats.bufferSize);
+		expect(last.getStat.stallActive).toBe(1);
+		expect(last.getStat.bufferSize).toBe(last.stats.bufferSize);
+		expect(last.getStat.stallActiveMs).toBe(last.getStats.stallActiveMs);
+
+		// stallActiveMs is a duration, not a flag: it has to climb across samples.
+		expect(stalled.at(-1)!.stats.stallActiveMs).toBeGreaterThan(stalled[0].stats.stallActiveMs);
+	}, 150_000);
+});

--- a/test/write-buffer-manager-stall-watchdog.test.ts
+++ b/test/write-buffer-manager-stall-watchdog.test.ts
@@ -51,7 +51,7 @@ function runStallChild(dbPath: string, deadlineMs: number): Promise<ChildResult>
 
 		child.stdout?.on('data', (chunk) => {
 			stdout += chunk.toString();
-			if (/^(STALLED|NEVER_STALLED|CLEARED)$/m.test(stdout)) {
+			if (/^(STALLED|NEVER_STALLED|CLEARED)\r?$/m.test(stdout)) {
 				finish();
 			}
 		});
@@ -84,10 +84,13 @@ describe('WriteBufferManager stall watchdog', () => {
 		expect(result.timedOut, `child never finished:\n${result.stderr}`).toBe(false);
 		// Anchored: 'NEVER_STALLED' also contains 'STALLED', and a run that never
 		// reached a stall must fail here rather than in the warn-count assertion.
-		expect(result.stdout.split('\n'), `child stderr:\n${result.stderr}`).toContain('STALLED');
+		expect(result.stdout.split(/\r?\n/), `child stderr:\n${result.stderr}`).toContain('STALLED');
 
+		// Split on either line ending: the C++ warn line goes through the Windows
+		// CRT's text-mode stderr, which turns its '\n' into '\r\n', while Node's
+		// console.log on stdout does not translate.
 		const warnings = result.stderr
-			.split('\n')
+			.split(/\r?\n/)
 			.filter((line) => line.includes('WriteBufferManager write stall active for'));
 		// Not one per blocked writer and not one per poll: the stall is held for
 		// several times the threshold and still yields a single line.
@@ -104,7 +107,7 @@ describe('WriteBufferManager stall watchdog', () => {
 		expect(warning).toMatch(/maxWriteBufferSizeToMaintain=\{33554432:[1-9]\d*\}/);
 
 		const samples = result.stdout
-			.split('\n')
+			.split(/\r?\n/)
 			.filter((line) => line.startsWith('STATS '))
 			.map((line) => JSON.parse(line.slice('STATS '.length)));
 		const stalled = samples.filter((sample) => sample.stats.stallActive);
@@ -131,7 +134,7 @@ describe('WriteBufferManager stall watchdog', () => {
 		// The `'log.warn'` event is the programmatic half of the warn line: same
 		// payload, same once-per-episode cadence.
 		const warned = result.stdout
-			.split('\n')
+			.split(/\r?\n/)
 			.filter((line) => line.startsWith('WARNED '))
 			.map((line) => line.slice('WARNED '.length));
 		expect(warned).toHaveLength(1);

--- a/test/write-buffer-manager-stall-watchdog.test.ts
+++ b/test/write-buffer-manager-stall-watchdog.test.ts
@@ -4,18 +4,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
-/**
- * The WriteBufferManager stall watchdog, against a real stall.
- *
- * A real stall blocks the thread that writes, so the runner's own timeout cannot
- * fire (HarperFast/rocksdb-js#781 item 2). The deadline belongs to a parent process
- * that can kill the deliberately wedged child.
- *
- * The decision logic itself is unit-tested deterministically in
- * `test/native/wbm_stall_watchdog_test.cc`; this proves the wiring: that a stall
- * is reached, that both read surfaces see it, and that the watchdog writes exactly
- * one line no matter how long it lasts.
- */
+// A real stall blocks the writer, so a parent process owns the deadline and kills the child.
 
 const fixturePath = join(__dirname, 'fixtures', 'fork-wbm-stall-watchdog.mts');
 const exitFixturePath = join(__dirname, 'fixtures', 'fork-wbm-watchdog-exit.mts');

--- a/test/write-buffer-manager-stall-watchdog.test.ts
+++ b/test/write-buffer-manager-stall-watchdog.test.ts
@@ -1,4 +1,4 @@
-import { spawn } from 'node:child_process';
+import { spawn, spawnSync } from 'node:child_process';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -19,6 +19,7 @@ import { describe, expect, it } from 'vitest';
 
 const fixturePath = join(__dirname, 'fixtures', 'fork-wbm-stall-watchdog.mts');
 const exitFixturePath = join(__dirname, 'fixtures', 'fork-wbm-watchdog-exit.mts');
+const disabledFixturePath = join(__dirname, 'fixtures', 'fork-wbm-watchdog-disabled.mts');
 const WARN_MS = 2000;
 
 type ChildResult = { stdout: string; stderr: string; timedOut: boolean };
@@ -116,6 +117,28 @@ describe('WriteBufferManager stall watchdog', () => {
 			}
 		}
 	);
+
+	it('starts no thread when the threshold is 0, with a stalling manager configured', () => {
+		const dir = mkdtempSync(join(tmpdir(), 'rocksdb-wbm-disabled-'));
+		try {
+			const child = spawnSync(process.execPath, [disabledFixturePath, join(dir, 'db')], {
+				encoding: 'utf8',
+				timeout: 30000,
+				env: { ...process.env, ROCKSDB_JS_WBM_STALL_WARN_MS: '0' },
+			});
+			expect(child.status, child.stderr).toBe(0);
+
+			const stats = JSON.parse(child.stdout.trim().split(/\r?\n/).at(-1)!);
+			expect(stats.enabled).toBe(true);
+			expect(stats.allowStall).toBe(true);
+			expect(stats.watchdogRunning).toBe(false);
+			expect(stats.stallActiveMs).toBe(0);
+		} finally {
+			if (!process.env.KEEP_FILES) {
+				rmSync(dir, { recursive: true, force: true, maxRetries: 3, retryDelay: 500 });
+			}
+		}
+	});
 
 	it('reports a sustained stall exactly once, and both read surfaces see it', async () => {
 		const dir = mkdtempSync(join(tmpdir(), 'rocksdb-wbm-stall-'));

--- a/test/write-buffer-manager-stall-watchdog.test.ts
+++ b/test/write-buffer-manager-stall-watchdog.test.ts
@@ -20,6 +20,7 @@ import { describe, expect, it } from 'vitest';
  */
 
 const fixturePath = join(__dirname, 'fixtures', 'fork-wbm-stall-watchdog.mts');
+const exitFixturePath = join(__dirname, 'fixtures', 'fork-wbm-watchdog-exit.mts');
 const WARN_MS = 2000;
 
 type ChildResult = { stdout: string; stderr: string; timedOut: boolean };
@@ -66,7 +67,56 @@ function runStallChild(dbPath: string, deadlineMs: number): Promise<ChildResult>
 	});
 }
 
+function runExitChild(
+	dbPath: string,
+	listenerOrder: 'before' | 'after'
+): Promise<{
+	code: number | null;
+	signal: NodeJS.Signals | null;
+	timedOut: boolean;
+	stderr: string;
+}> {
+	return new Promise((resolve, reject) => {
+		const child = spawn(process.execPath, [exitFixturePath, dbPath, listenerOrder]);
+		let stderr = '';
+		let timedOut = false;
+		const deadline = setTimeout(() => {
+			timedOut = true;
+			child.kill('SIGKILL');
+		}, 15_000);
+
+		child.stderr?.on('data', (chunk) => {
+			stderr += chunk.toString();
+		});
+		child.on('error', (error) => {
+			clearTimeout(deadline);
+			reject(error);
+		});
+		child.on('close', (code, signal) => {
+			clearTimeout(deadline);
+			resolve({ code, signal, timedOut, stderr });
+		});
+	});
+}
+
 describe('WriteBufferManager stall watchdog', () => {
+	it.each(['before', 'after'] as const)(
+		'exits cleanly when the global listener is registered %s watchdog construction',
+		async (listenerOrder) => {
+			const dir = mkdtempSync(join(tmpdir(), 'rocksdb-wbm-exit-'));
+			try {
+				const result = await runExitChild(join(dir, 'db'), listenerOrder);
+				expect(result.timedOut, result.stderr).toBe(false);
+				expect(result.signal, result.stderr).toBeNull();
+				expect(result.code, result.stderr).toBe(0);
+			} finally {
+				if (!process.env.KEEP_FILES) {
+					rmSync(dir, { recursive: true, force: true, maxRetries: 3, retryDelay: 500 });
+				}
+			}
+		}
+	);
+
 	it('reports a sustained stall exactly once, and both read surfaces see it', async () => {
 		const dir = mkdtempSync(join(tmpdir(), 'rocksdb-wbm-stall-'));
 		let result: ChildResult;

--- a/test/write-buffer-manager-stall-watchdog.test.ts
+++ b/test/write-buffer-manager-stall-watchdog.test.ts
@@ -7,11 +7,9 @@ import { describe, expect, it } from 'vitest';
 /**
  * The WriteBufferManager stall watchdog, against a real stall.
  *
- * Two constraints force the child-process shape. `allowStall` is fixed when the
- * manager singleton is constructed, so this needs a process no other manager has
- * run in; and a real stall blocks the thread that writes, so the runner's own
- * timeout cannot fire (HarperFast/rocksdb-js#781 item 2) — the deadline has to be
- * the parent's, and the child is killed rather than asked to exit.
+ * A real stall blocks the thread that writes, so the runner's own timeout cannot
+ * fire (HarperFast/rocksdb-js#781 item 2). The deadline belongs to a parent process
+ * that can kill the deliberately wedged child.
  *
  * The decision logic itself is unit-tested deterministically in
  * `test/native/wbm_stall_watchdog_test.cc`; this proves the wiring: that a stall
@@ -77,7 +75,9 @@ function runExitChild(
 	stderr: string;
 }> {
 	return new Promise((resolve, reject) => {
-		const child = spawn(process.execPath, [exitFixturePath, dbPath, listenerOrder]);
+		const child = spawn(process.execPath, [exitFixturePath, dbPath, listenerOrder], {
+			env: { ...process.env, ROCKSDB_JS_WBM_STALL_WARN_MS: String(WARN_MS) },
+		});
 		let stderr = '';
 		let timedOut = false;
 		const deadline = setTimeout(() => {
@@ -173,7 +173,7 @@ describe('WriteBufferManager stall watchdog', () => {
 		expect(last.stats.columnFamilies).toBeGreaterThan(0);
 
 		// getStats()/getStat() are the scrape surfaces and must agree with the
-		// static accessor — an operator reading only one of them must not be told
+		// process-wide accessor — an operator reading only one of them must not be told
 		// the process is healthy.
 		expect(last.getStats.stallActive).toBe(1);
 		expect(last.getStats.bufferSize).toBe(last.stats.bufferSize);

--- a/test/write-buffer-manager-stall-watchdog.test.ts
+++ b/test/write-buffer-manager-stall-watchdog.test.ts
@@ -24,11 +24,19 @@ const WARN_MS = 2000;
 
 type ChildResult = { stdout: string; stderr: string; timedOut: boolean };
 
-function runStallChild(dbPath: string, deadlineMs: number): Promise<ChildResult> {
+function runStallChild(
+	dbPath: string,
+	deadlineMs: number,
+	shutdownWhenStalled = false
+): Promise<ChildResult> {
 	return new Promise((resolve, reject) => {
-		const child = spawn(process.execPath, [fixturePath, dbPath], {
-			env: { ...process.env, ROCKSDB_JS_WBM_STALL_WARN_MS: String(WARN_MS) },
-		});
+		const child = spawn(
+			process.execPath,
+			[fixturePath, dbPath, ...(shutdownWhenStalled ? ['shutdown'] : [])],
+			{
+				env: { ...process.env, ROCKSDB_JS_WBM_STALL_WARN_MS: String(WARN_MS) },
+			}
+		);
 		let stdout = '';
 		let stderr = '';
 		let timedOut = false;
@@ -51,12 +59,15 @@ function runStallChild(dbPath: string, deadlineMs: number): Promise<ChildResult>
 
 		child.stdout?.on('data', (chunk) => {
 			stdout += chunk.toString();
-			if (/^(STALLED|NEVER_STALLED|CLEARED)\r?$/m.test(stdout)) {
+			if (!shutdownWhenStalled && /^(STALLED|NEVER_STALLED|CLEARED)\r?$/m.test(stdout)) {
 				finish();
 			}
 		});
 		child.stderr?.on('data', (chunk) => {
 			stderr += chunk.toString();
+			if (shutdownWhenStalled && stderr.includes('WriteBufferManager write stall active for')) {
+				finish();
+			}
 		});
 		child.on('error', (error) => {
 			clearTimeout(deadline);
@@ -204,4 +215,20 @@ describe('WriteBufferManager stall watchdog', () => {
 
 		expect(stalled.at(-1)!.stats.stallActiveMs).toBeGreaterThan(stalled[0].stats.stallActiveMs);
 	}, 150_000);
+
+	it('keeps reporting while shutdown waits for a stalled writer', async () => {
+		const dir = mkdtempSync(join(tmpdir(), 'rocksdb-wbm-stall-shutdown-'));
+		let result: ChildResult;
+		try {
+			result = await runStallChild(join(dir, 'db'), 60_000, true);
+		} finally {
+			if (!process.env.KEEP_FILES) {
+				rmSync(dir, { recursive: true, force: true, maxRetries: 3, retryDelay: 500 });
+			}
+		}
+
+		expect(result.timedOut, `child never warned:\n${result.stderr}`).toBe(false);
+		expect(result.stdout).toContain('SHUTTING_DOWN');
+		expect(result.stderr).toContain('WriteBufferManager write stall active for');
+	}, 90_000);
 });

--- a/test/write-buffer-manager-stall-watchdog.test.ts
+++ b/test/write-buffer-manager-stall-watchdog.test.ts
@@ -132,8 +132,6 @@ describe('WriteBufferManager stall watchdog', () => {
 		}
 
 		expect(result.timedOut, `child never finished:\n${result.stderr}`).toBe(false);
-		// Anchored: 'NEVER_STALLED' also contains 'STALLED', and a run that never
-		// reached a stall must fail here rather than in the warn-count assertion.
 		expect(result.stdout.split(/\r?\n/), `child stderr:\n${result.stderr}`).toContain('STALLED');
 
 		// Split on either line ending: the C++ warn line goes through the Windows
@@ -142,8 +140,6 @@ describe('WriteBufferManager stall watchdog', () => {
 		const warnings = result.stderr
 			.split(/\r?\n/)
 			.filter((line) => line.includes('WriteBufferManager write stall active for'));
-		// Not one per blocked writer and not one per poll: the stall is held for
-		// several times the threshold and still yields a single line.
 		expect(warnings).toHaveLength(1);
 
 		const [warning] = warnings;
@@ -151,8 +147,6 @@ describe('WriteBufferManager stall watchdog', () => {
 		expect(warning).toMatch(/usage=\d[\d.]*[KMGT]?B \(\d/);
 		expect(warning).toMatch(/mutable=\d[\d.]*[KMGT]?B \(\d/);
 		expect(warning).toContain('allowStall=true');
-		// The retention target that filled the budget, grouped by how many column
-		// families carry it — the value that explained the production wedge.
 		expect(warning).toMatch(/columnFamilies=[1-9]\d*/);
 		expect(warning).toMatch(/maxWriteBufferSizeToMaintain=\{33554432:[1-9]\d*\}/);
 
@@ -172,17 +166,12 @@ describe('WriteBufferManager stall watchdog', () => {
 		expect(last.stats.stallActiveMs).toBeGreaterThanOrEqual(WARN_MS);
 		expect(last.stats.columnFamilies).toBeGreaterThan(0);
 
-		// getStats()/getStat() are the scrape surfaces and must agree with the
-		// process-wide accessor — an operator reading only one of them must not be told
-		// the process is healthy.
 		expect(last.getStats.stallActive).toBe(1);
 		expect(last.getStats.bufferSize).toBe(last.stats.bufferSize);
 		expect(last.getStat.stallActive).toBe(1);
 		expect(last.getStat.bufferSize).toBe(last.stats.bufferSize);
 		expect(last.getStat.stallActiveMs).toBe(last.getStats.stallActiveMs);
 
-		// The `'log.warn'` event is the programmatic half of the warn line: same
-		// payload, same once-per-episode cadence.
 		const warned = result.stdout
 			.split(/\r?\n/)
 			.filter((line) => line.startsWith('WARNED '))
@@ -190,7 +179,6 @@ describe('WriteBufferManager stall watchdog', () => {
 		expect(warned).toHaveLength(1);
 		expect(warned[0]).toBe(warning);
 
-		// stallActiveMs is a duration, not a flag: it has to climb across samples.
 		expect(stalled.at(-1)!.stats.stallActiveMs).toBeGreaterThan(stalled[0].stats.stallActiveMs);
 	}, 150_000);
 });

--- a/test/write-buffer-manager-stall-watchdog.test.ts
+++ b/test/write-buffer-manager-stall-watchdog.test.ts
@@ -193,7 +193,8 @@ describe('WriteBufferManager stall watchdog', () => {
 		expect(last.getStats.bufferSize).toBe(last.stats.bufferSize);
 		expect(last.getStat.stallActive).toBe(1);
 		expect(last.getStat.bufferSize).toBe(last.stats.bufferSize);
-		expect(last.getStat.stallActiveMs).toBe(last.getStats.stallActiveMs);
+		expect(last.getStats.stallActiveMs).toBeGreaterThanOrEqual(last.stats.stallActiveMs);
+		expect(last.getStat.stallActiveMs).toBeGreaterThanOrEqual(last.getStats.stallActiveMs);
 
 		const warned = result.stdout
 			.split(/\r?\n/)

--- a/test/write-buffer-manager-stall.test.ts
+++ b/test/write-buffer-manager-stall.test.ts
@@ -3,9 +3,8 @@ import { dbRunner } from './lib/util.ts';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 /**
- * `allowStall` is fixed when the WriteBufferManager singleton is created and cannot be changed
- * afterwards, so this scenario needs a WBM nothing else in the process has built yet — hence its
- * own file (Vitest isolates each test file in its own worker/process).
+ * This scenario intentionally drives the process-wide manager into a stall, so it stays isolated
+ * from tests that use the singleton with ordinary budgets.
  */
 describe('WriteBufferManager stall', () => {
 	beforeAll(() => {
@@ -18,12 +17,11 @@ describe('WriteBufferManager stall', () => {
 		});
 	});
 
-	// Leave no manager attached to databases opened by later files (same reason
-	// write-buffer-manager.test.ts resets); `allowStall` itself is not resettable.
 	afterAll(() => {
 		RocksDatabase.config({
 			blockCacheSize: 32 * 1024 * 1024,
 			writeBufferManagerSize: 0,
+			writeBufferManagerAllowStall: false,
 		});
 	});
 

--- a/test/write-buffer-manager.test.ts
+++ b/test/write-buffer-manager.test.ts
@@ -1,5 +1,6 @@
 import { RocksDatabase } from '../src/index.ts';
-import { dbRunner } from './lib/util.ts';
+import { dbRunner, generateDBPath } from './lib/util.ts';
+import { rmSync } from 'node:fs';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 /**
@@ -28,6 +29,28 @@ describe('WriteBufferManager', () => {
 				await db.put('foo', 'bar');
 				expect(await db.get('foo')).toBe('bar');
 			}));
+
+		// Runs before this file's beforeAll creates the manager, so it is the only
+		// place the "no manager in this process" shape is observable.
+		it('should report an unconfigured manager as disabled rather than absent', () =>
+			dbRunner(async ({ db }) => {
+				const stats = RocksDatabase.getWriteBufferManagerStats();
+				expect(stats.enabled).toBe(false);
+				expect(stats.bufferSize).toBe(0);
+				expect(stats.memoryUsage).toBe(0);
+				expect(stats.mutableMemoryUsage).toBe(0);
+				expect(stats.stallActive).toBe(false);
+				expect(stats.stallActiveMs).toBe(0);
+				expect(stats.watchdogRunning).toBe(false);
+				expect(stats.columnFamilies).toBe(0);
+				expect(stats.maxWriteBufferSizeToMaintain).toEqual({});
+
+				// The scrape keys keep their shape so a dashboard reading them does
+				// not have to special-case "manager not configured".
+				const dbStats = db.getStats();
+				expect(dbStats['writeBufferManager.bufferSize']).toBe(0);
+				expect(dbStats['writeBufferManager.stallActive']).toBe(0);
+			}));
 	});
 
 	describe('with costToCache enabled', () => {
@@ -47,6 +70,127 @@ describe('WriteBufferManager', () => {
 				blockCacheSize: 32 * 1024 * 1024,
 				writeBufferManagerSize: 0,
 			});
+		});
+
+		describe('observability', () => {
+			it('should report the live budget and usage on both surfaces', () =>
+				dbRunner(async ({ db }) => {
+					const value = 'x'.repeat(2048);
+					for (let i = 0; i < 500; i++) {
+						await db.put(`obs-${i.toString().padStart(6, '0')}`, value);
+					}
+
+					const stats = RocksDatabase.getWriteBufferManagerStats();
+					expect(stats.enabled).toBe(true);
+					expect(stats.bufferSize).toBe(64 * 1024 * 1024);
+					expect(stats.costToCache).toBe(true);
+					expect(stats.allowStall).toBe(false);
+					// Nothing can stall a manager built without allowStall, so the
+					// watchdog is deliberately not running.
+					expect(stats.stallActive).toBe(false);
+					expect(stats.watchdogRunning).toBe(false);
+					expect(stats.memoryUsage).toBeGreaterThan(1024 * 1024);
+					expect(stats.mutableMemoryUsage).toBeGreaterThan(0);
+					expect(stats.mutableMemoryUsage).toBeLessThanOrEqual(stats.memoryUsage);
+
+					// `db.getStats()` reports the same process-wide manager, and is
+					// not gated on `enableStats` (this database has statistics off).
+					const dbStats = db.getStats();
+					expect(dbStats['writeBufferManager.bufferSize']).toBe(stats.bufferSize);
+					expect(dbStats['writeBufferManager.stallActive']).toBe(0);
+					expect(dbStats['writeBufferManager.memoryUsage']).toBeGreaterThan(1024 * 1024);
+				}));
+
+			it('should resolve each key through getStat() without requiring statistics', () =>
+				dbRunner(async ({ db }) => {
+					await db.put('stat-routing', 'value');
+					expect(db.getStat('writeBufferManager.bufferSize')).toBe(64 * 1024 * 1024);
+					expect(db.getStat('writeBufferManager.memoryUsage')).toBeGreaterThan(0);
+					expect(typeof db.getStat('writeBufferManager.mutableMemoryUsage')).toBe('number');
+					expect(db.getStat('writeBufferManager.stallActive')).toBe(0);
+					expect(db.getStat('writeBufferManager.stallActiveMs')).toBe(0);
+					// An unknown key in this namespace is never a RocksDB ticker or
+					// property, so it must not fall through to the statistics path —
+					// which throws when statistics are disabled, i.e. exactly when an
+					// operator is reaching for this during an incident.
+					expect(db.getStat('writeBufferManager.nope')).toBeUndefined();
+				}));
+
+			it('should count only column families attached to this manager', () => {
+				const detachedPath = generateDBPath();
+				const readOnlyPath = generateDBPath();
+				const attachedPath = generateDBPath();
+				const columnFamilies = (): number =>
+					RocksDatabase.getWriteBufferManagerStats().columnFamilies;
+
+				const opened: RocksDatabase[] = [];
+				try {
+					const baseline = columnFamilies();
+
+					const attached = new RocksDatabase(attachedPath, { name: 'attached' });
+					attached.open();
+					opened.push(attached);
+					const withAttached = columnFamilies();
+					expect(withAttached).toBeGreaterThan(baseline);
+
+					// Size 0 means "no new attachments", not a teardown: a database
+					// opened in that window draws on its own budget and cannot explain
+					// the manager's memory, so its column families must not appear.
+					RocksDatabase.config({ writeBufferManagerSize: 0 });
+					const detached = new RocksDatabase(detachedPath, { name: 'detached' });
+					detached.open();
+					opened.push(detached);
+					RocksDatabase.config({ writeBufferManagerSize: 64 * 1024 * 1024 });
+					expect(columnFamilies()).toBe(withAttached);
+
+					// A read-only database attaches the manager but writes nothing to
+					// it, so counting it would inflate the retention distribution the
+					// stall report is meant to explain.
+					const seed = new RocksDatabase(readOnlyPath);
+					seed.open();
+					seed.putSync('seed', 'value');
+					seed.close();
+					const readOnly = new RocksDatabase(readOnlyPath, { readOnly: true });
+					readOnly.open();
+					opened.push(readOnly);
+					expect(columnFamilies()).toBe(withAttached);
+				} finally {
+					for (const db of opened) {
+						db.close();
+					}
+					if (!process.env.KEEP_FILES) {
+						for (const path of [attachedPath, detachedPath, readOnlyPath]) {
+							rmSync(path, { force: true, recursive: true, maxRetries: 3, retryDelay: 500 });
+						}
+					}
+				}
+			});
+
+			// Guards the docs/stats.md note: with `atomic_flush` (which this library
+			// always sets) manager-pressure flushes reach BOTH counters. Only their
+			// presence is asserted — the two count different events (scheduling
+			// requests vs executed flushes) and their ratio is not stable, so no
+			// relationship between the magnitudes is claimed here or in the docs.
+			it('should record manager-pressure flushes on both flush-reason tickers', () =>
+				dbRunner({ dbOptions: [{ enableStats: true }] }, async ({ db }) => {
+					// Shrink the shared budget so ordinary test volume reaches it.
+					RocksDatabase.config({ writeBufferManagerSize: 4 * 1024 * 1024 });
+					try {
+						const value = 'x'.repeat(8192);
+						for (let i = 0; i < 2000; i++) {
+							await db.put(`flush-${i.toString().padStart(6, '0')}`, value);
+						}
+						await new Promise((resolve) => setTimeout(resolve, 500));
+
+						const stats = db.getStats(true);
+						const requests = stats['rocksdb.atomic_flush.request.reason.write_buffer_manager'];
+						const perColumnFamily = stats['rocksdb.flush.reason.write_buffer_manager'];
+						expect(requests).toBeGreaterThan(0);
+						expect(perColumnFamily).toBeGreaterThan(0);
+					} finally {
+						RocksDatabase.config({ writeBufferManagerSize: 64 * 1024 * 1024 });
+					}
+				}));
 		});
 
 		it('should open a database with the WriteBufferManager + costToCache', () =>

--- a/test/write-buffer-manager.test.ts
+++ b/test/write-buffer-manager.test.ts
@@ -125,6 +125,7 @@ describe('WriteBufferManager', () => {
 
 				const opened: RocksDatabase[] = [];
 				try {
+					expect(RocksDatabase.getWriteBufferManagerStats().inventoryAvailable).toBe(true);
 					const baseline = columnFamilies();
 
 					const attached = new RocksDatabase(attachedPath, { name: 'attached' });

--- a/test/write-buffer-manager.test.ts
+++ b/test/write-buffer-manager.test.ts
@@ -85,8 +85,7 @@ describe('WriteBufferManager', () => {
 					expect(stats.bufferSize).toBe(64 * 1024 * 1024);
 					expect(stats.costToCache).toBe(true);
 					expect(stats.allowStall).toBe(false);
-					// Nothing can stall a manager built without allowStall, so the
-					// watchdog is deliberately not running.
+					// Nothing can stall a manager built without allowStall.
 					expect(stats.stallActive).toBe(false);
 					expect(stats.watchdogRunning).toBe(false);
 					expect(stats.memoryUsage).toBeGreaterThan(1024 * 1024);
@@ -109,12 +108,26 @@ describe('WriteBufferManager', () => {
 					expect(typeof db.getStat('writeBufferManager.mutableMemoryUsage')).toBe('number');
 					expect(db.getStat('writeBufferManager.stallActive')).toBe(0);
 					expect(db.getStat('writeBufferManager.stallActiveMs')).toBe(0);
-					// An unknown key in this namespace is never a RocksDB ticker or
-					// property, so it must not fall through to the statistics path —
-					// which throws when statistics are disabled, i.e. exactly when an
+					// An unknown key here must not fall through to the statistics path,
+					// which throws when statistics are disabled — i.e. exactly when an
 					// operator is reaching for this during an incident.
 					expect(db.getStat('writeBufferManager.nope')).toBeUndefined();
 				}));
+
+			it('should start and stop the watchdog on the allowStall edges', () => {
+				expect(RocksDatabase.getWriteBufferManagerStats().watchdogRunning).toBe(false);
+				try {
+					// allowStall is the only thing that makes a stall reachable, and it
+					// is mutable at runtime, so the watchdog has to follow both edges
+					// rather than only the manager's construction.
+					RocksDatabase.config({ writeBufferManagerAllowStall: true });
+					expect(RocksDatabase.getWriteBufferManagerStats().watchdogRunning).toBe(true);
+					RocksDatabase.config({ writeBufferManagerAllowStall: false });
+					expect(RocksDatabase.getWriteBufferManagerStats().watchdogRunning).toBe(false);
+				} finally {
+					RocksDatabase.config({ writeBufferManagerAllowStall: false });
+				}
+			});
 
 			it('should count only column families attached to this manager', () => {
 				const detachedPath = generateDBPath();

--- a/test/write-buffer-manager.test.ts
+++ b/test/write-buffer-manager.test.ts
@@ -1,7 +1,11 @@
 import { getWriteBufferManagerStats, RocksDatabase } from '../src/index.ts';
 import { dbRunner, generateDBPath } from './lib/util.ts';
+import { spawnSync } from 'node:child_process';
 import { rmSync } from 'node:fs';
+import { join } from 'node:path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+const unconfiguredFixturePath = join(__dirname, 'fixtures', 'fork-wbm-unconfigured.mts');
 
 /**
  * The WriteBufferManager is a process-global singleton. Once created, its
@@ -30,11 +34,18 @@ describe('WriteBufferManager', () => {
 				expect(await db.get('foo')).toBe('bar');
 			}));
 
-		// Runs before this file's beforeAll creates the manager, so it is the only
-		// place the "no manager in this process" shape is observable.
-		it('should report an unconfigured manager as disabled rather than absent', () =>
-			dbRunner(async ({ db }) => {
-				const stats = getWriteBufferManagerStats();
+		// In a child process: the manager is a process-wide singleton shared by
+		// every vitest worker thread, so any other file that configures one makes
+		// the unconfigured shape unobservable here.
+		it('should report an unconfigured manager as disabled rather than absent', () => {
+			const dbPath = generateDBPath();
+			try {
+				const child = spawnSync(process.execPath, [unconfiguredFixturePath, dbPath], {
+					encoding: 'utf8',
+				});
+				expect(child.status, child.stderr).toBe(0);
+
+				const { stats, dbStats } = JSON.parse(child.stdout.trim().split(/\r?\n/).at(-1)!);
 				expect(stats.enabled).toBe(false);
 				expect(stats.bufferSize).toBe(0);
 				expect(stats.memoryUsage).toBe(0);
@@ -47,10 +58,14 @@ describe('WriteBufferManager', () => {
 
 				// The scrape keys keep their shape so a dashboard reading them does
 				// not have to special-case "manager not configured".
-				const dbStats = db.getStats();
 				expect(dbStats['writeBufferManager.bufferSize']).toBe(0);
 				expect(dbStats['writeBufferManager.stallActive']).toBe(0);
-			}));
+			} finally {
+				if (!process.env.KEEP_FILES) {
+					rmSync(dbPath, { force: true, recursive: true, maxRetries: 3, retryDelay: 500 });
+				}
+			}
+		});
 	});
 
 	describe('with costToCache enabled', () => {

--- a/test/write-buffer-manager.test.ts
+++ b/test/write-buffer-manager.test.ts
@@ -85,15 +85,12 @@ describe('WriteBufferManager', () => {
 					expect(stats.bufferSize).toBe(64 * 1024 * 1024);
 					expect(stats.costToCache).toBe(true);
 					expect(stats.allowStall).toBe(false);
-					// Nothing can stall a manager built without allowStall.
 					expect(stats.stallActive).toBe(false);
 					expect(stats.watchdogRunning).toBe(false);
 					expect(stats.memoryUsage).toBeGreaterThan(1024 * 1024);
 					expect(stats.mutableMemoryUsage).toBeGreaterThan(0);
 					expect(stats.mutableMemoryUsage).toBeLessThanOrEqual(stats.memoryUsage);
 
-					// `db.getStats()` reports the same process-wide manager, and is
-					// not gated on `enableStats` (this database has statistics off).
 					const dbStats = db.getStats();
 					expect(dbStats['writeBufferManager.bufferSize']).toBe(stats.bufferSize);
 					expect(dbStats['writeBufferManager.stallActive']).toBe(0);
@@ -108,9 +105,6 @@ describe('WriteBufferManager', () => {
 					expect(typeof db.getStat('writeBufferManager.mutableMemoryUsage')).toBe('number');
 					expect(db.getStat('writeBufferManager.stallActive')).toBe(0);
 					expect(db.getStat('writeBufferManager.stallActiveMs')).toBe(0);
-					// An unknown key here must not fall through to the statistics path,
-					// which throws when statistics are disabled — i.e. exactly when an
-					// operator is reaching for this during an incident.
 					expect(db.getStat('writeBufferManager.nope')).toBeUndefined();
 				}));
 
@@ -133,8 +127,9 @@ describe('WriteBufferManager', () => {
 				}
 			);
 
-			it('should count only column families attached to this manager', () => {
+			it('should inventory column families attached to this manager', () => {
 				const detachedPath = generateDBPath();
+				const droppedPath = generateDBPath();
 				const readOnlyPath = generateDBPath();
 				const attachedPath = generateDBPath();
 				const columnFamilies = (): number => getWriteBufferManagerStats().columnFamilies;
@@ -160,9 +155,6 @@ describe('WriteBufferManager', () => {
 					RocksDatabase.config({ writeBufferManagerSize: 64 * 1024 * 1024 });
 					expect(columnFamilies()).toBe(withAttached);
 
-					// A read-only database attaches the manager but writes nothing to
-					// it, so counting it would inflate the retention distribution the
-					// stall report is meant to explain.
 					const seed = new RocksDatabase(readOnlyPath);
 					seed.open();
 					seed.putSync('seed', 'value');
@@ -170,13 +162,22 @@ describe('WriteBufferManager', () => {
 					const readOnly = new RocksDatabase(readOnlyPath, { readOnly: true });
 					readOnly.open();
 					opened.push(readOnly);
-					expect(columnFamilies()).toBe(withAttached);
+					expect(columnFamilies()).toBe(withAttached + 1);
+
+					const dropped = new RocksDatabase(droppedPath, { name: 'dropped' });
+					dropped.open();
+					opened.push(dropped);
+					dropped.dropSync();
+					const incomplete = getWriteBufferManagerStats();
+					expect(incomplete.inventoryAvailable).toBe(false);
+					expect(incomplete.columnFamilies).toBe(0);
+					expect(incomplete.maxWriteBufferSizeToMaintain).toEqual({});
 				} finally {
 					for (const db of opened) {
 						db.close();
 					}
 					if (!process.env.KEEP_FILES) {
-						for (const path of [attachedPath, detachedPath, readOnlyPath]) {
+						for (const path of [attachedPath, detachedPath, droppedPath, readOnlyPath]) {
 							rmSync(path, { force: true, recursive: true, maxRetries: 3, retryDelay: 500 });
 						}
 					}

--- a/test/write-buffer-manager.test.ts
+++ b/test/write-buffer-manager.test.ts
@@ -1,12 +1,12 @@
-import { RocksDatabase } from '../src/index.ts';
+import { getWriteBufferManagerStats, RocksDatabase } from '../src/index.ts';
 import { dbRunner, generateDBPath } from './lib/util.ts';
 import { rmSync } from 'node:fs';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 /**
  * The WriteBufferManager is a process-global singleton. Once created, its
- * `costToCache` and `allowStall` settings are fixed for the life of the
- * process — only `bufferSize` is mutable at runtime (via `SetBufferSize`).
+ * `costToCache` is fixed for the life of the process, while `allowStall` and
+ * `bufferSize` are mutable at runtime.
  *
  * So we initialize it ONCE for the whole file with the most informative
  * configuration (`costToCache: true`, room for resizing) and write each test
@@ -34,7 +34,7 @@ describe('WriteBufferManager', () => {
 		// place the "no manager in this process" shape is observable.
 		it('should report an unconfigured manager as disabled rather than absent', () =>
 			dbRunner(async ({ db }) => {
-				const stats = RocksDatabase.getWriteBufferManagerStats();
+				const stats = getWriteBufferManagerStats();
 				expect(stats.enabled).toBe(false);
 				expect(stats.bufferSize).toBe(0);
 				expect(stats.memoryUsage).toBe(0);
@@ -80,7 +80,7 @@ describe('WriteBufferManager', () => {
 						await db.put(`obs-${i.toString().padStart(6, '0')}`, value);
 					}
 
-					const stats = RocksDatabase.getWriteBufferManagerStats();
+					const stats = getWriteBufferManagerStats();
 					expect(stats.enabled).toBe(true);
 					expect(stats.bufferSize).toBe(64 * 1024 * 1024);
 					expect(stats.costToCache).toBe(true);
@@ -115,15 +115,15 @@ describe('WriteBufferManager', () => {
 				}));
 
 			it('should start and stop the watchdog on the allowStall edges', () => {
-				expect(RocksDatabase.getWriteBufferManagerStats().watchdogRunning).toBe(false);
+				expect(getWriteBufferManagerStats().watchdogRunning).toBe(false);
 				try {
 					// allowStall is the only thing that makes a stall reachable, and it
 					// is mutable at runtime, so the watchdog has to follow both edges
 					// rather than only the manager's construction.
 					RocksDatabase.config({ writeBufferManagerAllowStall: true });
-					expect(RocksDatabase.getWriteBufferManagerStats().watchdogRunning).toBe(true);
+					expect(getWriteBufferManagerStats().watchdogRunning).toBe(true);
 					RocksDatabase.config({ writeBufferManagerAllowStall: false });
-					expect(RocksDatabase.getWriteBufferManagerStats().watchdogRunning).toBe(false);
+					expect(getWriteBufferManagerStats().watchdogRunning).toBe(false);
 				} finally {
 					RocksDatabase.config({ writeBufferManagerAllowStall: false });
 				}
@@ -133,12 +133,11 @@ describe('WriteBufferManager', () => {
 				const detachedPath = generateDBPath();
 				const readOnlyPath = generateDBPath();
 				const attachedPath = generateDBPath();
-				const columnFamilies = (): number =>
-					RocksDatabase.getWriteBufferManagerStats().columnFamilies;
+				const columnFamilies = (): number => getWriteBufferManagerStats().columnFamilies;
 
 				const opened: RocksDatabase[] = [];
 				try {
-					expect(RocksDatabase.getWriteBufferManagerStats().inventoryAvailable).toBe(true);
+					expect(getWriteBufferManagerStats().inventoryAvailable).toBe(true);
 					const baseline = columnFamilies();
 
 					const attached = new RocksDatabase(attachedPath, { name: 'attached' });

--- a/test/write-buffer-manager.test.ts
+++ b/test/write-buffer-manager.test.ts
@@ -114,20 +114,24 @@ describe('WriteBufferManager', () => {
 					expect(db.getStat('writeBufferManager.nope')).toBeUndefined();
 				}));
 
-			it('should start and stop the watchdog on the allowStall edges', () => {
-				expect(getWriteBufferManagerStats().watchdogRunning).toBe(false);
-				try {
-					// allowStall is the only thing that makes a stall reachable, and it
-					// is mutable at runtime, so the watchdog has to follow both edges
-					// rather than only the manager's construction.
-					RocksDatabase.config({ writeBufferManagerAllowStall: true });
-					expect(getWriteBufferManagerStats().watchdogRunning).toBe(true);
-					RocksDatabase.config({ writeBufferManagerAllowStall: false });
+			it.skipIf(process.env.ROCKSDB_JS_WBM_STALL_WARN_MS === '0')(
+				'should start and stop the watchdog on the allowStall edges',
+				() => {
 					expect(getWriteBufferManagerStats().watchdogRunning).toBe(false);
-				} finally {
-					RocksDatabase.config({ writeBufferManagerAllowStall: false });
+					try {
+						RocksDatabase.config({ writeBufferManagerAllowStall: true });
+						expect(getWriteBufferManagerStats().watchdogRunning).toBe(true);
+						RocksDatabase.config({ writeBufferManagerAllowStall: false });
+						expect(getWriteBufferManagerStats().watchdogRunning).toBe(false);
+						RocksDatabase.config({ writeBufferManagerAllowStall: true });
+						expect(getWriteBufferManagerStats().watchdogRunning).toBe(true);
+						RocksDatabase.config({ writeBufferManagerAllowStall: false });
+						expect(getWriteBufferManagerStats().watchdogRunning).toBe(false);
+					} finally {
+						RocksDatabase.config({ writeBufferManagerAllowStall: false });
+					}
 				}
-			});
+			);
 
 			it('should count only column families attached to this manager', () => {
 				const detachedPath = generateDBPath();

--- a/test/write-buffer-manager.test.ts
+++ b/test/write-buffer-manager.test.ts
@@ -34,9 +34,6 @@ describe('WriteBufferManager', () => {
 				expect(await db.get('foo')).toBe('bar');
 			}));
 
-		// In a child process: the manager is a process-wide singleton shared by
-		// every vitest worker thread, so any other file that configures one makes
-		// the unconfigured shape unobservable here.
 		it('should report an unconfigured manager as disabled rather than absent', () => {
 			const dbPath = generateDBPath();
 			try {
@@ -225,7 +222,6 @@ describe('WriteBufferManager', () => {
 			// relationship between the magnitudes is claimed here or in the docs.
 			it('should record manager-pressure flushes on both flush-reason tickers', () =>
 				dbRunner({ dbOptions: [{ enableStats: true }] }, async ({ db }) => {
-					// Shrink the shared budget so ordinary test volume reaches it.
 					RocksDatabase.config({ writeBufferManagerSize: 4 * 1024 * 1024 });
 					try {
 						const value = 'x'.repeat(8192);

--- a/test/write-buffer-manager.test.ts
+++ b/test/write-buffer-manager.test.ts
@@ -133,6 +133,8 @@ describe('WriteBufferManager', () => {
 				const readOnlyPath = generateDBPath();
 				const attachedPath = generateDBPath();
 				const columnFamilies = (): number => getWriteBufferManagerStats().columnFamilies;
+				const sumTargets = (targets: Record<string, number>): number =>
+					Object.values(targets).reduce((total, count) => total + count, 0);
 
 				const opened: RocksDatabase[] = [];
 				try {
@@ -164,14 +166,31 @@ describe('WriteBufferManager', () => {
 					opened.push(readOnly);
 					expect(columnFamilies()).toBe(withAttached + 1);
 
+					// A dropped family keeps charging the manager until its last handle
+					// closes, so it stays counted across the drop and stops being
+					// counted at that close — the inventory recovers rather than
+					// latching unavailable for the life of the database.
+					const retained = new RocksDatabase(droppedPath);
+					retained.open();
+					opened.push(retained);
 					const dropped = new RocksDatabase(droppedPath, { name: 'dropped' });
 					dropped.open();
 					opened.push(dropped);
+					const withDropped = columnFamilies();
+					expect(withDropped).toBe(withAttached + 3);
+
 					dropped.dropSync();
-					const incomplete = getWriteBufferManagerStats();
-					expect(incomplete.inventoryAvailable).toBe(false);
-					expect(incomplete.columnFamilies).toBe(0);
-					expect(incomplete.maxWriteBufferSizeToMaintain).toEqual({});
+					const afterDrop = getWriteBufferManagerStats();
+					expect(afterDrop.inventoryAvailable).toBe(true);
+					expect(afterDrop.columnFamilies).toBe(withDropped);
+					expect(sumTargets(afterDrop.maxWriteBufferSizeToMaintain)).toBe(withDropped);
+
+					dropped.close();
+					opened.splice(opened.indexOf(dropped), 1);
+					const afterClose = getWriteBufferManagerStats();
+					expect(afterClose.inventoryAvailable).toBe(true);
+					expect(afterClose.columnFamilies).toBe(withDropped - 1);
+					expect(sumTargets(afterClose.maxWriteBufferSizeToMaintain)).toBe(withDropped - 1);
 				} finally {
 					for (const db of opened) {
 						db.close();


### PR DESCRIPTION
A `WriteBufferManager` stall is a second, entirely separate stall mechanism from the one RocksDB reports on. `DBImpl::WriteBufferManagerStallWrites` parks writers on the manager's own queue without touching the `WriteController`, so `rocksdb.stall.micros`, the `WRITE_STALL` histogram and `OnStallConditionsChanged` — and therefore `db.isWriteStalled()` and the `'writeStall'` event — all read `0` for its entire duration. Through an eight-hour production wedge every one of them did, while reads kept working and diagnosis needed gdb.

This makes the condition visible. It is additive: no write-path behavior changes, and nothing about `allowStall`, WriteBufferManager sizing, or the retained-history resolution (#821) is touched.

**1. The manager's live state, on two surfaces.** `db.getStats()` / `db.getStat()` gain five keys under a `writeBufferManager.` prefix — `bufferSize`, `memoryUsage`, `mutableMemoryUsage`, `stallActive`, `stallActiveMs` — added unconditionally, the same treatment the existing `txnlog.*` and `commitPipeline.*` keys get, so they appear with `enableStats: false`. They are routed through [the same prefix branch in `DBHandle::getStat`](https://github.com/HarperFast/rocksdb-js/pull/824/changes?w=1#diff-927a214e5d5cca0234f56ddcab411eac454d4ee098051bde49cd6cd923828bb4R192) those two use, because a single-key read that fell through to the RocksDB statistics path would throw "Statistics are not enabled" during exactly the incident an operator is reaching for it in. The top-level `getWriteBufferManagerStats()` export returns the same values plus the manager's configuration and its live column-family inventory. Both read the manager through an [`std::atomic<WriteBufferManager*>` published at construction](https://github.com/HarperFast/rocksdb-js/pull/824/changes?w=1#diff-44bc4a676f65953959ecb869ef849f6d2924dcc6120e8102870b0dd2fa395ca1R83), so a metrics scrape takes no lock and never materializes the manager as a side effect.

These are process-wide values coming back from a per-database call — the manager is a singleton shared by every database in the process, `worker_threads` included — which is stated in the docs, the JSDoc, and the stat-name reference.

**2. A watchdog that logs one warn line per stall episode**, carrying the budget, usage, mutable share, live column-family count and the [*effective* per-CF `max_write_buffer_size_to_maintain`](https://github.com/HarperFast/rocksdb-js/pull/824/changes?w=1#diff-a31cff767fb80ff129fd8f72784731a6c6db684ab520782ae1edddd7779d2587R872) — effective, not requested, because #821's whole finding is that `TransactionDB::Open` rewrites a requested `0` into 256 MiB per column family, so the requested value would hide the fact the line exists to expose. Every one of those was needed to explain the wedge and every one required the RocksDB `LOG` or a debugger.

It owns a thread because every other tick in the process is blocked by the condition it reports: `CommitWorker` parks in `db->Write()` (the `rocksdb-commit` lanes are in #822's backtrace), `logWorker` is event-driven off commits the stall prevents, `ParkTimeoutRegistry`'s thread is per-descriptor and only exists after a VT conflict, RocksDB's stall callbacks never fire, and a JS timer cannot run on a thread parked in `store.putSync()`. One thread per process, [started lazily](https://github.com/HarperFast/rocksdb-js/pull/824/changes?w=1#diff-44bc4a676f65953959ecb869ef849f6d2924dcc6120e8102870b0dd2fa395ca1R87) only while a manager exists *with* `allowStall` (`ShouldStall()` short-circuits otherwise, so no stall is reachable and no thread is started), sampling one relaxed atomic per second. Four lifecycle constraints on that thread are the places to look hardest, each of which the review found the hard way:

- **Lock order is `databasesMutex -> writeBufferManagerMutex -> watchdogMutex`**, because `DBRegistry::OpenDB` holds the first across `DBDescriptor::open`. So the start path [never joins a retiring thread](https://github.com/HarperFast/rocksdb-js/pull/824/changes?w=1#diff-44bc4a676f65953959ecb869ef849f6d2924dcc6120e8102870b0dd2fa395ca1R87) — the thread it would join may be waiting for exactly that lock — and a per-start generation counter retires stale threads instead.
- **The inventory walk [try_locks `databasesMutex`](https://github.com/HarperFast/rocksdb-js/pull/824/changes?w=1#diff-1ac655e46fe2a38bac691bf6882595e27c00f8f61015ff57b7d305c13de15b98R307)** and reports `inventoryAvailable: false` rather than waiting: `PurgeAll` holds that lock across a close whose flush waits out a write stall (AGENTS.md note 16), so blocking there would silence the alarm and hang `getWriteBufferManagerStats()` during the incident both exist to report. A dropped column family keeps charging the manager until its last handle closes, so it moves to a [`weak_ptr` plus a copy of its retention target](https://github.com/HarperFast/rocksdb-js/pull/824/changes?w=1#diff-a31cff767fb80ff129fd8f72784731a6c6db684ab520782ae1edddd7779d2587R298) and stays counted until then. Only `expired()` is ever called on that reference — `lock()`ing it would make the sampling thread the potential last releaser, running `~ColumnFamilyDescriptor` under both inventory locks.
- **Stop and join both follow the database flush** — [`shutdown()` snapshots the arm-request generation, closes databases, then retires the watchdog](https://github.com/HarperFast/rocksdb-js/pull/824/changes?w=1#diff-5bdfd0ac49ea126864c1cfbff17a606f1aa339fffd20472611f6fc68082ca199R46), so a shutdown wedged behind a stalled writer can still emit its `stderr` warning. The [`allowStall` falling edge](https://github.com/HarperFast/rocksdb-js/pull/824/changes?w=1#diff-44bc4a676f65953959ecb869ef849f6d2924dcc6120e8102870b0dd2fa395ca1R119) only *parks* the thread, so a report blocked on a full pipe holds no lock any database open needs. Destruction order comes from `DBStats`'s constructor materializing `DBSettings` and `GlobalEvents` first, so reverse static destruction joins the watchdog before anything it reads dies.
- **One joiner owns each retirement.** In [`joinWriteBufferManagerWatchdog`](https://github.com/HarperFast/rocksdb-js/pull/824/changes?w=1#diff-44bc4a676f65953959ecb869ef849f6d2924dcc6120e8102870b0dd2fa395ca1R148), callers wait for an existing owner, return without touching stop state when there is no thread, and decline to retire a replacement when a concurrent reopen advanced the arm-request generation. [The deterministic fixture](https://github.com/HarperFast/rocksdb-js/pull/824/changes?w=1#diff-f2a47b19c8f19999e44f93b9ccecf5922480137a912de052809cbe7df0fab9abR69) delays an older joiner until a database has reopened, then proves the replacement remains monitored; it also runs four rounds of gated concurrent shutdowns.

The decision FSM itself is [Node-free](https://github.com/HarperFast/rocksdb-js/pull/824/changes?w=1#diff-dfe95546fb4a17f54377f5f142145418b9fe0471eb97b92e304e7a6cd881cd54R33) and GoogleTest-covered, so the sampling logic is proved without threads or RocksDB.

## For the human reviewer

The step-6 planning gate ran before any code and cleared: `Framing-Verdict: chosen-approach-sound`. Many pre-push review rounds followed across the original implementation and this rebase (codex + gemini + harper-domain); the decisions below are the ones a reviewer should weigh rather than defects left open.

**A recurring pattern worth knowing about before reading the round history below:** Gemini runs with no session continuity (a fresh model instance each round), so it re-derives the whole diff from scratch every time and has repeatedly raised the same handful of shutdown/teardown "blocker" claims about code paths it apparently doesn't fully trace before writing the finding. Four instances, all checked directly against the code and all wrong:
- **`DBRegistry::instance` torn down under the watchdog** (raised 3 times across rounds 20-26): `instance` is a `std::unique_ptr<DBRegistry>` assigned exactly once, in `Init()` (`db_registry.cpp:348`); grepping the whole file shows no other assignment to it anywhere — `Shutdown()` and `PurgeAll()` both only ever do `if (instance) { ... }` and use the object through it, never reset or release it.
- **`emitGlobalEvent`-vs-`GlobalEvents::Shutdown` use-after-free** (raised twice): `GlobalEvents::Shutdown()` is `releaseAll()` on a function-local-static `EventEmitter` (`global_events.cpp:93-96`) — nothing is freed. `EventEmitter::notify`'s fast path returns on `listenerCount == 0` before touching anything else (`event_emitter.cpp:296-303`), and every listener-mutating path (including `releaseAll`) takes the same mutex `notify` holds across its calls, so a watchdog emit landing after shutdown safely no-ops.
- **Mixed-`allowRearm` join races unloading the module with a thread still running**: the last-env cleanup hook's `join(false)` only runs at `moduleRefCount == 0`, and the env executing the JS `shutdown()` call holds a ref until that call returns — the two joins the claim depends on overlapping cannot overlap. A thread re-armed by the JS path is joined by `~DBStats` at static destruction regardless, which is the backstop for every path.
- **`emitGlobalEvent` from a `std::thread` violates V8 thread-safety** (this round): `EventEmitter::notify` calls `napi_call_threadsafe_function` (`event_emitter.cpp:354` onward) — the standard N-API mechanism for exactly this, not a bare synchronous call into V8. This is also the same pattern the transaction-log worker already uses to reach JS from a non-JS thread.

None of these needed a code change; each is recorded here so a re-read of the raw Gemini lens text in review history doesn't get re-litigated.

Two findings from the last rounds were adjudicated and declined with evidence, both raised more than once: a claimed TOCTOU/use-after-free on `DBRegistry::instance` during shutdown, and a claimed `emitGlobalEvent`-vs-`GlobalEvents::Shutdown` race (see above — these are the same two, from earlier rounds).

**Decisions taken, each reversible:**

- **The warn line goes to `stderr` as well as the `'log.warn'` event.** Harper registers no `log.warn` listener today, so an event-only line reaches nothing without a Harper change. The cost is unstructured output a log pipeline cannot format; route the event and ignore `stderr` if you would rather have it structured. @kriszyp ruled on this, and corrected the rationale I had offered for it: WBM stalls have not been observed freezing Harper's JS threads (no `putSync` on active paths; the observed symptom is every thread complaining about slow commits), so the load-bearing argument for `stderr` is the missing listener, not a blocked event loop. A direct consumer of this library's synchronous write path can still block its own loop, which is why the *sampler* still cannot be a JS timer.
- **The process-wide keys live inside per-database `getStats()`.** That is what makes a stall visible in Harper's `system_information` with no Harper change. A scraper summing them across databases will N-count; the alternative was leaving them only on the static accessor, where nothing scrapes them.
- **The threshold is env-only** (`ROCKSDB_JS_WBM_STALL_WARN_MS`, read once per process), not a `config()` knob like every other WriteBufferManager setting. Adding the knob later is additive.
- **`0` disables the watchdog thread entirely**, and with it `stallActiveMs` — silencing the log also silences that gauge, because only the thread populates it.
- **An out-of-range threshold falls back to 5 s rather than clamping**, erring toward alarming earlier than asked, never later. It now says so on `stderr` instead of doing it silently.
- **The inventory counts every descriptor that attached this manager, read-only included** (WAL recovery can retain charged memtables), plus dropped families still held by a live handle. So `columnFamilies` will not reconcile with a count of open handles. Descriptors that never attached the manager — opened before it was configured, or while its size was 0 — are excluded, and skip the tracking entirely.
- **The end-to-end stall test lives in the default suite** (~9 s, and it hard-fails rather than skips if no stall is reached). It is the only proof the wiring works end to end.
- **`costToCache` in the stats/report surfaces reflects the requested setting, not whether a live cache actually got attached.** Only diverges with the self-contradictory `blockCacheSize: 0` + `writeBufferManagerCostToCache: true` combination — a pre-existing `config()` gap, not something introduced here. The natural fix is `config()` rejecting that combination outright, which is out of scope for an observability PR.

**Accepted residuals, all raised by the review and deliberately not fixed:**

- The end-to-end test does not exercise stall *recovery* or prove at the process level (rather than the Node-free FSM-unit level) that recovery re-arms a second episode or that `disable()` mid-stall zeroes `stallActiveMs`. The recovery FSM is covered deterministically in `test/native/wbm_stall_watchdog_test.cc`; reaching a recovering stall end to end needs a scenario whose retained history can drain, which this one deliberately cannot, and adding another child-process fixture purely for the re-arm/disable path is disproportionate to a nit-level gap.
- **Nothing exercises the inventory's fail-fast `try_lock`s under real contention.** Both could be reverted to blocking locks and every test would still pass. The only holder long enough to observe is `PurgeAll`'s close-with-flush, and `DBRegistry::Shutdown` deliberately closes every descriptor *outside* the lock first, so that window is already collapsed; making it deterministic needs a test-only delay seam inside the `databasesMutex` critical section — a branch on the open path to test a fail-fast property. The concurrent-shutdown fixture does now run four envs through `Shutdown()` while the watchdog samples, which exercises the path without asserting on it.
- **An open that races the module's last-env teardown or true process exit does not arm the watchdog.** `ensure` returns early while the stop latch is held, so a database opened in that narrow window gets no alarm until the *next* open arms it. This is fixed for the explicit, JS-callable `shutdown()` (see "Rebase onto main" below) — only the ambiguous last-env-cleanup-hook / `~DBStats()` path still declines to re-arm, unchanged from the original reasoning: that path cannot tell "shutdown, may reopen" from "process is ending", and a thread spawned there would never be joined again.
- **A refused `std::thread` is not logged**, for the same lock-order reason. It is visible as `watchdogRunning: false` while `enabled` and `allowStall` are true, and the next open retries.
- Recurring comment-narration nits raised across several rounds (`db_stats.cpp`, `binding.cpp`, `db_descriptor.cpp`/`.h`, `db_registry.cpp`/`.h`) were re-checked each time against the WHY-not-WHAT bar; the ones that survive explain a non-obvious lock-order or lifecycle constraint the code cannot say on its own and are kept. A handful that had genuinely become redundant with a newer comment nearby (introduced by this rebase's own fixes) were trimmed.

**Not implemented, by instruction:** issue item 3 (`SetAllowStall(false)` after N seconds to release queued writers). The hook is now obvious — the watchdog is the only thing in the process that knows how long a stall has lasted, so a bounded escape hatch is a second threshold in the same FSM — but it converts a hang into unbounded memtable growth, which is a maintainer's call.

**A finding the task anticipated that did not hold.** The context expected that with `atomic_flush` (which this library always sets) a WBM-pressure flush is recorded under `ATOMIC_FLUSH_REQUEST_REASON_WRITE_BUFFER_MANAGER` *instead of* `FLUSH_REASON_WRITE_BUFFER_MANAGER`, and asked for a `docs/stats.md` correction if so. Measured here, both counters move: 13/13 with one column family, roughly 1:2 with two to six, and requests can outnumber executed flushes when several databases share a manager. So `rocksdb.flush.reason.write_buffer_manager` is not the wrong counter, and the production `0` was genuine — no manager-pressure flush was ever *requested*, because the trigger looks only at mutable memory. The docs carry the measured relationship rather than the anticipated correction; writing the anticipated note would have shipped a false statement.

## Rebase onto main (2026-09-08)

Rebased onto `origin/main` (47 commits, including #814 secondary-open and #829 `db.use()`). One merge conflict, in `DBDescriptor`'s constructor and its call in `open()`: main added `identityPath`/`secondaryLockToken` for secondary-open support, this branch added `attachedWriteBufferManager`. Resolved by taking both — the header had already merged cleanly with both parameters, so the fix was ordering the constructor call and the `DBDescriptor(...)` definition to match it. Also renumbered a duplicate `AGENTS.md` invariant 19 (main and this branch each independently appended a new one).

Five independent review rounds (codex + gemini) immediately after the rebase surfaced and fixed real issues in the watchdog lifecycle, none touching write-path behavior:

- **Major (gemini): a `db.open()`/`config()` racing `shutdown()` permanently loses its stall watchdog.** `DBRegistry::Shutdown()` releases `databasesMutex` before closing descriptors (deliberately, per the lock-order note above), so a concurrent open during that window is real, not hypothetical. `ensureWriteBufferManagerWatchdog()` bailing on `watchdogStopRequested` was already documented above as an accepted residual — but the fix needed to reconcile with the *reason* it was accepted (see next point), not just remove the gap.
- **Reconciling with the residual above.** The straightforward fix — replay a queued `ensure()` once the stop resolves — re-triggers exactly the "resurrect a thread during final teardown" concern this PR's body already recorded as the reason for *not* doing that. Resolved by making `joinWriteBufferManagerWatchdog()` caller-aware (`allowRearm`): the explicit, JS-callable `shutdown()` — already documented and tested (`shutdown.test.ts`) to support reopening — passes `true`; the module's last-env cleanup hook and `~DBStats()`, which cannot distinguish "may reopen" from "process is ending", pass `false` and drop a queued replay exactly as before this ever tracked one.
- **Two follow-ups from codex's delta review:** an explicit `disableWriteBufferManagerWatchdog()` landing after a queued replay could have the replay silently re-arm a watchdog the caller had just turned off (fixed: disable now cancels a pending replay); and a failing `std::thread::join()` (rare, but `std::system_error` is documented as possible) left the thread object still joinable, so its destructor would call `std::terminate()` even though the flag/wedge state was already fixed by the retirement guard (fixed then, later fully removed — see below).
- **TOCTOU (gemini): a disable racing a live sample could have its `stallActiveMs` reset overwritten by a stale in-flight value.** `sampleWriteBufferManagerStall()` checked-then-stored without holding `watchdogMutex`, while `disableWriteBufferManagerWatchdog()` clears the same field under that lock. Fixed by moving the check-then-store under the lock.

**Declined at that stage, with evidence:** a repeated gemini "blocker" that `std::erase_if(vector)` (pre-existing, not part of this rebase's changes) needs C++20 and this repo might target C++17 — `binding.gyp` pins `-std=c++20` / `/std:c++20` / `CLANG_CXX_LANGUAGE_STANDARD=c++20` on every platform. A repeated codex minor that the join-failure handling was still not fully airtight (a genuinely unreachable trigger, since `join()` is only ever called on a private, non-shared, non-self-joining local `std::thread` here) — later resolved by deleting the handling entirely rather than continuing to defend it (see below). Two gemini minors — a "hot path" string-allocation claim against `getStats()` (an administrative/telemetry surface, not a per-operation path, later fixed anyway — see below) and a claimed unconditional watchdog spawn when `writeBufferManagerSize` is 0 (a plain misread; the code has two size==0 early returns before that call).

### CI repairs, and post-rebase review continued (2026-09-08)

Two unrelated CI regressions surfaced after the rebase. First, pnpm 12's built-in `rebuild` took precedence over the same-named repository script, so automation now uses the unambiguous `pnpm run rebuild`. Then the floating `pnpm/action-setup` input moved again: failing run 34209077677 upgraded its bootstrap pnpm to 12.3.4 and produced a dead Windows shim before repository code ran, while green run 33831487630 had resolved 11.25.0. The repository now [pins pnpm 11.25.0 in `packageManager`](https://github.com/HarperFast/rocksdb-js/pull/824/changes?w=1#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R97), and all 12 action sites defer to that single pin instead of `latest`.

The same failing matrix exposed a separate macOS-only path spelling regression from the rebase: `/var/...` was correctly canonicalized to `/private/var/...` for transaction-log I/O, but the public `TransactionLog.path` getter leaked that identity. The getter now [returns the store's caller-spelled `displayPath`](https://github.com/HarperFast/rocksdb-js/pull/824/changes?w=1#diff-6a5fb51459adc2a017bf9767a4dc899c0681885c1fb96431af114466605d3448R339), while all I/O stays on the resolved path; [the symlink regression covers both discovered and newly created stores](https://github.com/HarperFast/rocksdb-js/pull/824/changes?w=1#diff-22a3c4e9b693561b0d3d6534ae81880ea0dec05f14fc12b7bbc837a5748e59e5R2246).

Six more review rounds (codex + gemini, forcing harper-domain back in once to adjudicate two Gemini findings that a narrow-delta round had auto-pruned it for) found and fixed:

- **A degraded stall report on inventory contention.** `sampleWriteBufferManagerStall()` marked the episode reported as soon as the alarm line itself was written, even when the retention-histogram inventory collection lost its `try_lock` race (e.g. `DBRegistry::OpenDB` holding `databasesMutex` for WAL recovery, which the review cited at "hundreds of milliseconds"). Since this is the one report a stall episode ever gets, that left the exact diagnostic #821 exists for permanently missing whenever the two windows overlapped. Now retries the inventory collection up to 10 times, 50ms apart (~450ms worst case) before giving up and reporting degraded — still non-blocking (`try_lock` each attempt), bounded, and cheap since it runs once per episode, not per sample.
- **Dead, and actively wrong if reached, join-failure handling.** The `catch (std::system_error) + detach()` guard around `toJoin.join()` (added in an earlier round) turned out to be unreachable — `toJoin` is a local moved out under `watchdogMutex`, so exactly one caller ever holds it, and neither the JS thread nor the static destructor is the watchdog thread itself, so `join()` can neither self-join nor race a concurrent join — and domain adjudication noted that if the branch were somehow reached, the compensating detach is actively wrong (`RetireGuard` would resurrect the detached, still-parked thread). Deleted.
- **A string-keyed round-trip on every `db.getStats()` call.** `setWriteBufferManagerStatsOnObject()` looked up five known keys through the generic string-keyed `lookupWriteBufferManagerStat()`, allocating temporaries and running compare chains for values already known at the call site. Now assigns the five values directly; the generic lookup still backs the single-name `getWriteBufferManagerStat(name)` path, which legitimately needs it.
- **A lock-order violation in the malformed-threshold diagnostic.** `writeBufferManagerStallWarnMs()`'s rare, one-time `fprintf(stderr, ...)` for a malformed `ROCKSDB_JS_WBM_STALL_WARN_MS` ran inside a lazily-initialized function-local static — so its first call, reachable from `ensureWriteBufferManagerWatchdog()` under `databasesMutex -> writeBufferManagerMutex` via `DBDescriptor::open()`, could in principle block those callers on a wedged `stderr` pipe, directly contradicting this PR's own established "no stderr under those locks" rule. Moved the resolution into `DBStats::DBStats()`, which `DBStats::Init()` already materializes once at module load on the JS thread with no locks held (the same pattern already used for the `DBStats` singleton itself); both call sites now read a cached `const` member.
- **Two README/JSDoc mismatches**, in `README.md` and the mirrored `WriteBufferManagerStats` doc comment in `src/load-binding.ts`: "every other value is 0/false when unconfigured" is wrong for `inventoryAvailable` (defaults `true` — nothing to fail to collect) and for `allowStall`/`costToCache` (they reflect the configured setting even before a manager exists, since a manager additionally needs `writeBufferManagerSize`); and "the first five values are also in `db.getStats()`" relied on declaration order matching the five actually-mirrored keys, which it didn't (`enabled` is listed first but isn't one of the five). Both now name the fields explicitly.

The CI-repair review then found and fixed two shutdown-lifecycle gaps: the watchdog had been stopped before database teardown, suppressing the only diagnostic when teardown itself waited on a WBM stall, and a delayed concurrent shutdown could retire a watchdog that a newer open had armed. Retirement now happens after the database flush, is bound to the caller's arm-request generation, and no-thread callers leave shared stop state untouched. The review also replaced an exact cross-surface `stallActiveMs` equality with monotonic assertions because the one-second sampler may tick between separate reads.

The next cross-runtime matrix separated three timing assumptions from product failures. The transaction-log backup warning test now [waits for asynchronous event delivery](https://github.com/HarperFast/rocksdb-js/pull/824/changes?w=1#diff-9f2dd4646e38cd6a757b8ca49223179f96d6981088310017d76a1e77f2cd0bdaR139), the coordinated-retry close regression accepts either rejection or the native `RETRY_NOW` result because both prove the park drained, and the pre-existing Deno/macOS worker-teardown abort in #746 uses the suite's established one-retry policy. Windows then exposed the same identity/display distinction in malformed-segment warning text: backup snapshots now [compose warnings from the store's display path and the segment filename](https://github.com/HarperFast/rocksdb-js/pull/824/changes?w=1#diff-42d2e6ef64957846e9ce8c84051a6fd7e8f6307406deaf7bc1bb3840938b8979R462), while filesystem access remains on the canonical identity path.

Finally, Node 22/macOS exposed that a close-during-backup promise could settle before `AsyncBackupState` released its copied descriptor pin, allowing an immediate `registryStatus()` or subsequent `shutdown()` to observe the closing database. The complete callback now [releases the pin and retries the deferred purge before resolve/reject](https://github.com/HarperFast/rocksdb-js/pull/824/changes?w=1#diff-07add81e0e72aab506258935de0b08132dc52c05c2df8109bef01b257c7bf1cdR372); the destructor remains an idempotent fallback for earlier exits.

**Full local suite green** on the final pushed head: 65 files passed, 1 skipped, 906 tests passed, 9 skipped, 0 failed (`pnpm test`, Node 26 / Linux), plus 194/194 native GoogleTest. The two final production deltas also passed incremental release binding rebuilds, their focused backup/transaction-log/shutdown regressions, and `pnpm check`.

## Verification

- **The concurrent-join regression is proved by reverting the fix**: the fixture hung to its deadline on 1 of 3 runs without it, and passes 4/4 with it.
- **Concurrent reopen is deterministic**: a test seam delays the second shutdown join for five seconds, the database reopens after the first caller returns, and the delayed caller leaves the replacement watchdog running.
- **Stalled teardown stays diagnosable**: [the real-stall shutdown regression](https://github.com/HarperFast/rocksdb-js/pull/824/changes?w=1#diff-2d0db2138b6a78af721ce4096bb065a01879c61b11ac60d0f52a0cbd683b3b43R209) blocks `shutdown()` behind a parked writer and observes the watchdog warning before the parent kills the child.
- **Native GoogleTest**: 194 tests pass (`pnpm test:native`) on the current pushed head, including the watchdog FSM (rising edge, threshold crossing, one-shot, retry-until-acknowledged, recovery re-arm, flapping, threshold `0`), the env-var parse (clamp, reject, out-of-range) and the report formatter.
- **The end-to-end stall test reaches a real stall** and asserts exactly one warn line across several times the threshold, its full payload, the `'log.warn'` event carrying the same line once, and — from the child's main thread while a worker is blocked in `putSync` — `stallActive`, a rising `stallActiveMs`, and agreement between `getWriteBufferManagerStats()`, `getStats()` and `getStat()`.
- **`process.exit()` with a live watchdog exits 0**, verified directly; without the join it is `std::terminate()` by construction.
- **The `allowStall` runtime edges** start and stop the watchdog, verified by test and by hand (`on → off → back on`).
- **Transaction-log display path**: the discovered/created symlink test fails on `origin/main` with the resolved real path and passes on this head with the caller spelling.
- **CI toolchain audit**: local pnpm resolves to 11.25.0; all 12 `pnpm/action-setup` sites use the manifest pin, with no pnpm `version: latest` input remaining. Run 34225580031 passed every Windows Node/native/Bun/Deno job.
- **Cross-runtime stabilization**: run 34225580031 passed every Linux job and every macOS Bun/Deno/Node 24/Node 26 job; its sole failure, Node 22/macOS, was the backup completion-order regression fixed in the final delta.
- **Full Vitest suite**: 65 files passed, 1 skipped, 906 tests passed, 9 skipped, 0 failed (`pnpm test`, Node 26 / Linux) on final HEAD `4e308c5f`.
- **Backup completion regression**: Node 22 ran the full backup plus shutdown suites (37 passed, 1 skipped), then the close-during-backup test passed five additional consecutive runs.
- **Final GitHub CI**: [all 19 Test workflow jobs passed](https://github.com/HarperFast/rocksdb-js/actions/runs/34227730170) on `4e308c5f`, covering Node 22/24/26, Bun, Deno, and native GoogleTest across Linux, macOS, and Windows; [Benchmark](https://github.com/HarperFast/rocksdb-js/actions/runs/34227730173), [Stress](https://github.com/HarperFast/rocksdb-js/actions/runs/34227730180), caller-workflow validation, and both Socket checks also passed.
- `pnpm check` (type-check, lint, format) clean.

Refs #822

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LHT9magoijhyikugJcB3Wu

Complexity: complicated

<sub>Review-Coverage: authored=codex; ran=claude,gemini; declined=cursor-grok,cursor-composer,domain; rounds=12 @ 4e308c5f7bf9</sub>

<sub>Human-Review-Need: 3 @ 4e308c5f7bf9</sub>
