### PR TITLE
Release a dying env's queued unlock callbacks from its cleanup hook

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -872,6 +872,24 @@ sufficient (env teardown does not honor tsfn acquire counts); see
     a child process the parent kills on a deadline, because the stalled writer blocks the JS thread
     and the runner's own timeout cannot fire (#781 item 2).
 
+22. **A queued unlock callback belongs to its env and is released by that env's cleanup hook**:
+    `tryLock(key, callback)` on a held key queues the callback as a threadsafe function of the
+    caller's env on the shared `LockHandle` (`DBDescriptor::lockEnqueueCallback`), and only the
+    holder's `unlock()` (`lockReleaseByKey`) or `db.close()` (`lockReleaseByOwner`) ever calls it. A
+    `worker_threads` env that is `terminate()`d never closes its handles in order, so its callback
+    stayed queued on a lock another env held; that env's later `unlock()` then called a tsfn Node had
+    already freed — Node 24 returns `napi_closing`, Node 22 aborts the process (rocksdb-js#848;
+    harper's derived-index runner kept exactly such a waiter on every non-owner worker, and Harper's
+    thread manager terminates workers on restart). Every `LockCallback` now records its `napi_env`,
+    and `DBRegistry::ReleaseLockCallbacksByEnv` → `DBDescriptor::releaseLockCallbacksByEnv`, wired
+    into the module env-cleanup hook beside `ReleaseParkTimeoutsByEnv`, releases (never calls) the
+    dying env's callbacks. The release paths hold `locksMutex` **across** their tsfn calls for the
+    same reason `EventEmitter::notify` holds its mutex (harper#1370): the cleanup hook takes that
+    mutex too, so it either removes a callback before the call or waits until the call has returned,
+    and Node cannot free the tsfn under `napi_call_threadsafe_function`. Calling a tsfn only enqueues
+    onto its env's loop, so holding the mutex across it cannot re-enter. `test/lock-teardown-abort.test.ts`
+    is the child-process repro; it also proves a live waiter is still woken.
+
 ## Debugging native heap corruption
 
 AddressSanitizer is the first choice (`ROCKSDB_ASAN=1 node-gyp rebuild` toggles `-fsanitize=address`

--- a/src/binding/binding.cpp
+++ b/src/binding/binding.cpp
@@ -232,6 +232,9 @@ NAPI_MODULE_INIT() {
 		// tsfns, so the descriptor's park-timeout thread never fires into a
 		// torn-down env.
 		rocksdb_js::DBRegistry::ReleaseParkTimeoutsByEnv(dyingEnv);
+		// And this env's queued unlock callbacks: a lock another env holds would
+		// otherwise call them after Node freed their tsfns (rocksdb-js#848).
+		rocksdb_js::DBRegistry::ReleaseLockCallbacksByEnv(dyingEnv);
 
 		int32_t newRefCount = --moduleRefCount;
 		if (newRefCount == 0) {

--- a/src/binding/database/db_descriptor.cpp
+++ b/src/binding/database/db_descriptor.cpp
@@ -1205,7 +1205,7 @@ void DBDescriptor::lockEnqueueCallback(
 		NAPI_STATUS_THROWS_VOID(::napi_unref_threadsafe_function(env, threadsafeCallback));
 
 		// Create LockCallback and add to queue
-		lockHandle->threadsafeCallbacks.push(LockCallback(threadsafeCallback, deferred));
+		lockHandle->threadsafeCallbacks.push(LockCallback(threadsafeCallback, deferred, env));
 	}
 }
 
@@ -1224,23 +1224,25 @@ bool DBDescriptor::lockExistsByKey(std::string& key) {
  * Releases a lock by key. Called by `db.unlock()`.
  */
 bool DBDescriptor::lockReleaseByKey(std::string& key) {
-	std::queue<LockCallback> threadsafeCallbacks;
+	// The callbacks are called while `locksMutex` is held: a worker env whose
+	// callback is queued here can be torn down concurrently, and its cleanup hook
+	// (`releaseLockCallbacksByEnv`) takes the same mutex, so it either removes the
+	// callback before this call or waits until the call has returned -- Node
+	// cannot free the tsfn out from under `napi_call_threadsafe_function`.
+	// Calling a tsfn only enqueues onto its env's loop, so nothing re-enters here.
+	std::lock_guard<std::mutex> lock(this->locksMutex);
+	auto lockHandle = this->locks.find(key);
 
-	{
-		std::lock_guard<std::mutex> lock(this->locksMutex);
-		auto lockHandle = this->locks.find(key);
-
-		if (lockHandle == this->locks.end()) {
-			// no lock found
-			DEBUG_LOG("%p DBDescriptor::lockReleaseByKey no lock found\n", this);
-			return false;
-		}
-
-		// lock found, remove it
-		threadsafeCallbacks = std::move(lockHandle->second->threadsafeCallbacks);
-		DEBUG_LOG("%p DBDescriptor::lockReleaseByKey removing lock\n", this);
-		this->locks.erase(key);
+	if (lockHandle == this->locks.end()) {
+		// no lock found
+		DEBUG_LOG("%p DBDescriptor::lockReleaseByKey no lock found\n", this);
+		return false;
 	}
+
+	// lock found, remove it
+	std::queue<LockCallback> threadsafeCallbacks = std::move(lockHandle->second->threadsafeCallbacks);
+	DEBUG_LOG("%p DBDescriptor::lockReleaseByKey removing lock\n", this);
+	this->locks.erase(key);
 
 	DEBUG_LOG("%p DBDescriptor::lockReleaseByKey calling %zu unlock callbacks\n", this, threadsafeCallbacks.size());
 
@@ -1260,27 +1262,52 @@ bool DBDescriptor::lockReleaseByKey(std::string& key) {
 }
 
 /**
+ * Env-cleanup hook (see `Binding::Init`): a worker that is terminated never
+ * closes its handles in order, so an unlock callback it queued on a lock held
+ * by another env would still be called by that env's `unlock()` after Node has
+ * freed the tsfn -- on Node 22 that aborts the process (rocksdb-js#848). Drop
+ * such callbacks under `locksMutex`, the same mutex the release paths hold
+ * while calling, so a call that already started completes before the tsfn goes.
+ */
+void DBDescriptor::releaseLockCallbacksByEnv(napi_env env) {
+	std::lock_guard<std::mutex> lock(this->locksMutex);
+	for (auto& [_key, lockHandle] : this->locks) {
+		std::queue<LockCallback> kept;
+		while (!lockHandle->threadsafeCallbacks.empty()) {
+			LockCallback lockCallback = lockHandle->threadsafeCallbacks.front();
+			lockHandle->threadsafeCallbacks.pop();
+			if (lockCallback.env == env) {
+				DEBUG_LOG("%p DBDescriptor::releaseLockCallbacksByEnv dropping callback %p of dying env\n", this, lockCallback.callback);
+				::napi_release_threadsafe_function(lockCallback.callback, napi_tsfn_release);
+			} else {
+				kept.push(lockCallback);
+			}
+		}
+		lockHandle->threadsafeCallbacks = std::move(kept);
+	}
+}
+
+/**
  * Releases all locks owned by the given handle. Called by `db.close()`.
  */
 void DBDescriptor::lockReleaseByOwner(DBHandle* owner) {
 	std::set<napi_threadsafe_function> threadsafeCallbacks;
 
-	{
-		std::lock_guard<std::mutex> lock(this->locksMutex);
-			DEBUG_LOG("%p DBDescriptor::lockReleaseByOwner checking %zu locks if they are owned handle %p\n", this, this->locks.size(), owner);
-		for (auto it = this->locks.begin(); it != this->locks.end();) {
-			auto lockOwner = it->second->owner.lock();
-			if (!lockOwner || lockOwner.get() == owner) {
-				DEBUG_LOG("%p DBDescriptor::lockReleaseByOwner found lock %p with %zu callbacks\n", this, it->second.get(), it->second->threadsafeCallbacks.size());
-				// move all callbacks from the queue
-				while (!it->second->threadsafeCallbacks.empty()) {
-					threadsafeCallbacks.insert(it->second->threadsafeCallbacks.front().callback);
-					it->second->threadsafeCallbacks.pop();
-				}
-				it = this->locks.erase(it);
-			} else {
-				++it;
+	// Held across the calls for the same reason as lockReleaseByKey.
+	std::lock_guard<std::mutex> lock(this->locksMutex);
+	DEBUG_LOG("%p DBDescriptor::lockReleaseByOwner checking %zu locks if they are owned handle %p\n", this, this->locks.size(), owner);
+	for (auto it = this->locks.begin(); it != this->locks.end();) {
+		auto lockOwner = it->second->owner.lock();
+		if (!lockOwner || lockOwner.get() == owner) {
+			DEBUG_LOG("%p DBDescriptor::lockReleaseByOwner found lock %p with %zu callbacks\n", this, it->second.get(), it->second->threadsafeCallbacks.size());
+			// move all callbacks from the queue
+			while (!it->second->threadsafeCallbacks.empty()) {
+				threadsafeCallbacks.insert(it->second->threadsafeCallbacks.front().callback);
+				it->second->threadsafeCallbacks.pop();
 			}
+			it = this->locks.erase(it);
+		} else {
+			++it;
 		}
 	}
 

--- a/src/binding/database/db_descriptor.h
+++ b/src/binding/database/db_descriptor.h
@@ -609,6 +609,12 @@ public:
 	bool lockExistsByKey(std::string& key);
 	bool lockReleaseByKey(std::string& key);
 	void lockReleaseByOwner(DBHandle* owner);
+
+	/**
+	 * Env-cleanup hook: release every queued unlock callback that a dying env
+	 * registered, on every lock this descriptor tracks. Never calls them.
+	 */
+	void releaseLockCallbacksByEnv(napi_env env);
 	void onCallbackComplete(const std::string& key);
 
 	void transactionAdd(std::shared_ptr<TransactionHandle> txnHandle);
@@ -740,11 +746,18 @@ struct LockCallbackCompletionData final {
  * Holds a threadsafe callback and its associated deferred promise (if any).
  */
 struct LockCallback final {
-	LockCallback(napi_threadsafe_function callback, napi_deferred deferred = nullptr)
-		: callback(callback), deferred(deferred) {}
+	LockCallback(napi_threadsafe_function callback, napi_deferred deferred = nullptr, napi_env env = nullptr)
+		: callback(callback), deferred(deferred), env(env) {}
 
 	napi_threadsafe_function callback;
 	napi_deferred deferred;
+
+	/**
+	 * The env that queued this callback. A worker's env can be torn down while
+	 * its callback still waits on a lock another env holds; `releaseLockCallbacksByEnv`
+	 * drops it then, because calling the tsfn after Node freed it aborts the process.
+	 */
+	napi_env env;
 };
 
 /**

--- a/src/binding/database/db_registry.cpp
+++ b/src/binding/database/db_registry.cpp
@@ -896,6 +896,31 @@ void DBRegistry::ReleaseParkTimeoutsByEnv(napi_env env) {
 }
 
 /**
+ * Env-cleanup hook: drop every unlock callback a dying env queued on any
+ * descriptor's locks (rocksdb-js#848). Mirrors ReleaseParkTimeoutsByEnv.
+ */
+void DBRegistry::ReleaseLockCallbacksByEnv(napi_env env) {
+	if (!instance) {
+		return;
+	}
+
+	std::vector<std::shared_ptr<DBDescriptor>> descriptors;
+	{
+		std::lock_guard<std::mutex> lock(instance->databasesMutex);
+		descriptors.reserve(instance->databases.size());
+		for (auto& [_key, entry] : instance->databases) {
+			if (entry.descriptor) {
+				descriptors.push_back(entry.descriptor);
+			}
+		}
+	}
+
+	for (auto& descriptor : descriptors) {
+		descriptor->releaseLockCallbacksByEnv(env);
+	}
+}
+
+/**
  * Shutdown will force all databases to flush in-memory data to disk and purge the registry.
  */
 void DBRegistry::Shutdown() {

--- a/src/binding/database/db_registry.h
+++ b/src/binding/database/db_registry.h
@@ -150,6 +150,7 @@ public:
 	static void RemoveListenersByEnv(napi_env env);
 	static void ReleaseCommitCompletionsByEnv(napi_env env);
 	static void ReleaseParkTimeoutsByEnv(napi_env env);
+	static void ReleaseLockCallbacksByEnv(napi_env env);
 	static void Shutdown();
 	static size_t Size();
 };

--- a/test/fixtures/fork-lock-teardown-abort.mts
+++ b/test/fixtures/fork-lock-teardown-abort.mts
@@ -1,0 +1,101 @@
+/**
+ * Isolated repro for rocksdb-js#848: an unlock callback queued by a worker env
+ * that is later terminated must not be called when another env unlocks.
+ *
+ * Scenario:
+ * 1. Main opens the path and takes `tryLock(key)`.
+ * 2. A worker opens the same path and calls `tryLock(key, callback)`; the lock
+ *    is held, so the callback -- a threadsafe function of the worker's env -- is
+ *    queued on the shared LockHandle.
+ * 3. Main terminates the worker. Node tears the worker env down and frees its
+ *    tsfns.
+ * 4. Main calls `unlock(key)`.
+ *
+ * Before the fix, `lockReleaseByKey` called the freed tsfn: Node 22 aborts the
+ * process inside `napi_call_threadsafe_function`; Node 24 returns
+ * `napi_closing`. After the fix, the worker env's cleanup hook removes its
+ * queued callbacks under the lock mutex, so unlock finds nothing of that env.
+ * Exit 0 = survived; a crash exits via signal / non-zero.
+ */
+import { RocksDatabase } from '../../src/index.ts';
+import { createWorkerBootstrapScript } from '../lib/worker-bootstrap.ts';
+import { mkdirSync } from 'node:fs';
+import { setTimeout as delay } from 'node:timers/promises';
+import { Worker } from 'node:worker_threads';
+
+const dbPath = process.argv[2];
+
+if (!dbPath) {
+	console.error('Usage: fork-lock-teardown-abort.mts <dbPath>');
+	process.exit(1);
+}
+
+mkdirSync(dbPath, { recursive: true });
+
+// Each round is one full queue -> terminate -> unlock sequence; the failure is
+// deterministic on an affected runtime, so a few rounds are only insurance.
+const ROUNDS = 3;
+
+function spawnWaiter(key: string): Promise<Worker> {
+	return new Promise((resolve, reject) => {
+		const worker = new Worker(
+			createWorkerBootstrapScript('./test/workers/lock-teardown-worker.mts'),
+			{
+				eval: true,
+				workerData: { path: dbPath, key },
+			}
+		);
+		worker.once('message', (event: { ready?: boolean; acquired?: boolean }) => {
+			if (!event.ready) {
+				return;
+			}
+			if (event.acquired) {
+				reject(new Error('the worker acquired a lock the main thread holds'));
+				return;
+			}
+			resolve(worker);
+		});
+		worker.once('error', reject);
+	});
+}
+
+async function run(): Promise<void> {
+	const db = RocksDatabase.open(dbPath);
+	for (let round = 0; round < ROUNDS; round++) {
+		const key = `lock-${round}`;
+		if (!db.tryLock(key)) {
+			throw new Error(`main could not take ${key}`);
+		}
+		const waiter = await spawnWaiter(key);
+		await waiter.terminate();
+		// Let the terminated env's cleanup settle before the release that used to
+		// call into it; the fix must hold with or without this gap.
+		await delay(round === 0 ? 0 : 20);
+		db.unlock(key);
+	}
+	// A surviving waiter must still be woken: prove the fix did not drop live callbacks.
+	if (!db.tryLock('live')) {
+		throw new Error('main could not take the live lock');
+	}
+	const live = await spawnWaiter('live');
+	const fired = new Promise<void>((resolve) => {
+		live.once('message', (event: { fired?: boolean }) => {
+			if (event.fired) {
+				resolve();
+			}
+		});
+	});
+	db.unlock('live');
+	await fired;
+	await live.terminate();
+	db.close();
+}
+
+try {
+	await run();
+	console.log('SUCCESS');
+	process.exit(0);
+} catch (error) {
+	console.error('FAILED', error);
+	process.exit(1);
+}

--- a/test/lock-teardown-abort.test.ts
+++ b/test/lock-teardown-abort.test.ts
@@ -1,0 +1,46 @@
+import { generateDBPath } from './lib/util.ts';
+import { spawn } from 'node:child_process';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const fixturePath = join(__dirname, 'fixtures', 'fork-lock-teardown-abort.mts');
+
+/**
+ * Runs the repro in a child process so the SIGABRT (rocksdb-js#848) surfaces as
+ * a signal / non-zero exit instead of taking down vitest. The failure is
+ * deterministic on an affected Node, so one child run with a few rounds is
+ * enough; the fixture also proves a live waiter is still woken afterwards.
+ */
+function spawnRepro(
+	dbPath: string
+): Promise<{ code: number | null; signal: NodeJS.Signals | null }> {
+	return new Promise((resolve, reject) => {
+		const child = spawn(process.execPath, [fixturePath, dbPath]);
+		let stderr = '';
+		child.stderr?.on('data', (chunk) => {
+			stderr += chunk.toString();
+		});
+		child.on('close', (code, signal) => {
+			if (code !== 0 || signal) {
+				console.error(`Repro child stderr:\n${stderr}`);
+			}
+			resolve({ code, signal });
+		});
+		child.on('error', reject);
+	});
+}
+
+describe('tryLock callback vs. worker env teardown', () => {
+	// Node-only for the same reason as notify-teardown-uaf: the guarantee under
+	// test is Node's env-cleanup ordering (cleanup hooks run before the env's
+	// tsfns are freed), which Deno's and Bun's N-API shims do not provide.
+	it.skipIf(Boolean(process.versions.deno || process.versions.bun))(
+		'should survive unlock() after a waiting worker was terminated, and still wake a live waiter',
+		async () => {
+			const { code, signal } = await spawnRepro(generateDBPath());
+			expect(signal).toBeNull();
+			expect(code).toBe(0);
+		},
+		60_000
+	);
+});

--- a/test/workers/lock-teardown-worker.mts
+++ b/test/workers/lock-teardown-worker.mts
@@ -1,0 +1,14 @@
+import { RocksDatabase } from '../../src/index.ts';
+import { parentPort, workerData } from 'node:worker_threads';
+
+// Open the SAME path as the parent so both envs share one DBDescriptor and its
+// lock table. The parent holds `key`; this tryLock therefore fails and queues an
+// unlock callback -- a threadsafe function bound to THIS env -- on the shared
+// LockHandle. The parent then terminates this worker and unlocks.
+const db = RocksDatabase.open(workerData.path);
+const acquired = db.tryLock(workerData.key, () => {
+	parentPort?.postMessage({ fired: true });
+});
+parentPort?.postMessage({ ready: true, acquired });
+// Stay alive until terminated; the callback must still be queued at teardown.
+setInterval(() => {}, 1000);


### PR DESCRIPTION
Fixes #848.

## Defect

A `tryLock(key, callback)` waiter registered from a worker thread that is later `worker.terminate()`d leaves its callback — a threadsafe function bound to the dead env — queued on the shared `LockHandle`. When another env calls `unlock(key)`, `DBDescriptor::lockReleaseByKey` calls that tsfn: Node 24 returns `napi_closing` (skipped), **Node 22 aborts the process**. Queued lock callbacks had no per-env cleanup; parks already do (`ParkTimeoutRegistry::releaseByEnv`), and so do commit completions and event listeners.

Found when harper#2430 landed: its derived-index runtime keeps a standing lock waiter on every non-owner worker, Harper's thread manager terminates workers on restart, and every Node 22 unit-test run on harper `main` aborted (`Aborted (core dumped)`, exit 134). `recordLock.ts` uses the same primitive, so the exposure predates that runtime.

## Fix

- `LockCallback` records the `napi_env` that queued it.
- `DBDescriptor::releaseLockCallbacksByEnv(env)` drops a dying env's callbacks from every lock's queue (releasing their tsfns, never calling them), under `locksMutex`.
- `DBRegistry::ReleaseLockCallbacksByEnv` snapshots descriptors and calls it; wired into the module env-cleanup hook in `binding.cpp` next to `ReleaseParkTimeoutsByEnv`.
- `lockReleaseByKey` / `lockReleaseByOwner` now hold `locksMutex` **across** the tsfn calls instead of moving the queue out and calling unlocked. That is the same closure as `EventEmitter::notify` (harper#1370): the cleanup hook takes the same mutex, so it either removes a callback before the call or waits until the call has returned, and Node cannot free the tsfn under `napi_call_threadsafe_function`. Calling a tsfn only enqueues onto its env's loop, so nothing re-enters the mutex.
- AGENTS.md invariant 22 records the rule.

## Verification

- `test/lock-teardown-abort.test.ts` (child-process repro, same shape as `notify-teardown-uaf`): 3 rounds of queue → `terminate()` → `unlock()`, then a live waiter that must still be woken.
  - **Unfixed binding, Node 22.23.1: exit 134** (control).
  - Fixed binding: exit 0 on Node 22.23.1 and 24.18.0.
- `lock.test.ts`, `lock-tracker.test.ts`, `notify-teardown-uaf.test.ts`, `lock-teardown-abort.test.ts`: 30 passing (Node 24).
- Harper: `unitTests/resources/vectorIndexPlane.test.js` (the suite that aborted harper `main`'s Node 22 CI) against this binary with **no Harper change**: 22 passing on Node 22.23.1.
- `oxfmt --check`, `oxlint` clean. `node-gyp rebuild` clean on macOS arm64.

Deno/Bun skip the new test for the same reason `notify-teardown-uaf` does: the guarantee under test is Node's env-cleanup ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
